### PR TITLE
Ruby 2.6, fix gem install

### DIFF
--- a/build/ruby/patches-26/openssl-EAGAIN.patch
+++ b/build/ruby/patches-26/openssl-EAGAIN.patch
@@ -1,0 +1,21 @@
+diff -wpruN '--exclude=*.orig' a~/ext/openssl/ossl_ssl.c a/ext/openssl/ossl_ssl.c
+--- a~/ext/openssl/ossl_ssl.c	1970-01-01 00:00:00
++++ a/ext/openssl/ossl_ssl.c	1970-01-01 00:00:00
+@@ -1851,13 +1851,16 @@ ossl_ssl_read_internal(int argc, VALUE *
+                 rb_io_wait_writable(fptr->fd);
+                 continue;
+ 	    case SSL_ERROR_WANT_READ:
++wantread:
+ 		if (no_exception_p(opts)) { return sym_wait_readable; }
+                 read_would_block(nonblock);
+                 rb_io_wait_readable(fptr->fd);
+ 		continue;
+ 	    case SSL_ERROR_SYSCALL:
+ 		if (!ERR_peek_error()) {
+-		    if (errno)
++		    if (errno == EAGAIN)
++			goto wantread;
++		    else if (errno)
+ 			rb_sys_fail(0);
+ 		    else {
+ 			/*

--- a/build/ruby/patches-26/series
+++ b/build/ruby/patches-26/series
@@ -1,1 +1,2 @@
 02-config.patch
+openssl-EAGAIN.patch

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -162,16 +162,16 @@ EOM
 logcmd() {
     typeset preserve_stdout=0
     [ "$1" = "-p" ] && shift && preserve_stdout=1
+    echo Running: "$@" >> $LOGFILE
     if [ -z "$SCREENOUT" ]; then
-        echo Running: "$@" >> $LOGFILE
         if [ "$preserve_stdout" = 0 ]; then
             "$@" >> $LOGFILE 2>&1
         else
             "$@"
         fi
     else
-        echo Running: "$@" | tee -a $LOGFILE
         if [ "$preserve_stdout" = 0 ]; then
+            echo Running: "$@"
             "$@" | tee -a $LOGFILE 2>&1
             return ${PIPESTATUS[0]}
         else


### PR DESCRIPTION
Ruby 2.6 performs parallel downloads when installing gems, and this exposes a fault in the ruby openssl module where it does not handle EAGAIN coming back from a non-blocking SSL_read() call. The OpenSSL documentation suggests that EAGAIN should not be a response that comes back from SSL_read(), although the interface allows for arbitrary errnos to come back from the underlying OS.
In any case, EAGAIN means that the operation should be retried.

With this patch in place:

```
% ls -l =gem
lrwxrwxrwx   1 root     root          19 Jan 22 21:50 /opt/ooce/bin/gem -> ../ruby-2.6/bin/gem*
% pfexec gem install bundler
Fetching bundler-2.0.1.gem
Successfully installed bundler-2.0.1
Parsing documentation for bundler-2.0.1
Installing ri documentation for bundler-2.0.1
Done installing documentation for bundler after 9 seconds
1 gem installed
```
