### PR TITLE
Virtualbox: add gsoap licence

### DIFF
--- a/build/virtualbox/build.sh
+++ b/build/virtualbox/build.sh
@@ -65,6 +65,7 @@ XFORM_ARGS="
     -DPROG=$PROG
     -DVERSION=$MAJVER
     -DsVERSION=$sMAJVER
+    -DGSOAPDIR=$GSOAPDIR
 "
 
 # The usual --prefix etc. options are not supported

--- a/build/virtualbox/local.mog
+++ b/build/virtualbox/local.mog
@@ -16,6 +16,7 @@
 set name=variant.opensolaris.zone value="global"
 
 license opt/$(PROG)/LICENSE license=GPLv2
+license ../$(GSOAPDIR)/GPLv2_license.txt license=GPLv2
 
 driver name=vboxdrv
 driver name=vboxflt


### PR DESCRIPTION
This, along with the other PRs to add source-URLs, results in these package differences:

```diff
--- Published ooce/virtualization/virtualbox@5.2.22,5.11-151028.0
--- Comparing old package with new

+set name=info.source-url.0 \
+    value=https://mirrors.omniosce.org/gsoap/gsoap_2.8.73.zip
+set name=info.source-url.1 \
+    value=https://mirrors.omniosce.org/VirtualBox/VirtualBox-5.2.22.tar.bz2
+license 1d0fe189cc6789d7d16c8ac9a84e56e7fcd9f530 license=GPLv2
```