### PR TITLE
Use ASLR for nginx?

### DIFF
--- a/build/nginx/files/http-nginx.xml
+++ b/build/nginx/files/http-nginx.xml
@@ -42,7 +42,7 @@ CDDL HEADER END
             name="start"
             exec="/lib/svc/method/http-nginx start"
             timeout_seconds="60">
-            <method_context>
+            <method_context security_flags="aslr">
                 <method_credential user="nginx" group="nginx"
                     privileges="basic,net_privaddr,!proc_info,!proc_session" />
             </method_context>


### PR DESCRIPTION
We can easily run nginx with address-space layout randomisation by adding a security flag to the start method context. Is this something we should enable in the extra package by default?

```
bloody# psecflags `pgrep -o nginx`
2496:   /opt/ooce/sbin/nginx
        E:      aslr
        I:      aslr
        L:      none
        U:      aslr,forbidnullmap,noexecstack
```