### PR TITLE
Fix smartmontools update-smart-drivedb script

### DIFF
--- a/build/smartmontools/build.sh
+++ b/build/smartmontools/build.sh
@@ -37,7 +37,11 @@ CPPFLAGS64+=" -D_AVL_H"
 CONFIGURE_OPTS="
     --sysconfdir=/etc$PREFIX
     --sbindir=$PREFIX/sbin
+    --with-gnupg=/opt/ooce/bin/gpg
+    --with-scriptpath=/usr/bin:/opt/ooce/bin
 "
+
+RUN_DEPENDS_IPS=ooce/security/gnupg
 
 reset_configure_opts
 

--- a/build/smartmontools/patches/bash-shebang.patch
+++ b/build/smartmontools/patches/bash-shebang.patch
@@ -1,0 +1,9 @@
+diff -ru smartmontools-6.6/update-smart-drivedb.in smartmontools-6.6~/update-smart-drivedb.in
+--- smartmontools-6.6/update-smart-drivedb.in	2017-11-03 22:43:32.000000000 +0000
++++ smartmontools-6.6~/update-smart-drivedb.in	2018-11-04 20:16:37.685811494 +0000
+@@ -1,4 +1,4 @@
+-#! /bin/sh
++#!/bin/bash
+ #
+ # smartmontools drive database update script
+ #

--- a/build/smartmontools/patches/series
+++ b/build/smartmontools/patches/series
@@ -1,0 +1,1 @@
+bash-shebang.patch


### PR DESCRIPTION
The update-smart-drivedb script uses some bash extensions but has /bin/sh in the shebang line. It also uses a path that excludes /opt/ooce/bin which means that it cannot find the gpg utility.