### PR TITLE
Add mediators to python links

### DIFF
--- a/build/python36/build.sh
+++ b/build/python36/build.sh
@@ -79,9 +79,8 @@ create_symlinks() {
     logmsg "--- Create man symlink"
     logcmd mkdir -p $DESTDIR/$ORIGPREFIX/share/man/man1
     logcmd ln -s $PREFIX/share/man/man1/$PROGLC${VERMAJOR}.1 $DESTDIR/$ORIGPREFIX/share/man/man1/$PROGLC${VERMAJOR}.1
-    logmsg "--- Patch runpath in local.mog" 
-    logcmd cp $SRCDIR/files/local.mog $SRCDIR
-    logcmd gsed -i 's|PKGDEPEND_RUNPATH:/opt/ooce/python-[^/]\+/lib|PKGDEPEND_RUNPATH:/opt/ooce/python-'$VER'/lib|' $SRCDIR/local.mog
+    logmsg "--- Update version number in local.mog file" 
+    sed "s/__VERSION__/$VER/g" < $SRCDIR/files/local.mog > $SRCDIR/local.mog
 }
 
 init

--- a/build/python36/files/local.mog
+++ b/build/python36/files/local.mog
@@ -1,2 +1,6 @@
 license LICENSE license=Python
-set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/opt/ooce/python-VERSION/lib
+set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/opt/ooce/python-__VERSION__/lib
+
+<transform link path=opt/ooce/(bin|share) -> set mediator python>
+<transform link path=opt/ooce/(bin|share) -> set mediator-version __VERSION__>
+


### PR DESCRIPTION
This change makes the symlinks to python in `/opt/ooce/bin/` and `/opt/ooce/share/man/` into mediated links, allowing multiple omnios-extra versions of python to be installed in parallel, should the need arise.

```
bloody# pkg mediator -a
MEDIATOR VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
gcc      system    5.1     system
mta      system            system     mailwrapper
mta      system            system     sendmail
python   system    3.6.1   system
```

Perhaps we should call the mediator ooce-python?