### PR TITLE
Add PHP 7.2 package with FPM service

### DIFF
--- a/build/php/build-72.sh
+++ b/build/php/build-72.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Use is subject to license terms.
+#
+. ../../lib/functions.sh
+
+PROG=php
+PKG=ooce/application/php72
+VER=7.2.5
+VERHUMAN=$VER
+SUMMARY="PHP 7.2"
+DESC="A popular general-purpose scripting language"
+
+BUILDARCH=64
+
+MAJVER=${VER%.*}            # M.m
+sMAJVER=${MAJVER//./}       # Mm
+PATCHDIR=patches-$sMAJVER
+
+OPREFIX=$PREFIX
+PREFIX+=/$PROG-$MAJVER
+CONFPATH=/etc$OPREFIX/$PROG-$MAJVER
+LOGPATH=/var/log$OPREFIX/$PROG
+VARPATH=/var$OPREFIX/$PROG
+RUNPATH=$VARPATH/run
+
+BUILD_DEPENDS_IPS="ooce/database/bdb"
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DVERSION=$MAJVER
+    -DsVERSION=$sMAJVER
+"
+
+CONFIGURE_OPTS_64="
+    --prefix=$PREFIX
+    --sysconfdir=$CONFPATH
+    --localstatedir=$VARPATH
+    --with-config-file-path=$CONFPATH/php.ini
+
+    --disable-libgcc
+    --with-iconv
+    --enable-dtrace
+    --enable-ftp
+    --enable-mbstring
+    --enable-calendar
+    --enable-dba
+    --with-gettext
+    --enable-pcntl
+    --with-openssl
+    --with-gmp
+    --with-mysqli=mysqlnd
+    --with-pdo-mysql=mysqlnd
+    --with-zlib=/usr
+    --with-zlib-dir=/usr
+    --with-bz2=/usr
+    --with-curl
+
+    --with-db4=/opt/ooce
+
+    --enable-fpm
+    --with-fpm-user=php
+    --with-fpm-group=php
+"
+CPPFLAGS+=" -I/usr/include/gmp"
+LDFLAGS+=" -static-libgcc -L$OPREFIX/lib/$ISAPART64 -R$OPREFIX/lib/$ISAPART64"
+export LDFLAGS
+
+make_install() {
+    logmsg "--- make install"
+    logcmd $MAKE INSTALL_ROOT=${DESTDIR} install || \
+        logerr "--- Make install failed"
+
+    pushd $DESTDIR/$CONFPATH >/dev/null
+
+    # Enable PID file by default
+    sed < php-fpm.conf.default > php-fpm.conf '
+            /^;pid =/s/;//
+    '
+    # Provide working configuration out of the box
+    sed < php-fpm.d/www.conf.default > php-fpm.d/www.conf "
+        /^listen / {
+            s/^/;/
+            a\\
+listen = $RUNPATH/www.sock
+        }
+        /listen.mode/ {
+            s/^;//
+            s/0660/0664/
+        }
+    "
+
+    # Provide production php.ini
+    sed < $TMPDIR/$BUILDDIR/php.ini-production > php.ini '
+        /^;*cgi\.fix_pathinfo=1/c\
+cgi.fix_pathinfo=0
+        /^expose_php =/c\
+expose_php = Off
+        /^;*upload_tmp_dir =/c\
+upload_tmp_dir = /tmp
+    '
+
+    popd >/dev/null
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+install_smf application php$sMAJVER.xml php-$sMAJVER
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/php/files/php-72
+++ b/build/php/files/php-72
@@ -1,0 +1,57 @@
+#!/sbin/sh
+
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+. /lib/svc/share/smf_include.sh
+
+PIDF=/var/opt/ooce/php/run/php-fpm.pid
+
+check_and_kill()
+{
+	PID=`head -1 $1`
+	kill -0 $PID > /dev/null 2>&1
+	[ $? -eq 0 ] && kill $PID
+}
+
+case "$1" in
+'refresh')
+        [ -f $PIDF ] && kill -USR2 `head -1 $PIDF`
+        ;;
+
+'start')
+	/opt/ooce/php-7.2/sbin/php-fpm -c /etc/opt/ooce/php-7.2/php.ini
+	;;
+
+'stop')
+	[ -f $PIDF ] && check_and_kill $PIDF
+	# Need to kill the entire service contract to kill all php related
+	# processes
+	smf_kill_contract $2 TERM 1 30
+	ret=$?
+	[ $ret -eq 1 ] && exit 1
+
+	# It is possible that some of these are not responding to TERM.
+	# If the contract did not empty after TERM, move on to KILL.
+	if [ $ret -eq 2 ] ; then
+		smf_kill_contract $2 KILL 1
+	fi
+	;;
+*)
+	echo "Usage: $0 { start | stop | refresh }"
+	exit 1
+	;;
+esac
+exit 0
+

--- a/build/php/files/php72.xml
+++ b/build/php/files/php72.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+	{{{ CDDL HEADER
+
+	This file and its contents are supplied under the terms of the
+	Common Development and Distribution License ("CDDL"), version 1.0.
+	You may only use this file in accordance with the terms of version
+	1.0 of the CDDL.
+
+	A full copy of the text of the CDDL should have accompanied this
+	source. A copy of the CDDL is also available via the Internet at
+	http://www.illumos.org/license/CDDL.
+
+	}}}
+
+	Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+-->
+
+<service_bundle type='manifest' name='php72:fpm'>
+
+<service
+	name='application/php72'
+	type='service'
+	version='1'>
+
+	<instance name='default' enabled='false' >
+
+	<dependency name='paths'
+	    grouping='require_all'
+	    restart_on='error'
+	    type='path'>
+		<service_fmri value='file://localhost/etc/opt/ooce/php-7.2/php-fpm.conf' />
+	</dependency>
+
+	<dependency
+		name='loopback'
+		grouping='require_any'
+		restart_on='error'
+		type='service'>
+		<service_fmri value='svc:/network/loopback' />
+	</dependency>
+
+	<dependency
+		name='network'
+		grouping='optional_all'
+		restart_on='error'
+		type='service'>
+		<service_fmri value='svc:/milestone/network' />
+	</dependency>
+
+	<dependency
+	    name='filesystem_local'
+	    grouping='require_all'
+	    restart_on='none'
+	    type='service'>
+		<service_fmri value='svc:/system/filesystem/local:default' />
+	</dependency>
+
+	<dependent
+		name='php7fpm_multi-user'
+		grouping='optional_all'
+		restart_on='none'>
+		<service_fmri value='svc:/milestone/multi-user' />
+	</dependent>
+
+	<exec_method
+	    type='method'
+	    name='start'
+	    exec='/lib/svc/method/php-72 start'
+	    timeout_seconds='60'>
+            <method_context security_flags="aslr">
+		<method_credential user='php' group='php'
+		    privileges='basic,!proc_info,!proc_session,!file_link_any' />
+	    </method_context>
+	</exec_method>
+
+	<exec_method
+	    type='method'
+	    name='stop'
+	    exec='/lib/svc/method/php-72 stop %{restarter/contract}'
+	    timeout_seconds='60' />
+
+	<exec_method
+	    type='method'
+	    name='refresh'
+	    exec='/lib/svc/method/php-72 refresh %{restarter/contract}'
+	    timeout_seconds='60' />
+
+	</instance>
+
+	<stability value='Unstable' />
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'>
+			PHP7.2 FPM
+			</loctext>
+		</common_name>
+	</template>
+</service>
+
+</service_bundle>

--- a/build/php/local.mog
+++ b/build/php/local.mog
@@ -1,0 +1,36 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+# CDDL HEADER START
+#
+# Copyright 2018 OmniOS Community Edition.  All rights reserved.
+
+dir group=bin mode=0755 owner=root path=var/$(OPREFIX)
+dir group=bin mode=0755 owner=root path=var/$(OPREFIX)/$(PROG)
+dir group=bin mode=0755 owner=root path=var/log/$(OPREFIX)/$(PROG)
+dir group=bin mode=0775 owner=root path=$(OPREFIX)/sbin
+
+link path=$(OPREFIX)/bin/$(PROG) target=../$(PROG)-$(VERSION)/bin/$(PROG) \
+    mediator=php mediator-version=$(VERSION)
+
+<transform file dir path=\. -> drop>
+
+group groupname=$(PROG) gid=82
+user username=$(PROG) uid=82 group=$(PROG) gcos-field="PHP User" \
+    home-dir=/var/$(OPREFIX)/$(PROG) password=NP
+<transform file path=etc/$(OPREFIX)/$(PROG)/.+$ -> set preserve renamenew>
+<transform dir  path=var/$(OPREFIX)/$(PROG) -> set owner $(PROG)>
+<transform dir  path=var/log/$(OPREFIX)/$(PROG) -> set owner $(PROG)>
+<transform file path=$(PREFIX)/sbin/ \
+    -> set restart_fmri svc:/application/$(PROG)$(sVERSION):default>
+
+license LICENSE license=PHP
+

--- a/build/php/patches-72/configure.patch
+++ b/build/php/patches-72/configure.patch
@@ -1,0 +1,14 @@
+Adjust for non-standard location of OmniOS' gmp.h include file
+
+diff -ru php-7.2.5~/configure php-7.2.5/configure
+--- php-7.2.5~/configure	Tue Apr 24 15:10:05 2018
++++ php-7.2.5/configure	Fri Apr 27 14:01:29 2018
+@@ -38772,7 +38772,7 @@
+   MACHINE_INCLUDES=$($CC -dumpmachine)
+ 
+   for i in $PHP_GMP /usr/local /usr; do
+-    test -f $i/include/gmp.h && GMP_DIR=$i && break
++    test -f $i/include/gmp/gmp.h && GMP_DIR=$i && break
+     test -f $i/include/$MACHINE_INCLUDES/gmp.h && GMP_DIR=$i && break
+   done
+ 

--- a/build/php/patches-72/series
+++ b/build/php/patches-72/series
@@ -1,0 +1,1 @@
+configure.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -1,5 +1,6 @@
 | Package | Version | Link | Maintainer |
 | :------ | :------ | :--- | :--------- |
+| ooce/application/php72	| 7.2.5		| http://uk1.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/texlive	| 20170524	| ftp://tug.org/historic/systems/texlive/2017/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/bdb		| 5.3.28	| http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/build/ant	| 1.9.11	| https://ant.apache.org/srcdownload.cgi | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
The service will run straight out of the box and listen on a UNIX socket with `svcadm enable php72`- configuration can be modified in `/etc/opt/ooce/php-7.2/php-fpm.d/` as desired - to alter the number of instances, configure additional pools, etc.

Adding something like the following block to the nginx configuration enables handling of PHP scripts via the FPM server.

```
        location ~ \.php$ {
                try_files $uri =404;
                fastcgi_pass unix:/var/opt/ooce/php/run/www.sock;
                fastcgi_index index.php;
                include fastcgi.conf;
        }
```

A fairly minimal set of PHP modules is enabled for this release - those for which extra dependencies are not required - more can be added in future.