### PR TITLE
fix github downloading release URL

### DIFF
--- a/build/ooceapps/build.sh
+++ b/build/ooceapps/build.sh
@@ -36,7 +36,7 @@ SUMMARY="Mattermost integrations for OmniOSce" # One-liner, must be filled in
 DESC=$SUMMARY   # Longer description, must be filled in
 BUILDARCH=64    # or 64 or both ... for libraries we want both for tools 32 bit only
 PREFIX=/opt/ooce
-MIRROR="https://github.com/hadfl/$PROG/releases/download"
+MIRROR="https://github.com/hadfl/$PROG/archive"
 
 CONFIGURE_OPTS_64="
     --prefix=$PREFIX/$PROG


### PR DESCRIPTION
It can be verified by curl. 
<code>curl -D - https://github.com/hadfl/ooceapps/archive/v0.1.4.tar.gz</code> works fine (gives 302 redirect), while <code>curl -D - https://github.com/hadfl/ooceapps/releases/download/v0.1.4.tar.gz</code> gives 404.