### PR TITLE
add mediators to python3 link, major version path

### DIFF
--- a/build/python36/build.sh
+++ b/build/python36/build.sh
@@ -79,7 +79,9 @@ create_symlinks() {
     logcmd ln -s $PROGLC$VERMAJOR $DESTDIR/$ORIGPREFIX/bin/${PROGLC}3
     logmsg "--- Create man symlink"
     logcmd mkdir -p $DESTDIR/$ORIGPREFIX/share/man/man1
-    logcmd ln -s $PREFIX/share/man/man1/$PROGLC${VERMAJOR}.1 $DESTDIR/$ORIGPREFIX/share/man/man1/$PROGLC${VERMAJOR}.1
+    logcmd ln -s ../../../$PROGLC-$VERMAJOR/share/man/man1/$PROGLC${VERMAJOR}.1 \
+        $DESTDIR/$ORIGPREFIX/share/man/man1/$PROGLC${VERMAJOR}.1
+    logcmd ln -s $PROGLC${VERMAJOR}.1 $DESTDIR/$ORIGPREFIX/share/man/man1/${PROGLC}3.1
     logmsg "--- Update version number in local.mog file"
     sed "s/__VERSION__/$VERMAJOR/g" < $SRCDIR/files/local.mog > $SRCDIR/local.mog
 }

--- a/build/python36/build.sh
+++ b/build/python36/build.sh
@@ -40,7 +40,7 @@ BUILD_DEPENDS_IPS="system/library/gcc-5-runtime library/libffi"
 RUN_DEPENDS_IPS=$BUILD_DEPENDS_IPS
 
 ORIGPREFIX=$PREFIX
-PREFIX=$PREFIX/$PROGLC-$VER
+PREFIX=$PREFIX/$PROGLC-$VERMAJOR
 BUILDARCH=64
 
 CFLAGS="-O3"
@@ -75,13 +75,13 @@ make_install64() {
 create_symlinks() {
     logmsg "--- Create bin symlink"
     logcmd mkdir -p $DESTDIR/$ORIGPREFIX/bin
-    logcmd ln -s $PREFIX/bin/$PROGLC$VERMAJOR $DESTDIR/$ORIGPREFIX/bin/${PROGLC}3
+    logcmd ln -s ../$PROGLC-$VERMAJOR/bin/$PROGLC$VERMAJOR $DESTDIR/$ORIGPREFIX/bin/$PROGLC$VERMAJOR
+    logcmd ln -s $PROGLC$VERMAJOR $DESTDIR/$ORIGPREFIX/bin/${PROGLC}3
     logmsg "--- Create man symlink"
     logcmd mkdir -p $DESTDIR/$ORIGPREFIX/share/man/man1
     logcmd ln -s $PREFIX/share/man/man1/$PROGLC${VERMAJOR}.1 $DESTDIR/$ORIGPREFIX/share/man/man1/$PROGLC${VERMAJOR}.1
-    logmsg "--- Patch runpath in local.mog" 
-    logcmd cp $SRCDIR/files/local.mog $SRCDIR
-    logcmd gsed -i 's|PKGDEPEND_RUNPATH:/opt/ooce/python-[^/]\+/lib|PKGDEPEND_RUNPATH:/opt/ooce/python-'$VER'/lib|' $SRCDIR/local.mog
+    logmsg "--- Update version number in local.mog file"
+    sed "s/__VERSION__/$VERMAJOR/g" < $SRCDIR/files/local.mog > $SRCDIR/local.mog
 }
 
 init

--- a/build/python36/files/local.mog
+++ b/build/python36/files/local.mog
@@ -1,2 +1,5 @@
 license LICENSE license=Python
-set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/opt/ooce/python-VERSION/lib
+set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/opt/ooce/python-__VERSION__/lib
+
+<transform link path=opt/ooce/bin/python3 -> set mediator python3>
+<transform link path=opt/ooce/bin/python3 -> set mediator-version __VERSION__>

--- a/build/python36/files/local.mog
+++ b/build/python36/files/local.mog
@@ -3,3 +3,5 @@ set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/opt/ooce/python-__VERSION_
 
 <transform link path=opt/ooce/bin/python3 -> set mediator python3>
 <transform link path=opt/ooce/bin/python3 -> set mediator-version __VERSION__>
+<transform link path=opt/ooce/share/man/man1/python3.1 -> set mediator python3>
+<transform link path=opt/ooce/share/man/man1/python3.1 -> set mediator-version __VERSION__>


### PR DESCRIPTION
Replaces https://github.com/omniosorg/omnios-extra/pull/11

This change makes the symlink to python (`/opt/ooce/bin/python3`) into a mediated link, allowing multiple omnios-extra versions of python3 to be installed in parallel, should the need arise.

Install directories are named after the major version. e.g. `/opt/ooce/python-3.6`


```
bloody# pkg mediator -a
MEDIATOR VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
gcc      system    5.1     system
mta      system            system     mailwrapper
mta      system            system     sendmail
python3  system    3.6     system
```