### PR TITLE
Fix protobuf package

### DIFF
--- a/build/protobuf/build.sh
+++ b/build/protobuf/build.sh
@@ -23,11 +23,6 @@ SUMMARY="protobuf"
 DESC="Google's language-neutral, platform-neutral, extensible mechanism "
 DESC+="for serializing structured data"
 
-XFORM_ARGS="
-    -DPREFIX=${PREFIX#/}
-    -DPROG=$PROG
-"
-
 CONFIGURE_OPTS_32+=" --disable-64bit-solaris"
 
 init

--- a/build/protobuf/local.mog
+++ b/build/protobuf/local.mog
@@ -12,13 +12,5 @@
 
 # Copyright 2019 OmniOS Community Edition.  All rights reserved.
 
-# Symlink binaries
-<transform file path=$(PREFIX)/(s?bin)/(.*) -> emit \
-    link path=$(OPREFIX)/%<1>/%<2> target=../$(PROG)/%<1>/%<2> >
-
-# Symlink man
-<transform file path=$(PREFIX)/(share/man/man\d/.*) -> emit \
-    link path=$(OPREFIX)/%<1> target=../../../$(PROG)/%<1> >
-
 license LICENSE license=modified-BSD
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1254,6 +1254,9 @@ make_package() {
         logcmd $PKGFMT -s $P5M_FINAL
     fi
 
+    fgrep -q '$(' $P5M_FINAL \
+        && logerr "------ Manifest contains unresolved variables"
+
     if [ -z "$SKIP_PKGLINT" ] && ( [ -n "$BATCH" ] || ask_to_pkglint ); then
         run_pkglint $PKGSRVR $P5M_FINAL
     fi


### PR DESCRIPTION

Protobuf currently includes a literal `/$(ORIGIN)/` directory:

```
# pkg contents protobuf
PATH
$(OPREFIX)/bin/amd64/protoc
$(OPREFIX)/bin/i386/protoc
$(OPREFIX)/bin/protoc
...
```