### PR TITLE
libpciaccess: PCI access utility library

### DIFF
--- a/build/libpciaccess/build.sh
+++ b/build/libpciaccess/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2018 Thomas Merkel
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=libpciaccess
+VER=0.14
+VERHUMAN=$VER
+PKG=library/libpciaccess
+SUMMARY="PCI access utility library from X.org"
+DESC="The pciaccess library wraps platform-dependent PCI access methods in a convenient library."
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+make_isa_stub
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/libpciaccess/local.mog
+++ b/build/libpciaccess/local.mog
@@ -1,0 +1,1 @@
+license COPYING license=Various

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -30,3 +30,4 @@
 | ooce/system/test/ior		| 3.1.0		| https://github.com/hpc/ior/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/system/test/iozone	| 3.478		| http://www.iozone.org/src/current/ | [omniosorg](https://github.com/omniosorg)
 | ooce/text/asciidoc		| 8.6.9		| http://www.methods.co.nz/asciidoc/ | [omniosorg](https://github.com/omniosorg)
+| ooce/library/libpciaccess	| 0.14		| https://xorg.freedesktop.org/archive/individual/lib | [drscream](https://github.com/drscream)


### PR DESCRIPTION
The pciaccess library wraps platform-dependent PCI access methods in a convenient library. For exmaple it's required to build gfx-drm and the kernel module.