### PR TITLE
lz4: update to 1.9.1

### DIFF
--- a/build/lz4/build.sh
+++ b/build/lz4/build.sh
@@ -18,7 +18,7 @@
 
 PROG=lz4
 PKG=ooce/compress/lz4
-VER=1.9.0
+VER=1.9.1
 VERHUMAN=$VER
 SUMMARY="LZ4"
 DESC="Extremely fast compression"

--- a/build/lz4/patches/Makefile.patch
+++ b/build/lz4/patches/Makefile.patch
@@ -1,0 +1,16 @@
+diff -wpruN '--exclude=*.orig' a~/programs/Makefile a/programs/Makefile
+--- a~/programs/Makefile	1970-01-01 00:00:00
++++ a/programs/Makefile	1970-01-01 00:00:00
+@@ -149,9 +149,9 @@ install: lz4
+ 	@echo Installing binaries
+ 	@$(INSTALL_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
+ 	@$(INSTALL_PROGRAM) lz4$(EXT) $(DESTDIR)$(bindir)/lz4$(EXT)
+-	@$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/lz4c$(EXT)
+-	@$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/lz4cat$(EXT)
+-	@$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/unlz4$(EXT)
++	@$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/lz4c$(EXT)
++	@$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/lz4cat$(EXT)
++	@$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/unlz4$(EXT)
+ 	@echo Installing man pages
+ 	@$(INSTALL_DATA) lz4.1 $(DESTDIR)$(man1dir)/lz4.1
+ 	@$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/lz4c.1

--- a/build/lz4/patches/series
+++ b/build/lz4/patches/series
@@ -1,0 +1,1 @@
+Makefile.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -6,7 +6,7 @@
 | ooce/application/php-73	| 7.3.4		| http://uk1.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/texlive	| 20180414	| ftp://tug.org/historic/systems/texlive/2018/ | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.3.2		| https://ftp.osuosl.org/pub/xiph/releases/flac/ | [omniosorg](https://github.com/omniosorg)
-| ooce/compress/lz4		| 1.9.0		| https://github.com/lz4/lz4/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/compress/lz4		| 1.9.1		| https://github.com/lz4/lz4/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pigz		| 2.4		| https://zlib.net/pigz/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/bdb		| 5.3.28	| http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
> This is a point release, which main objective is to fix a read out-of-bound issue reported in the decoder of v1.9.0. Upgrade from this version is recommended.