### PR TITLE
Add explicit restart FMRI targets

### DIFF
--- a/build/openvpn/local.mog
+++ b/build/openvpn/local.mog
@@ -20,7 +20,9 @@ dir group=root mode=0700 owner=root path=var/log/$(PREFIX)
 <transform path=etc/$(PREFIX) -> set owner root >
 
 <transform file path=$(PREFIX)/sbin/ \
-    -> set restart_fmri svc:/ooce/network/$(PROG) >
+    -> add restart_fmri svc:/ooce/network/$(PROG):server >
+<transform file path=$(PREFIX)/sbin/ \
+    -> add restart_fmri svc:/ooce/network/$(PROG):client >
 
 # symlink man page
 link path=$(OPREFIX)/share/man/man8/$(PROG).8 \


### PR DESCRIPTION
Fixes:

```
FMRI pattern might implicitly match more than one service instance.
Actuators for restart_fmri will not be run for svc:/ooce/network/openvpn.
```