### PR TITLE
docbook: add docbook xsl package

### DIFF
--- a/build/docbook/build.sh
+++ b/build/docbook/build.sh
@@ -16,38 +16,36 @@
 
 . ../../lib/functions.sh
 
-PROG=asciidoc
-VER=8.6.9
+PROG=docbook-xsl
+VER=20161215
 VERHUMAN=$VER
-PKG=ooce/text/asciidoc
-SUMMARY="AsciiDoc - text based documentation"
+PKG=ooce/text/docbook-xsl
+SUMMARY="XSLT 1.0 Stylesheets for DocBook"
 DESC="$SUMMARY"
+
+BUILDDIR=docbook-xsl-snapshot
 
 OPREFIX=$PREFIX
 PREFIX+="/$PROG"
 
-XFORM_ARGS=" -DOPREFIX=$OPREFIX -DPREFIX=$PREFIX"
-
-RUN_DEPENDS_IPS="ooce/text/docbook-xsl"
-
-# Building twice fails due to xmllint failure. Always use a fresh copy of
-# the source.
-REMOVE_PREVIOUS=1
-
-# Build 32-bit only and skip the arch-specific directories
-BUILDARCH=32
-CONFIGURE_OPTS="
-    --sysconfdir=/etc/$OPREFIX
-    --bindir=$PREFIX/bin
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
 "
 
-reset_configure_opts
+install() {
+    pushd $TMPDIR/$BUILDDIR
+    logcmd mkdir -p $DESTDIR/$PREFIX
+    find . | cpio -pvmud $DESTDIR/$PREFIX >/dev/null
+    popd
+}
 
 init
-download_source $PROG $PROG $VER
-patch_source
 prep_build
-build
+download_source docbook $PROG $VER
+patch_source
+install
 make_package
 clean_up
 

--- a/build/docbook/local.mog
+++ b/build/docbook/local.mog
@@ -1,0 +1,19 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license COPYING license="MIT"
+
+<transform file path=$(PREFIX)/\. -> drop>
+<transform file path=.*\.sh$ -> drop>
+

--- a/build/docbook/patches/series
+++ b/build/docbook/patches/series
@@ -1,0 +1,1 @@
+sourceforge.patch

--- a/build/docbook/patches/sourceforge.patch
+++ b/build/docbook/patches/sourceforge.patch
@@ -1,0 +1,12 @@
+
+Add rewrite rules for sourceforge resources
+
+--- a/catalog.xml	2016-12-15 14:24:30.000000000 +0000
++++ b/catalog.xml	2018-03-02 19:32:05.186540804 +0000
+@@ -5,4 +5,6 @@
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl/current/" rewritePrefix="./"/>
+   <rewriteURI uriStartString="http://cdn.docbook.org/release/xsl/snapshot/" rewritePrefix="./"/>
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl/snapshot/" rewritePrefix="./"/>
++  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
++  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
+ </catalog>


### PR DESCRIPTION
This provides local copies of stylesheets that can be used when generating man pages using asciidoc instead of retrieving them from sourceforge.net