### PR TITLE
Add irssi package + support for building all releases from master

### DIFF
--- a/build/irssi/build.sh
+++ b/build/irssi/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Use is subject to license terms.
+#
+. ../../lib/functions.sh
+
+PROG=irssi
+VER=1.1.0
+VERHUMAN=$VER
+PKG=ooce/network/irssi
+SUMMARY="$PROG - text-mode modular chat client"
+DESC="$SUMMARY"
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+"
+
+reset_configure_opts
+
+# Build 64-bit only and skip the arch-specific directories
+BUILDARCH=64
+CONFIGURE_OPTS="
+    --bindir=$PREFIX/bin
+    --libdir=$PREFIX/lib
+"
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/irssi/local.mog
+++ b/build/irssi/local.mog
@@ -1,0 +1,23 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license COPYING license=GPLv2
+
+link path=$(OPREFIX)/bin/$(PROG) target=../$(PROG)/bin/$(PROG)
+link path=$(OPREFIX)/share/man/man1/$(PROG).1 \
+    target=../../../$(PROG)/share/man/man1/$(PROG).1
+
+dir path=etc/$(OPREFIX) owner=root group=bin mode=0755
+<transform file path=etc -> set preserve true>
+

--- a/build/znc/build.sh
+++ b/build/znc/build.sh
@@ -67,7 +67,7 @@ build
 install_files
 install_smf network znc.xml
 make_package
-#clean_up
+clean_up
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -11,6 +11,7 @@
 | ooce/library/freetype2	| 2.9		| https://sourceforge.net/projects/freetype/files/freetype2/ | [omniosorg](https://github.com/omniosorg)
 | ooce/lxadm			| 0.1.6		| https://github.com/hadfl/lxadm/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/smtp/postfix	| 3.2.4		| https://www.swissrave.ch/mirror/postfix-source/index.html | [omniosorg](https://github.com/omniosorg)
+| ooce/network/irssi		| 1.1.0		| https://github.com/irssi/irssi/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/znc		| 1.6.5		| https://github.com/znc/znc/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/ooceapps			| 0.3.1		| https://github.com/omniosorg/ooceapps/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/python-36	| 3.6.4		| https://www.python.org/downloads/source/ | [omniosorg](https://github.com/omniosorg)

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -27,8 +27,22 @@
 # Configuration for the build system
 #############################################################################
 
-# Default branch
-RELVER=151025
+# Determine release version based on build system
+if [[ "`uname -v`" != omnios-* ]]; then
+	echo "This does not appear to be an OmniOS system."
+    uname -v
+    exit 1
+fi
+RELVER="`head -1 /etc/release | awk '{print $3}' | sed 's/[a-z]//g'`"
+if [[ ! "$RELVER" =~ ^151[0-9]{3}$ ]]; then
+    echo "Unable to determine release version (got $RELVER)"
+    exit 1
+fi
+
+echo
+echo "******** Building for release $RELVER ********"
+echo
+
 PVER=0.$RELVER
 
 # Default package publisher

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -253,7 +253,15 @@ url_encode() {
 #############################################################################
 # Set the LANG to C as the assembler will freak out on unicode in headers
 LANG=C
-GCCVER=6
+case $RELVER in
+    151022) GCCVER=5.1.0 ;;
+    151024) GCCVER=5 ;;
+    151025) GCCVER=6 ;;
+    151026) GCCVER=6 ;;
+    151027) GCCVER=7 ;;
+    151028) GCCVER=7 ;;
+    *)      logerr "Unknown release, can't select compiler." ;;
+esac
 GCCPATH=/opt/gcc-$GCCVER
 # Set the path - This can be overriden/extended in the build script
 PATH="$GCCPATH/bin:/usr/ccs/bin:/usr/bin:/usr/sbin:/usr/gnu/bin:/usr/sfw/bin"


### PR DESCRIPTION
Adding irssi.
Changing config.sh to automatically detect the release of the build host and create packages with that release version. At present the only difference between the release branches is this setting and this will allow us to remove the r151022/24 branches and maintain everything in one place.