### PR TITLE
nsd/unbound can build with openssl 1.1

### DIFF
--- a/build/nsd/build.sh
+++ b/build/nsd/build.sh
@@ -39,9 +39,6 @@ XFORM_ARGS="
     -DsVERSION=$sMAJVER
 "
 
-# See also --with-ssl configure option.
-FORCE_OPENSSL_VERSION=1.0
-
 BUILD_DEPENDS_IPS="ooce/library/libev"
 
 set_arch 64
@@ -59,7 +56,6 @@ CONFIGURE_OPTS="
     --with-xfrdfile=/var$sPREFIX/db/xfrd.state
     --with-zonelistfile=/var$sPREFIX/db/zone.list
     --with-pidfile=/var$sPREFIX/run/nsd.pid
-    --with-ssl=/usr/ssl-1.0
 "
 
 LDFLAGS="-L$OPREFIX/lib/$ISAPART64 -R$OPREFIX/lib/$ISAPART64"

--- a/build/unbound/build.sh
+++ b/build/unbound/build.sh
@@ -33,9 +33,6 @@ XFORM_ARGS="
 
 BUILD_DEPENDS_IPS="ooce/library/libev"
 
-# See also --with-ssl configure option.
-FORCE_OPENSSL_VERSION=1.0
-
 set_arch 64
 
 CONFIGURE_OPTS="
@@ -43,7 +40,6 @@ CONFIGURE_OPTS="
     --with-run-dir=/var$PREFIX
     --with-libevent=/opt/ooce
     --with-pthreads
-    --with-ssl=/usr/ssl-1.0
 "
 
 LDFLAGS="-L$OPREFIX/lib/$ISAPART64 -R$OPREFIX/lib/$ISAPART64"


### PR DESCRIPTION
Following the recent fix to the openssl header symlink.