### PR TITLE
mariadb-104: various improvements

### DIFF
--- a/build/mariadb/files/README.install
+++ b/build/mariadb/files/README.install
@@ -1,0 +1,20 @@
+
+--------------------------
+MariaDB Installation Notes
+--------------------------
+
+When the mariadb service is started for the first time, an initial
+database will be set up and two all-privilege accounts will be created.
+
+One is root@localhost, it has no password, but you need to
+be system 'root' user to connect. Use, for example, 'sudo mysql'
+
+The second is mysql@localhost, it has no password either, but
+you need to be the system 'mysql' user to connect.
+
+You may wish to review the default configuration file at
+/etc/opt/ooce/mariadb-<version>/my.cnf before starting the service
+for the first time.
+
+--------------------------
+

--- a/build/mariadb/files/mariadb-104
+++ b/build/mariadb/files/mariadb-104
@@ -1,0 +1,71 @@
+#!/sbin/sh
+
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+. /lib/svc/share/smf_include.sh
+
+if [ -z $SMF_FMRI ]; then
+	echo "SMF framework variables are not initialized."
+	exit $SMF_EXIT_ERR_FATAL
+fi
+
+rootdir="`svcprop -p application/root $SMF_FMRI`"
+datadir="`svcprop -p application/datadir $SMF_FMRI`"
+
+if [ -z "$rootdir" ]; then
+	echo "application/rootdir property is not set on this instance"
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+if [ -z "$datadir" ]; then
+	echo "application/datadir property is not set on this instance"
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+if [ ! -d "$datadir" ]; then
+	echo "Data directory $datadir does not exist"
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+if [ ! -w "$datadir" ]; then
+	echo "The $datadir directory is not writeable by `$USER`"
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+create_database() {
+	[ -d "$datadir/mysql" ] && return
+	echo "*** No existing database found, creating now"
+	$rootdir/bin/mysql_install_db \
+	    --datadir="$datadir" \
+	    --auth-root-authentication-method=socket \
+	    --auth-root-socket-user=`id -un`
+}
+
+start_mariadb() {
+	pidfile="$datadir/`uname -n`.pid"
+	echo "Starting mariadb with datadir=$datadir"
+	$rootdir/bin/mysqld_safe --datadir="$datadir" --pid-file="$pidfile" &
+}
+
+case "$1" in
+	start)
+		create_database
+		start_mariadb
+		;;
+	*)
+		echo "Usage $0 {start}"
+		exit $SMF_EXIT_ERR_FATAL
+		;;
+esac
+
+exit $SMF_EXIT_OK
+

--- a/build/mariadb/files/mariadb-104.xml
+++ b/build/mariadb/files/mariadb-104.xml
@@ -1,26 +1,16 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-CDDL HEADER START
+	This file and its contents are supplied under the terms of the
+	Common Development and Distribution License ("CDDL"), version 1.0.
+	You may only use this file in accordance with the terms of version
+	1.0 of the CDDL.
 
-The contents of this file are subject to the terms of the
-Common Development and Distribution License (the "License").
-You may not use this file except in compliance with the License.
+	A full copy of the text of the CDDL should have accompanied this
+	source. A copy of the CDDL is also available via the Internet at
+	http://www.illumos.org/license/CDDL.
 
-You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-or http://www.opensolaris.org/os/licensing.
-See the License for the specific language governing permissions
-and limitations under the License.
-
-When distributing Covered Code, include this CDDL HEADER in each
-file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-If applicable, add the following below this CDDL HEADER, with the
-fields enclosed by brackets "[]" replaced with your own identifying
-information: Portions Copyright [yyyy] [name of copyright owner]
-
-CDDL HEADER END
-
-Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+	Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 -->
 
 <service_bundle type='manifest' name='mariadb104'>
@@ -47,7 +37,7 @@ Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
         </dependent>
 
         <exec_method type='method' name='start' timeout_seconds='120'
-            exec='/opt/ooce/mariadb-10.4/bin/mysqld_safe --datadir="%{datadir}" &amp;'>
+            exec='/lib/svc/method/mariadb-104 %m'>
             <method_context security_flags='aslr'>
                 <method_credential user='mysql' group='mysql' />
             </method_context>
@@ -66,7 +56,9 @@ Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
         <instance name='default' enabled='false'>
             <property_group name='application' type='application'>
                 <propval name='datadir' type='astring'
-		    value='/var/opt/ooce/mariadb-10.4/data'/>
+		    value='/var/opt/ooce/mariadb-10.4/data' />
+		<propval name='root' type='astring'
+		    value='/opt/ooce/mariadb-10.4' />
             </property_group>
         </instance>
 

--- a/build/mariadb/patches-104/04-dtrace.patch
+++ b/build/mariadb/patches-104/04-dtrace.patch
@@ -1,0 +1,65 @@
+diff -wpruN '--exclude=*.orig' a~/cmake/plugin.cmake a/cmake/plugin.cmake
+--- a~/cmake/plugin.cmake	1970-01-01 00:00:00
++++ a/cmake/plugin.cmake	1970-01-01 00:00:00
+@@ -137,7 +137,7 @@ MACRO(MYSQL_ADD_PLUGIN)
+     ENDIF()
+ 
+     ADD_LIBRARY(${target} STATIC ${SOURCES})
+-    DTRACE_INSTRUMENT(${target})
++    #DTRACE_INSTRUMENT(${target})
+     ADD_DEPENDENCIES(${target} GenError ${ARG_DEPENDENCIES})
+     RESTRICT_SYMBOL_EXPORTS(${target})
+     IF(WITH_EMBEDDED_SERVER)
+@@ -147,7 +147,7 @@ MACRO(MYSQL_ADD_PLUGIN)
+         # Recompile some plugins for embedded
+         ADD_CONVENIENCE_LIBRARY(${target}_embedded ${SOURCES})
+         RESTRICT_SYMBOL_EXPORTS(${target}_embedded)
+-        DTRACE_INSTRUMENT(${target}_embedded)   
++        #DTRACE_INSTRUMENT(${target}_embedded)   
+         IF(ARG_RECOMPILE_FOR_EMBEDDED)
+           SET_TARGET_PROPERTIES(${target}_embedded 
+             PROPERTIES COMPILE_DEFINITIONS "EMBEDDED_LIBRARY")
+@@ -185,7 +185,7 @@ MACRO(MYSQL_ADD_PLUGIN)
+ 
+     ADD_VERSION_INFO(${target} MODULE SOURCES)
+     ADD_LIBRARY(${target} MODULE ${SOURCES}) 
+-    DTRACE_INSTRUMENT(${target})
++    #DTRACE_INSTRUMENT(${target})
+ 
+     SET_TARGET_PROPERTIES (${target} PROPERTIES PREFIX "")
+     IF (NOT ARG_CLIENT)
+diff -wpruN '--exclude=*.orig' a~/extra/mariabackup/CMakeLists.txt a/extra/mariabackup/CMakeLists.txt
+--- a~/extra/mariabackup/CMakeLists.txt	1970-01-01 00:00:00
++++ a/extra/mariabackup/CMakeLists.txt	1970-01-01 00:00:00
+@@ -80,6 +80,8 @@ MYSQL_ADD_EXECUTABLE(mariabackup
+   COMPONENT backup
+   )
+ 
++DTRACE_INSTRUMENT(mariabackup)
++
+ 
+ # Export all symbols on Unix, for better crash callstacks
+ SET_TARGET_PROPERTIES(mariabackup PROPERTIES ENABLE_EXPORTS TRUE)
+diff -wpruN '--exclude=*.orig' a~/mysys_ssl/CMakeLists.txt a/mysys_ssl/CMakeLists.txt
+--- a~/mysys_ssl/CMakeLists.txt	1970-01-01 00:00:00
++++ a/mysys_ssl/CMakeLists.txt	1970-01-01 00:00:00
+@@ -46,4 +46,4 @@ ENDIF()
+ 
+ ADD_CONVENIENCE_LIBRARY(mysys_ssl ${MYSYS_SSL_SOURCES})
+ TARGET_LINK_LIBRARIES(mysys_ssl dbug strings ${SSL_LIBRARIES})
+-DTRACE_INSTRUMENT(mysys_ssl)
++#DTRACE_INSTRUMENT(mysys_ssl)
+diff -wpruN '--exclude=*.orig' a~/storage/csv/CMakeLists.txt a/storage/csv/CMakeLists.txt
+--- a~/storage/csv/CMakeLists.txt	1970-01-01 00:00:00
++++ a/storage/csv/CMakeLists.txt	1970-01-01 00:00:00
+@@ -15,3 +15,10 @@
+ 
+ SET(CSV_SOURCES  ha_tina.cc ha_tina.h transparent_file.cc transparent_file.h)
+ MYSQL_ADD_PLUGIN(csv ${CSV_SOURCES} STORAGE_ENGINE MANDATORY)
++DTRACE_INSTRUMENT(csv)
++IF(WITH_EMBEDDED_SERVER)
++  IF(ARG_RECOMPILE_FOR_EMBEDDED OR NOT _SKIP_PIC)
++    DTRACE_INSTRUMENT(csv_embedded)
++  ENDIF()
++ENDIF()
++

--- a/build/mariadb/patches-104/05-no-pie.patch
+++ b/build/mariadb/patches-104/05-no-pie.patch
@@ -1,0 +1,14 @@
+diff -wpruN '--exclude=*.orig' a~/CMakeLists.txt a/CMakeLists.txt
+--- a~/CMakeLists.txt	1970-01-01 00:00:00
++++ a/CMakeLists.txt	1970-01-01 00:00:00
+@@ -235,8 +235,8 @@ ENDIF()
+ OPTION(SECURITY_HARDENED "Use security-enhancing compiler features (stack protector, relro, etc)" ON)
+ IF(SECURITY_HARDENED AND NOT WITH_ASAN AND NOT WITH_UBSAN AND NOT WITH_TSAN)
+   # security-enhancing flags
+-  MY_CHECK_AND_SET_COMPILER_FLAG("-pie -fPIC")
+-  MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,relro,-z,now")
++  MY_CHECK_AND_SET_COMPILER_FLAG("-fPIC")
++  MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,now")
+   MY_CHECK_AND_SET_COMPILER_FLAG("-fstack-protector --param=ssp-buffer-size=4")
+   MY_CHECK_AND_SET_COMPILER_FLAG("-D_FORTIFY_SOURCE=2" RELEASE RELWITHDEBINFO)
+ ENDIF()

--- a/build/mariadb/patches-104/08-dtrace-invalid-conversion.patch
+++ b/build/mariadb/patches-104/08-dtrace-invalid-conversion.patch
@@ -1,0 +1,211 @@
+diff -wpruN '--exclude=*.orig' a~/sql/filesort.cc a/sql/filesort.cc
+--- a~/sql/filesort.cc	1970-01-01 00:00:00
++++ a/sql/filesort.cc	1970-01-01 00:00:00
+@@ -156,7 +156,7 @@ SORT_INFO *filesort(THD *thd, TABLE *tab
+   SORT_INFO *sort;
+   TABLE_LIST *tab= table->pos_in_table_list;
+   Item_subselect *subselect= tab ? tab->containing_subselect() : 0;
+-  MYSQL_FILESORT_START(table->s->db.str, table->s->table_name.str);
++  MYSQL_FILESORT_START((char*)table->s->db.str, (char*)table->s->table_name.str);
+   DEBUG_SYNC(thd, "filesort_start");
+ 
+   if (!(sort= new SORT_INFO))
+diff -wpruN '--exclude=*.orig' a~/sql/handler.cc a/sql/handler.cc
+--- a~/sql/handler.cc	1970-01-01 00:00:00
++++ a/sql/handler.cc	1970-01-01 00:00:00
+@@ -6387,18 +6387,18 @@ int handler::ha_external_lock(THD *thd,
+   {
+     if (lock_type == F_RDLCK)
+     {
+-      MYSQL_HANDLER_RDLOCK_START(table_share->db.str,
+-                                 table_share->table_name.str);
++      MYSQL_HANDLER_RDLOCK_START((char*)table_share->db.str,
++                                 (char*)table_share->table_name.str);
+     }
+     else if (lock_type == F_WRLCK)
+     {
+-      MYSQL_HANDLER_WRLOCK_START(table_share->db.str,
+-                                 table_share->table_name.str);
++      MYSQL_HANDLER_WRLOCK_START((char*)table_share->db.str,
++                                 (char*)table_share->table_name.str);
+     }
+     else if (lock_type == F_UNLCK)
+     {
+-      MYSQL_HANDLER_UNLOCK_START(table_share->db.str,
+-                                 table_share->table_name.str);
++      MYSQL_HANDLER_UNLOCK_START((char*)table_share->db.str,
++                                 (char*)table_share->table_name.str);
+     }
+   }
+ 
+@@ -6659,7 +6659,7 @@ int handler::ha_write_row(const uchar *b
+   DBUG_ENTER("handler::ha_write_row");
+   DEBUG_SYNC_C("ha_write_row_start");
+ 
+-  MYSQL_INSERT_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_INSERT_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   mark_trx_read_write();
+   increment_statistics(&SSV::ha_write_count);
+ 
+@@ -6707,7 +6707,7 @@ int handler::ha_update_row(const uchar *
+   DBUG_ASSERT(new_data == table->record[0]);
+   DBUG_ASSERT(old_data == table->record[1]);
+ 
+-  MYSQL_UPDATE_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_UPDATE_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   mark_trx_read_write();
+   increment_statistics(&SSV::ha_update_count);
+   if (table->s->long_unique_table &&
+@@ -6775,7 +6775,7 @@ int handler::ha_delete_row(const uchar *
+   DBUG_ASSERT(buf == table->record[0] ||
+               buf == table->record[1]);
+ 
+-  MYSQL_DELETE_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_DELETE_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   mark_trx_read_write();
+   increment_statistics(&SSV::ha_delete_count);
+ 
+@@ -6816,7 +6816,7 @@ int handler::ha_direct_update_rows(ha_ro
+ {
+   int error;
+ 
+-  MYSQL_UPDATE_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_UPDATE_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   mark_trx_read_write();
+ 
+   error = direct_update_rows(update_rows, found_rows);
+@@ -6843,7 +6843,7 @@ int handler::ha_direct_delete_rows(ha_ro
+   /* Ensure we are not using binlog row */
+   DBUG_ASSERT(!table->in_use->is_current_stmt_binlog_format_row());
+ 
+-  MYSQL_DELETE_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_DELETE_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   mark_trx_read_write();
+ 
+   error = direct_delete_rows(delete_rows);
+diff -wpruN '--exclude=*.orig' a~/sql/sp_head.cc a/sql/sp_head.cc
+--- a~/sql/sp_head.cc	1970-01-01 00:00:00
++++ a/sql/sp_head.cc	1970-01-01 00:00:00
+@@ -3659,7 +3659,7 @@ sp_instr_stmt::exec_core(THD *thd, uint
+ {
+   MYSQL_QUERY_EXEC_START(thd->query(),
+                          thd->thread_id,
+-                         thd->get_db(),
++                         (char*)thd->get_db(),
+                          &thd->security_ctx->priv_user[0],
+                          (char *)thd->security_ctx->host_or_ip,
+                          3);
+diff -wpruN '--exclude=*.orig' a~/sql/sql_class.h a/sql/sql_class.h
+--- a~/sql/sql_class.h	1970-01-01 00:00:00
++++ a/sql/sql_class.h	1970-01-01 00:00:00
+@@ -6594,7 +6594,7 @@ inline int handler::ha_read_first_row(uc
+ inline int handler::ha_write_tmp_row(uchar *buf)
+ {
+   int error;
+-  MYSQL_INSERT_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_INSERT_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   increment_statistics(&SSV::ha_tmp_write_count);
+   TABLE_IO_WAIT(tracker, m_psi, PSI_TABLE_WRITE_ROW, MAX_KEY, 0,
+                 { error= write_row(buf); })
+@@ -6605,7 +6605,7 @@ inline int handler::ha_write_tmp_row(uch
+ inline int handler::ha_delete_tmp_row(uchar *buf)
+ {
+   int error;
+-  MYSQL_DELETE_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_DELETE_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   increment_statistics(&SSV::ha_tmp_delete_count);
+   TABLE_IO_WAIT(tracker, m_psi, PSI_TABLE_DELETE_ROW, MAX_KEY, 0,
+                 { error= delete_row(buf); })
+@@ -6616,7 +6616,7 @@ inline int handler::ha_delete_tmp_row(uc
+ inline int handler::ha_update_tmp_row(const uchar *old_data, uchar *new_data)
+ {
+   int error;
+-  MYSQL_UPDATE_ROW_START(table_share->db.str, table_share->table_name.str);
++  MYSQL_UPDATE_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str);
+   increment_statistics(&SSV::ha_tmp_update_count);
+   TABLE_IO_WAIT(tracker, m_psi, PSI_TABLE_UPDATE_ROW, active_index, 0,
+                 { error= update_row(old_data, new_data);})
+diff -wpruN '--exclude=*.orig' a~/sql/sql_cursor.cc a/sql/sql_cursor.cc
+--- a~/sql/sql_cursor.cc	1970-01-01 00:00:00
++++ a/sql/sql_cursor.cc	1970-01-01 00:00:00
+@@ -137,7 +137,7 @@ int mysql_open_cursor(THD *thd, select_r
+ 
+   MYSQL_QUERY_EXEC_START(thd->query(),
+                          thd->thread_id,
+-                         thd->get_db(),
++                         (char*)thd->get_db(),
+                          &thd->security_ctx->priv_user[0],
+                          (char *) thd->security_ctx->host_or_ip,
+                          2);
+diff -wpruN '--exclude=*.orig' a~/sql/sql_parse.cc a/sql/sql_parse.cc
+--- a~/sql/sql_parse.cc	1970-01-01 00:00:00
++++ a/sql/sql_parse.cc	1970-01-01 00:00:00
+@@ -1805,7 +1805,7 @@ bool dispatch_command(enum enum_server_c
+     if (unlikely(alloc_query(thd, packet, packet_length)))
+       break;					// fatal error is set
+     MYSQL_QUERY_START(thd->query(), thd->thread_id,
+-                      thd->get_db(),
++                      (char*)thd->get_db(),
+                       &thd->security_ctx->priv_user[0],
+                       (char *) thd->security_ctx->host_or_ip);
+     char *packet_end= thd->query() + thd->query_length();
+@@ -1896,7 +1896,7 @@ bool dispatch_command(enum enum_server_c
+ 
+       /* DTRACE begin */
+       MYSQL_QUERY_START(beginning_of_next_stmt, thd->thread_id,
+-                        thd->get_db(),
++                        (char*)thd->get_db(),
+                         &thd->security_ctx->priv_user[0],
+                         (char *) thd->security_ctx->host_or_ip);
+ 
+@@ -7675,7 +7675,7 @@ static void wsrep_prepare_for_autocommit
+ 
+   /* DTRACE begin */
+   MYSQL_QUERY_START(rawbuf, thd->thread_id,
+-                    thd->get_db(),
++                    (char *)thd->get_db(),
+                     &thd->security_ctx->priv_user[0],
+                     (char *) thd->security_ctx->host_or_ip);
+ 
+@@ -7893,7 +7893,7 @@ void mysql_parse(THD *thd, char *rawbuf,
+           lex->set_trg_event_type_for_tables();
+           MYSQL_QUERY_EXEC_START(thd->query(),
+                                  thd->thread_id,
+-                                 thd->get_db(),
++                                 (char*)thd->get_db(),
+                                  &thd->security_ctx->priv_user[0],
+                                  (char *) thd->security_ctx->host_or_ip,
+                                  0);
+diff -wpruN '--exclude=*.orig' a~/sql/sql_prepare.cc a/sql/sql_prepare.cc
+--- a~/sql/sql_prepare.cc	1970-01-01 00:00:00
++++ a/sql/sql_prepare.cc	1970-01-01 00:00:00
+@@ -4751,7 +4751,7 @@ bool Prepared_statement::execute(String
+       PSI_statement_locker *parent_locker;
+       MYSQL_QUERY_EXEC_START(thd->query(),
+                              thd->thread_id,
+-                             thd->get_db(),
++                             (char*)thd->get_db(),
+                              &thd->security_ctx->priv_user[0],
+                              (char *) thd->security_ctx->host_or_ip,
+                              1);
+diff -wpruN '--exclude=*.orig' a~/storage/csv/ha_tina.cc a/storage/csv/ha_tina.cc
+--- a~/storage/csv/ha_tina.cc	1970-01-01 00:00:00
++++ a/storage/csv/ha_tina.cc	1970-01-01 00:00:00
+@@ -1226,7 +1226,7 @@ int ha_tina::rnd_next(uchar *buf)
+ {
+   int rc;
+   DBUG_ENTER("ha_tina::rnd_next");
+-  MYSQL_READ_ROW_START(table_share->db.str, table_share->table_name.str,
++  MYSQL_READ_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str,
+                        TRUE);
+ 
+   if (share->crashed)
+@@ -1281,7 +1281,7 @@ int ha_tina::rnd_pos(uchar * buf, uchar
+ {
+   int rc;
+   DBUG_ENTER("ha_tina::rnd_pos");
+-  MYSQL_READ_ROW_START(table_share->db.str, table_share->table_name.str,
++  MYSQL_READ_ROW_START((char*)table_share->db.str, (char*)table_share->table_name.str,
+                        FALSE);
+   current_position= my_get_ptr(pos,ref_length);
+   rc= find_current_row(buf);

--- a/build/mariadb/patches-104/auth_socket.diff
+++ b/build/mariadb/patches-104/auth_socket.diff
@@ -1,0 +1,101 @@
+Submitted upstream at https://github.com/MariaDB/server/pull/1434
+
+diff --git a/plugin/auth_socket/CMakeLists.txt b/plugin/auth_socket/CMakeLists.txt
+index 5a59520a..5941cf07 100644
+--- a/plugin/auth_socket/CMakeLists.txt
++++ b/plugin/auth_socket/CMakeLists.txt
+@@ -57,12 +57,39 @@ IF (HAVE_XUCRED)
+   SET(ok 1)
+ ELSE()
+ 
++# illumos, is that you?
++CHECK_CXX_SOURCE_COMPILES(
++"#include <ucred.h>
++int main() {
++  ucred_t *cred = NULL;
++  getpeerucred(0, &cred);
++  }" HAVE_GETPEERUCRED)
++
++# Depending on the flags set in the compilation environment, illumos will have
++# either the POSIX.1c draft 6 or POSIX.1c final implementation of getpwuid_r()
++# Check that defining _POSIX_PTHREAD_SEMANTICS provides the final standard
++# version.
++
++CHECK_CXX_SOURCE_COMPILES(
++"#define _POSIX_PTHREAD_SEMANTICS
++#include <pwd.h>
++int main() {
++  getpwuid_r(0, NULL, NULL, 0, NULL);
++  }" HAVE_GETPWUID_POSIX_FINAL)
++
++IF (HAVE_GETPEERUCRED AND HAVE_GETPWUID_POSIX_FINAL)
++  ADD_DEFINITIONS(-DHAVE_GETPEERUCRED)
++  ADD_DEFINITIONS(-D_POSIX_PTHREAD_SEMANTICS)
++  SET(ok 1)
++ELSE()
++
+ # Who else? Anyone?
+ # C'mon, show your creativity, be different! ifdef's are fun, aren't they?
+ 
+ ENDIF()
+ ENDIF()
+ ENDIF()
++ENDIF()
+ 
+ IF(ok)
+   MYSQL_ADD_PLUGIN(auth_socket auth_socket.c DEFAULT)
+diff --git a/plugin/auth_socket/auth_socket.c b/plugin/auth_socket/auth_socket.c
+index 46eae517..b10679a5 100644
+--- a/plugin/auth_socket/auth_socket.c
++++ b/plugin/auth_socket/auth_socket.c
+@@ -47,6 +47,9 @@
+ #define uid cr_uid
+ #define ucred xucred
+ 
++#elif defined HAVE_GETPEERUCRED
++#include <ucred.h>
++
+ #else
+ #error impossible
+ #endif
+@@ -64,10 +67,15 @@ static int socket_auth(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
+ {
+   unsigned char *pkt;
+   MYSQL_PLUGIN_VIO_INFO vio_info;
++#ifdef HAVE_GETPEERUCRED
++  ucred_t *cred = NULL;
++#else
+   struct ucred cred;
+   socklen_t cred_len= sizeof(cred);
++#endif
+   struct passwd pwd_buf, *pwd;
+   char buf[1024];
++  uid_t u;
+ 
+   /* no user name yet ? read the client handshake packet with the user name */
+   if (info->user_name == 0)
+@@ -83,14 +91,23 @@ static int socket_auth(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
+     return CR_ERROR;
+ 
+   /* get the UID of the client process */
++#ifdef HAVE_GETPEERUCRED
++  if (getpeerucred(vio_info.socket, &cred) != 0)
++    return CR_ERROR;
++  u = ucred_geteuid(cred);
++  ucred_free(cred);
++#else
+   if (getsockopt(vio_info.socket, level, SO_PEERCRED, &cred, &cred_len))
+     return CR_ERROR;
+ 
+   if (cred_len != sizeof(cred))
+     return CR_ERROR;
+ 
++  u = cred.uid;
++#endif
++
+   /* and find the username for this uid */
+-  getpwuid_r(cred.uid, &pwd_buf, buf, sizeof(buf), &pwd);
++  getpwuid_r(u, &pwd_buf, buf, sizeof(buf), &pwd);
+   if (pwd == NULL)
+     return CR_ERROR;
+ 

--- a/build/mariadb/patches-104/series
+++ b/build/mariadb/patches-104/series
@@ -1,2 +1,6 @@
 reorder_includes.patch
 si_kernel.patch
+04-dtrace.patch
+05-no-pie.patch
+08-dtrace-invalid-conversion.patch
+auth_socket.diff

--- a/build/mariadb/patches-104/si_kernel.patch
+++ b/build/mariadb/patches-104/si_kernel.patch
@@ -4,7 +4,7 @@ https://github.com/omniosorg/illumos-omnios/blob/master/usr/src/uts/common/sys/s
 diff -wpruN '--exclude=*.orig' a~/sql/mysqld.cc a/sql/mysqld.cc
 --- a~/sql/mysqld.cc	1970-01-01 00:00:00
 +++ a/sql/mysqld.cc	1970-01-01 00:00:00
-@@ -3286,7 +3286,7 @@ pthread_handler_t signal_hand(void *arg
+@@ -3282,7 +3282,7 @@ pthread_handler_t signal_hand(void *arg
        }
        break;
      case SIGHUP:

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -117,6 +117,7 @@ ARCHIVE_TYPES="tar.xz tar.bz2 tar.gz tgz tar zip"
 
 # Default prefix for packages (may be overridden)
 PREFIX=/opt/ooce
+NOTES_LOCATION=$PREFIX/share/doc/release-notes
 
 # Temporary directories
 # TMPDIR is used for source archives and build directories


### PR DESCRIPTION
Automatically create an initial database on first start.
Fix and enable UNIX socket authentication.
Enable dtrace support.
Use system zlib (previously the bundled version was used)
Move items from scripts/ to bin/
Show release notes during installation

See https://omnios.org/article/mariadb