### PR TITLE
Virtualbox should include CTF data

### DIFF
--- a/build/virtualbox/patches/build-in-zone.patch
+++ b/build/virtualbox/patches/build-in-zone.patch
@@ -3,7 +3,7 @@ Patch originally taken from OpenIndiana, author is Alexander Pyhalov
 diff -wpruN '--exclude=*.orig' a~/Config.kmk a/Config.kmk
 --- a~/Config.kmk	1970-01-01 00:00:00
 +++ a/Config.kmk	1970-01-01 00:00:00
-@@ -2701,8 +2701,6 @@ $(PATH_OUT)/DynamicConfig.kmk: \
+@@ -2796,8 +2796,6 @@ $(PATH_OUT)/DynamicConfig.kmk: \
  		$(VBOX_GCC32_PATH_CC) \
  		$(VBOX_GCC32_PATH_CXX) \
                 $(VBOX_GCC32_LIBGCC) \

--- a/build/virtualbox/patches/configure.patch
+++ b/build/virtualbox/patches/configure.patch
@@ -4,7 +4,7 @@ ooce/library/libpng
 diff -wpruN '--exclude=*.orig' a~/configure a/configure
 --- a~/configure	1970-01-01 00:00:00
 +++ a/configure	1970-01-01 00:00:00
-@@ -130,8 +130,8 @@ MAKESELF="makeself"
+@@ -131,8 +131,8 @@ MAKESELF="makeself"
  MESA="-lGL"
  INCZ=""
  LIBZ="-lz"
@@ -15,7 +15,7 @@ diff -wpruN '--exclude=*.orig' a~/configure a/configure
  INCDEVMAPPER=""
  LIBDEVMAPPER="-ldevmapper"
  CXX_FLAGS=""
-@@ -145,8 +145,8 @@ if [ "$OS" = "freebsd" ]; then
+@@ -146,8 +146,8 @@ if [ "$OS" = "freebsd" ]; then
  else
    INCCURL=""
    LIBCURL="-lcurl"

--- a/build/virtualbox/patches/ctf.patch
+++ b/build/virtualbox/patches/ctf.patch
@@ -2,11 +2,10 @@ Add CTF data to virtualbox objects to aid debugging. Also use the same gcc
 flags as for the main illumos build to disable optimisations that hinder
 problem resolution.
 
-diff --git a/kBuild/tools/GCC3PLAIN.kmk b/kBuild/tools/GCC3PLAIN.kmk
-index 0793f839..585aeafa 100644
---- a/kBuild/tools/GCC3PLAIN.kmk
-+++ b/kBuild/tools/GCC3PLAIN.kmk
-@@ -66,7 +66,11 @@ endif
+diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3PLAIN.kmk
+--- a~/kBuild/tools/GCC3PLAIN.kmk	1970-01-01 00:00:00
++++ a/kBuild/tools/GCC3PLAIN.kmk	1970-01-01 00:00:00
+@@ -66,18 +66,37 @@ endif
  # General Properties used by kBuild
  TOOL_GCC3PLAIN_COBJSUFF         ?= .o
  TOOL_GCC3PLAIN_CFLAGS           ?=
@@ -15,11 +14,19 @@ index 0793f839..585aeafa 100644
 +	-gdwarf-2 -fno-inline-small-functions \
 +	-fno-inline-functions-called-once \
 +	-fno-ipa-cp -fno-ipa-icf \
-+	-fno-clone-functions -fno-reorder-functions
++	-fno-clone-functions -fno-reorder-functions \
++	-fno-shrink-wrap -fno-aggressive-loop-optimizations
  TOOL_GCC3PLAIN_CFLAGS.profile   ?= -O2 #-g -pg
- TOOL_GCC3PLAIN_CFLAGS.release   ?= -O2
+-TOOL_GCC3PLAIN_CFLAGS.release   ?= -O2
++TOOL_GCC3PLAIN_CFLAGS.release   ?= -O2 \
++	-gdwarf-2 -fno-inline-small-functions \
++	-fno-inline-functions-called-once \
++	-fno-ipa-cp -fno-ipa-icf \
++	-fno-clone-functions -fno-reorder-functions \
++	-fno-shrink-wrap -fno-aggressive-loop-optimizations
  TOOL_GCC3PLAIN_CINCS            ?=
-@@ -75,7 +79,11 @@ TOOL_GCC3PLAIN_CDEFS            ?=
+ TOOL_GCC3PLAIN_CDEFS            ?=
+ 
  TOOL_GCC3PLAIN_CXXOBJSUFF       ?= .o
  TOOL_GCC3PLAIN_CXXOBJSUFF       ?= .o
  TOOL_GCC3PLAIN_CXXFLAGS         ?=
@@ -30,9 +37,17 @@ index 0793f839..585aeafa 100644
 +	-fno-ipa-cp -fno-ipa-icf \
 +	-fno-clone-functions -fno-reorder-functions
  TOOL_GCC3PLAIN_CXXFLAGS.profile ?= -O2 #-g -pg
- TOOL_GCC3PLAIN_CXXFLAGS.release ?= -O2
+-TOOL_GCC3PLAIN_CXXFLAGS.release ?= -O2
++TOOL_GCC3PLAIN_CXXFLAGS.release ?= -O2 \
++	-gdwarf-2 -fno-inline-small-functions \
++	-fno-inline-functions-called-once \
++	-fno-ipa-cp -fno-ipa-icf \
++	-fno-clone-functions -fno-reorder-functions \
++	-fno-shrink-wrap -fno-aggressive-loop-optimizations
  TOOL_GCC3PLAIN_CXXINCS          ?=
-@@ -91,6 +99,8 @@ TOOL_GCC3PLAIN_ARLIBSUFF        ?= .a
+ TOOL_GCC3PLAIN_CXXDEFS          ?=
+ 
+@@ -91,6 +110,8 @@ TOOL_GCC3PLAIN_ARLIBSUFF        ?= .a
  
  TOOL_GCC3PLAIN_LDFLAGS          ?=
  
@@ -41,43 +56,42 @@ index 0793f839..585aeafa 100644
  
  ## Compile C source.
  # @param    $(target)   Normalized main target name.
-@@ -122,6 +132,7 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
+@@ -122,6 +143,7 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
  		$(flags) -fpreprocessed -x c\
  		-o $(obj)\
  		-
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
++	$(QUIET)$(TOOL_CTFCONVERT) -i -l vbox $(obj)
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  else # !KBUILD_USE_KOBJCACHE
-@@ -132,6 +143,7 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
+@@ -132,6 +154,7 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
  		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
  		-o $(obj)\
  		$(abspath $(source))
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
++	$(QUIET)$(TOOL_CTFCONVERT) -i -l vbox $(obj)
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  endif # !KBUILD_USE_KOBJCACHE
-@@ -166,6 +178,7 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
+@@ -166,6 +189,7 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
  		$(flags) -fpreprocessed -x c++\
  		-o $(obj)\
  		-
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
++	$(QUIET)$(TOOL_CTFCONVERT) -i -l vbox $(obj)
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  else # !KBUILD_USE_KOBJCACHE
-@@ -176,6 +189,7 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
+@@ -176,6 +200,7 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
  		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
  		-o $(obj)\
  		$(abspath $(source))
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
++	$(QUIET)$(TOOL_CTFCONVERT) -i -l vbox $(obj)
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  endif # !KBUILD_USE_KOBJCACHE
-diff --git a/kBuild/tools/GXX3PLAIN.kmk b/kBuild/tools/GXX3PLAIN.kmk
-index 92ab12bb..6217d108 100644
---- a/kBuild/tools/GXX3PLAIN.kmk
-+++ b/kBuild/tools/GXX3PLAIN.kmk
-@@ -66,7 +66,11 @@ endif
+diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GXX3PLAIN.kmk a/kBuild/tools/GXX3PLAIN.kmk
+--- a~/kBuild/tools/GXX3PLAIN.kmk	1970-01-01 00:00:00
++++ a/kBuild/tools/GXX3PLAIN.kmk	1970-01-01 00:00:00
+@@ -67,17 +67,35 @@ endif
  # General Properties used by kBuild
  TOOL_GXX3PLAIN_COBJSUFF         ?= .o
  TOOL_GXX3PLAIN_CFLAGS           ?=
@@ -88,10 +102,16 @@ index 92ab12bb..6217d108 100644
 +	-fno-ipa-cp -fno-ipa-icf \
 +	-fno-clone-functions -fno-reorder-functions
  TOOL_GXX3PLAIN_CFLAGS.profile   ?= -O2 #-g -pg
- TOOL_GXX3PLAIN_CFLAGS.release   ?= -O2
+-TOOL_GXX3PLAIN_CFLAGS.release   ?= -O2
++TOOL_GXX3PLAIN_CFLAGS.release   ?= -O2 \
++	-gdwarf-2 -fno-inline-small-functions \
++	-fno-inline-functions-called-once \
++	-fno-ipa-cp -fno-ipa-icf \
++	-fno-clone-functions -fno-reorder-functions \
++	-fno-shrink-wrap -fno-aggressive-loop-optimizations
  TOOL_GXX3PLAIN_CINCS            ?=
-@@ -75,7 +79,11 @@ TOOL_GXX3PLAIN_CDEFS            ?=
- TOOL_GXX3PLAIN_CXXOBJSUFF       ?= .o
+ TOOL_GXX3PLAIN_CDEFS            ?=
+ 
  TOOL_GXX3PLAIN_CXXOBJSUFF       ?= .o
  TOOL_GXX3PLAIN_CXXFLAGS         ?=
 -TOOL_GXX3PLAIN_CXXFLAGS.debug   ?= -g
@@ -101,9 +121,17 @@ index 92ab12bb..6217d108 100644
 +	-fno-ipa-cp -fno-ipa-icf \
 +	-fno-clone-functions -fno-reorder-functions
  TOOL_GXX3PLAIN_CXXFLAGS.profile ?= -O2 #-g -pg
- TOOL_GXX3PLAIN_CXXFLAGS.release ?= -O2
+-TOOL_GXX3PLAIN_CXXFLAGS.release ?= -O2
++TOOL_GXX3PLAIN_CXXFLAGS.release ?= -O2 \
++	-gdwarf-2 -fno-inline-small-functions \
++	-fno-inline-functions-called-once \
++	-fno-ipa-cp -fno-ipa-icf \
++	-fno-clone-functions -fno-reorder-functions \
++	-fno-shrink-wrap -fno-aggressive-loop-optimizations
  TOOL_GXX3PLAIN_CXXINCS          ?=
-@@ -91,6 +99,8 @@ TOOL_GXX3PLAIN_ARLIBSUFF        ?= .a
+ TOOL_GXX3PLAIN_CXXDEFS          ?=
+ 
+@@ -99,6 +117,8 @@ TOOL_GXX3PLAIN_ARLIBSUFF        ?= .a
  
  TOOL_GXX3PLAIN_LDFLAGS          ?=
  
@@ -112,35 +140,19 @@ index 92ab12bb..6217d108 100644
  
  ## Compile C source.
  # @param    $(target)   Normalized main target name.
-@@ -122,6 +132,7 @@ define TOOL_GXX3PLAIN_COMPILE_C_CMDS
- 		$(flags) -fpreprocessed -x c\
+@@ -137,6 +157,7 @@ else
  		-o $(obj)\
- 		-
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
+ 		$(abspath $(source))
+ endif
++	$(QUIET)$(TOOL_CTFCONVERT) -i -l vbox $(obj)
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
- else # !KBUILD_USE_KOBJCACHE
-@@ -132,6 +143,7 @@ define TOOL_GXX3PLAIN_COMPILE_C_CMDS
+ 
+@@ -231,6 +253,7 @@ define TOOL_GXX3PLAIN_COMPILE_AS_CMDS
  		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
  		-o $(obj)\
  		$(abspath $(source))
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
++	-$(QUIET)$(TOOL_CTFCONVERT) -i -l vbox $(obj)
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
- endif # !KBUILD_USE_KOBJCACHE
-@@ -166,6 +178,7 @@ define TOOL_GXX3PLAIN_COMPILE_CXX_CMDS
- 		$(flags) -fpreprocessed -x c++\
- 		-o $(obj)\
- 		-
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
- 	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
- endef
- else # !KBUILD_USE_KOBJCACHE
-@@ -176,6 +189,7 @@ define TOOL_GXX3PLAIN_COMPILE_CXX_CMDS
- 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
- 		-o $(obj)\
- 		$(abspath $(source))
-+	-$(QUIET)$(TOOL_CTFCONVERT) -i -L VERSION $(obj)
- 	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
- endef
- endif # !KBUILD_USE_KOBJCACHE
+ 

--- a/build/virtualbox/patches/hma.patch
+++ b/build/virtualbox/patches/hma.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/src/VBox/HostDrivers/Support/SUPDrv.cpp a/src/VBox/HostDrivers/Support/SUPDrv.cpp
 --- a~/src/VBox/HostDrivers/Support/SUPDrv.cpp	1970-01-01 00:00:00
 +++ a/src/VBox/HostDrivers/Support/SUPDrv.cpp	1970-01-01 00:00:00
-@@ -4016,7 +4016,7 @@ SUPR0DECL(RTCCUINTREG) SUPR0ChangeCR4(RT
+@@ -4049,7 +4049,7 @@ SUPR0DECL(RTCCUINTREG) SUPR0ChangeCR4(RT
   */
  SUPR0DECL(int) SUPR0EnableVTx(bool fEnable)
  {
@@ -10,7 +10,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/HostDrivers/Support/SUPDrv.cpp a/src/
      return supdrvOSEnableVTx(fEnable);
  #else
      RT_NOREF1(fEnable);
-@@ -4034,7 +4034,7 @@ SUPR0DECL(int) SUPR0EnableVTx(bool fEnab
+@@ -4067,7 +4067,7 @@ SUPR0DECL(int) SUPR0EnableVTx(bool fEnab
   */
  SUPR0DECL(bool) SUPR0SuspendVTxOnCpu(void)
  {
@@ -19,7 +19,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/HostDrivers/Support/SUPDrv.cpp a/src/
      return supdrvOSSuspendVTxOnCpu();
  #else
      return false;
-@@ -4051,7 +4051,7 @@ SUPR0DECL(bool) SUPR0SuspendVTxOnCpu(voi
+@@ -4084,7 +4084,7 @@ SUPR0DECL(bool) SUPR0SuspendVTxOnCpu(voi
   */
  SUPR0DECL(void) SUPR0ResumeVTxOnCpu(bool fSuspended)
  {
@@ -39,7 +39,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/HostDrivers/Support/solaris/SUPDrv-so
  
  #include "../SUPDrvInternal.h"
  #include <VBox/log.h>
-@@ -973,6 +974,53 @@ bool VBOXCALL  supdrvOSAreTscDeltasInSyn
+@@ -972,6 +973,53 @@ bool VBOXCALL  supdrvOSAreTscDeltasInSyn
      return false;
  }
  

--- a/build/virtualbox/patches/series
+++ b/build/virtualbox/patches/series
@@ -2,5 +2,5 @@ configure.patch
 stackclash.patch
 solaris-install.patch
 build-in-zone.patch
-#ctf.patch
+ctf.patch
 hma.patch

--- a/build/virtualbox/patches/solaris-install.patch
+++ b/build/virtualbox/patches/solaris-install.patch
@@ -5,7 +5,7 @@ the default layout without building the package file.
 diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/VBox/Installer/solaris/Makefile.kmk
 --- a~/src/VBox/Installer/solaris/Makefile.kmk	1970-01-01 00:00:00
 +++ a/src/VBox/Installer/solaris/Makefile.kmk	1970-01-01 00:00:00
-@@ -533,7 +533,7 @@ endif
+@@ -530,7 +530,7 @@ endif
  # Creates the System V style installer package.
  #
  solaris-package:: $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).pkg
@@ -14,7 +14,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  		$(VBOX_VERSION_STAMP) \
  		\
  		$(VBOX_PATH_INST_COMMON_SRC)/virtualbox.desktop.in \
-@@ -541,7 +541,6 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
+@@ -538,7 +538,6 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
  		$(VBOX_PATH_SOL_INST_SRC)/virtualbox.applications.in \
  		$(VBOX_PATH_SOL_INST_SRC)/vbox.pkginfo \
  		\
@@ -22,7 +22,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  		$(if-expr !defined(VBOX_OSE) && defined(VBOX_WITH_VBOXSDL), $(PATH_DEVTOOLS_TRG)/libsdl/v1.2.13/lib/libSDL-1.2.so.0.11.2,) \
  		\
  		$(if $(VBOX_OSE),,$(foreach arch, x86 amd64, $(foreach lib, libgcc_s.so.1 libstdc++.so.6, \
-@@ -602,8 +601,6 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
+@@ -599,8 +598,6 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
  		"$($(var).SRC)/$(file)" "$($(var).DST)/$(file)")))
  
  # VirtualBox: Common files.
@@ -31,7 +31,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  	$(LN_SYMLINK) -f ./pkginstall.sh	$(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/ipsinstall.sh
  	$(SED)	-e "s/_HARDENED_/$(if $(VBOX_WITH_HARDENED),hardened,)/" \
  		--output $(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/vboxconfig.sh \
-@@ -615,9 +612,6 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
+@@ -612,9 +609,6 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
  	$(if-expr defined(VBOX_WITH_QTGUI) \
  	,$(NLTAB)$(LN_SYMLINK) ../rdesktop-vrdp-keymaps/ $(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/$(VBOX_SI_ARCH)/rdesktop-vrdp-keymaps,)
  
@@ -41,7 +41,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  	$(if-expr !defined(VBOX_OSE) && defined(VBOX_WITH_VBOXSDL) \
  	,$(INSTALL) -s -m 0644 $(PATH_DEVTOOLS_TRG)/libsdl/v1.2.13/lib/libSDL-1.2.so.0.11.2 \
  		$(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/$(VBOX_SI_ARCH)/libSDL-1.2.so.0,)
-@@ -673,6 +667,7 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
+@@ -670,6 +664,7 @@ $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).
  		$(VBOX_PATH_SOL_INST_SRC)/vbox.pkginfo
  	$(INSTALL) -m 0644 $(VBOX_PATH_SOL_INST_SRC)/vbox.pkgresponse	$(VBOX_PATH_SI_SCRATCH_PKG)/autoresponse
  

--- a/build/virtualbox/patches/stackclash.patch
+++ b/build/virtualbox/patches/stackclash.patch
@@ -7,7 +7,7 @@ typedef int (*segcreate_func_t)(struct seg **, void *);
 diff -wpruN '--exclude=*.orig' a~/src/VBox/Runtime/r0drv/solaris/memobj-r0drv-solaris.h a/src/VBox/Runtime/r0drv/solaris/memobj-r0drv-solaris.h
 --- a~/src/VBox/Runtime/r0drv/solaris/memobj-r0drv-solaris.h	1970-01-01 00:00:00
 +++ a/src/VBox/Runtime/r0drv/solaris/memobj-r0drv-solaris.h	1970-01-01 00:00:00
-@@ -56,8 +56,9 @@ static struct seg_ops s_SegVBoxOps;
+@@ -58,8 +58,9 @@ static struct seg_ops s_SegVBoxOps;
  static vnode_t s_segVBoxVnode;
  
  


### PR DESCRIPTION
```
theeo% ctfdump -c /platform/i86pc/kernel/drv/amd64/vboxdrv
ctfdump: failed to open file /platform/i86pc/kernel/drv/amd64/vboxdrv: File does not contain CTF data
```
```
theeo% pfexec pkg apply-hot-fix https://hf.omnios.org/r151030/vbox6-ctf.p5p
theeo% pfexec init 6
...
theeo% ctfdump -c /platform/i86pc/kernel/drv/amd64/vboxdrv | more
/* Types */

typedef struct { /* 0x2 bytes */
        union  class_u; /* offset: 0 bytes */
} Classification_t;

typedef struct { /* 0x20 bytes */
        uint32_t c1; /* offset: 0 bytes */
        uint32_t c2; /* offset: 4 bytes */
        uint32_t c3; /* offset: 8 bytes */
        uint32_t c4; /* offset: 12 bytes */
        uint32_t c5; /* offset: 16 bytes */
        uint32_t c6; /* offset: 20 bytes */
        uint32_t c7; /* offset: 24 bytes */
        uint32_t c8; /* offset: 28 bytes */
} Compartments_t;
... (etc.)
```