### PR TITLE
apache-ant, freetype and python-36 for r151022

### DIFF
--- a/build/apache-ant/build.sh
+++ b/build/apache-ant/build.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=apache-ant
+VER=1.9.9 # stay on 1.9.x, 1.10.x requires Java8
+VERHUMAN=$VER
+JUNITVER=4.12
+PKG=ooce/developer/build/ant
+SUMMARY="Apache Ant is a Java library and command-line tool that help building software."
+DESC="$SUMMARY"
+PREFIX=$PREFIX/$PROG
+
+BUILD_DEPENDS_IPS="developer/java/jdk"
+RUN_DEPENDS_IPS="runtime/java runtime/perl runtime/python-27"
+
+BUILDARCH=32
+JAVA_HOME="/usr/jdk"
+export JAVA_HOME
+
+fetch_junit() {
+    pushd $TMPDIR/$BUILDDIR/lib/optional > /dev/null
+    logmsg "Fetching JUnit for build"
+    logcmd $WGET $MIRROR/junit/junit-${JUNITVER}.jar || \
+        logerr "-- Failed to download junit-${JUNITVER} jar file."
+    popd > /dev/null
+}
+
+build_ant() {
+    pushd $TMPDIR/$BUILDDIR > /dev/null
+    logmsg "Building Ant"
+    logcmd /bin/sh ./build.sh -Ddist.dir=${DESTDIR}${PREFIX} || \
+        logerr "-- Build failed"
+    popd > /dev/null
+}
+
+init
+download_source  $PROG $PROG ${VER}-src
+patch_source
+prep_build
+fetch_junit
+build_ant
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/apache-ant/local.mog
+++ b/build/apache-ant/local.mog
@@ -1,0 +1,1 @@
+license LICENSE license=Apache2

--- a/build/freetype2/build.sh
+++ b/build/freetype2/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=freetype
+DOWNLOADDIR=freetype2
+VER=2.8
+VERHUMAN=$VER
+PKG=ooce/library/freetype2
+SUMMARY="A Free, High-Quality, and Portable Font Engine"
+DESC="$SUMMARY"
+
+RUN_DEPENDS_IPS="compress/bzip2 library/zlib system/library/gcc-5-runtime"
+BUILD_DEPENDS_IPS=$RUN_DEPENDS_IPS
+
+init
+download_source $DOWNLOADDIR $PROG $VER
+patch_source
+prep_build
+build
+make_isa_stub
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/freetype2/local.mog
+++ b/build/freetype2/local.mog
@@ -1,0 +1,1 @@
+license docs/LICENSE.TXT license=freetype

--- a/build/python36/.gitignore
+++ b/build/python36/.gitignore
@@ -1,0 +1,1 @@
+local.mog

--- a/build/python36/build.sh
+++ b/build/python36/build.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=Python
+PROGLC=${PROG,,}
+VER=3.6.1
+VERHUMAN=$VER
+PKG=ooce/runtime/$PROGLC-36
+SUMMARY="$PROG - An Interpreted, Interactive, Object-oriented, Extensible Programming Language."
+DESC="$SUMMARY"
+VERMAJOR=${VER%.*}
+
+BUILD_DEPENDS_IPS="system/library/gcc-5-runtime library/libffi"
+RUN_DEPENDS_IPS=$BUILD_DEPENDS_IPS
+
+ORIGPREFIX=$PREFIX
+PREFIX=$PREFIX/$PROGLC-$VER
+BUILDARCH=64
+
+CFLAGS="-O3"
+CXXFLAGS="-O3"
+CPPFLAGS="-D_REENTRANT"
+
+CONFIGURE_OPTS="--enable-shared
+                --disable-static
+                --with-system-ffi
+"
+
+CONFIGURE_OPTS_64="--prefix=$PREFIX
+                   --sysconfdir=/etc/$ORIGPREFIX/$PROGLC$VERMAJOR
+                   --includedir=$PREFIX/include
+                   --bindir=$PREFIX/bin
+                   --sbindir=$PREFIX/sbin
+                   --libdir=$PREFIX/lib
+                   --libexecdir=$PREFIX/libexec
+"
+
+build() {
+    CC="$CC $CFLAGS $CFLAGS64" \
+    CXX="$CXX $CXXFLAGS $CXXFLAGS64" \
+    build64
+    mv "$DESTDIR/$PREFIX/lib/$PROGLC$VERMAJOR/site-packages/setuptools/script (dev).tmpl" "$DESTDIR/$PREFIX/lib/$PROGLC$VERMAJOR/site-packages/setuptools/script_dev.tmpl" 
+}
+
+make_install64() {
+    logmsg '--- make install'
+    logcmd $MAKE DESTDIR=$DESTDIR DESTSHARED=${PREFIX}/lib/$PROGLC${VERMAJOR}/lib-dynload install || logerr '--- make install failed'
+}
+create_symlinks() {
+    logmsg "--- Create bin symlink"
+    logcmd mkdir -p $DESTDIR/$ORIGPREFIX/bin
+    logcmd ln -s $PREFIX/bin/$PROGLC$VERMAJOR $DESTDIR/$ORIGPREFIX/bin/${PROGLC}3
+    logmsg "--- Create man symlink"
+    logcmd mkdir -p $DESTDIR/$ORIGPREFIX/share/man/man1
+    logcmd ln -s $PREFIX/share/man/man1/$PROGLC${VERMAJOR}.1 $DESTDIR/$ORIGPREFIX/share/man/man1/$PROGLC${VERMAJOR}.1
+    logmsg "--- Patch runpath in local.mog" 
+    logcmd cp $SRCDIR/files/local.mog $SRCDIR
+    logcmd gsed -i 's|PKGDEPEND_RUNPATH:/opt/ooce/python-[^/]\+/lib|PKGDEPEND_RUNPATH:/opt/ooce/python-'$VER'/lib|' $SRCDIR/local.mog
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+create_symlinks
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/python36/files/local.mog
+++ b/build/python36/files/local.mog
@@ -1,0 +1,2 @@
+license LICENSE license=Python
+set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/opt/ooce/python-VERSION/lib

--- a/build/python36/patches/cgi.py.patch
+++ b/build/python36/patches/cgi.py.patch
@@ -1,0 +1,8 @@
+--- python3.6/Lib/cgi.py	Tue Mar 21 07:32:38 2017
++++ python3.6/Lib/cgi.py	Sat Jul 15 22:13:21 2017
+@@ -1,4 +1,4 @@
+-#! /usr/local/bin/python
++#! /opt/ooce/bin/python3
+ 
+ # NOTE: the above "/usr/local/bin/python" is NOT a mistake.  It is
+ # intentionally NOT "/usr/bin/env python".  On many systems

--- a/build/python36/patches/series
+++ b/build/python36/patches/series
@@ -1,0 +1,1 @@
+cgi.py.patch


### PR DESCRIPTION
to satisfy build dependencies for `iso-codes` and `openjdk`