### PR TITLE
Add missing binary links

### DIFF
--- a/build/virtualbox/vbox.mog
+++ b/build/virtualbox/vbox.mog
@@ -41,6 +41,10 @@ driver name=vboxusbmon
 # web service link
 link path=$(PREFIX)/vboxwebsrv target=amd64/vboxwebsrv
 
+# Links to amd64/
+<transform file path=$(PREFIX)/amd64/(VBox[^.]+$) mode=0755 -> emit \
+    link path=$(PREFIX)/%<1> target=amd64/%<1> >
+
 # Set correct group on system directories
 <transform dir path=platform -> set group sys>
 


### PR DESCRIPTION
Reported by @jimklimov

This change adds these lines to the final manifest:

```
link path=opt/VirtualBox/VBoxManage target=amd64/VBoxManage
link path=opt/VirtualBox/VBoxBugReport target=amd64/VBoxBugReport
link path=opt/VirtualBox/VBoxBalloonCtrl target=amd64/VBoxBalloonCtrl
link path=opt/VirtualBox/VBoxZoneAccess target=amd64/VBoxZoneAccess
link path=opt/VirtualBox/VBoxXPCOMIPCD target=amd64/VBoxXPCOMIPCD
link path=opt/VirtualBox/VBoxDTrace target=amd64/VBoxDTrace
link path=opt/VirtualBox/VBoxSVC target=amd64/VBoxSVC
link path=opt/VirtualBox/VBoxAutostart target=amd64/VBoxAutostart
link path=opt/VirtualBox/VBoxExtPackHelperApp target=amd64/VBoxExtPackHelperApp 
```