### PR TITLE
Provide Vagrant for OmniOSce

### DIFF
--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -31,6 +31,7 @@ depend fmri=ooce/library/tiff type=require
 depend fmri=ooce/library/slang type=require
 depend fmri=ooce/multimedia/ffmpeg type=require
 depend fmri=ooce/runtime/node-12 type=require
+depend fmri=ooce/runtime/ruby-26 type=require
 depend fmri=system/header/header-agp type=require
 depend fmri=system/header/header-usb type=require
 

--- a/build/vagrant/build.sh
+++ b/build/vagrant/build.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition.  All rights reserved.
+
+. ../../lib/functions.sh
+
+PROG=vagrant
+PKG=ooce/application/vagrant
+VER=2.2.7
+SUMMARY="Vagrant"
+DESC="Build and distribute virtualized development environments"
+
+OPREFIX=$PREFIX
+PREFIX+=/$PROG
+
+set_arch 64
+set_gover 1.14
+set_rubyver 2.6
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DVERSION=$VER
+"
+
+build() {
+    pushd $TMPDIR/$BUILDDIR/$PROG >/dev/null
+
+    logmsg "Building Vagrant"
+    logcmd gem build $PROG.gemspec || logerr "Build Vagrant failed"
+
+    popd >/dev/null
+    pushd $TMPDIR/$BUILDDIR/$PROG-installers/substrate/launcher/ >/dev/null
+    
+    logmsg "Build Vagrant Installers"
+    GOPATH=$TMPDIR/$BUILDDIR/$PROG-installers/substrate/launcher/
+    logcmd go get github.com/kardianos/osext \
+        || logerr "Get dependency for Vagrant Installers failed"
+    logcmd go build -o $PROG || logerr "Build Vagrant Installers failed"
+
+    popd >/dev/null
+}
+
+install() {
+    pushd $TMPDIR/$BUILDDIR/$PROG >/dev/null
+
+    EMBEDDED_DIR=$TMPDIR/$BUILDDIR/$PROG/opt/$PROG/embedded/
+
+    logmsg "Install Vagrant"
+    GEM_PATH="$EMBEDDED_DIR"/gems/$VER \
+    GEM_HOME="$GEM_PATH" \
+    GEMRC="$EMBEDDED_DIR"/etc/gemrc \
+    logcmd gem install $PROG-$VER.gem --no-document || logerr "Install failed"
+
+    logmsg "Create embedded manifest with version number"
+    echo "{ \"vagrant_version\": \"$VER\" }" > $EMBEDDED_DIR/manifest.json
+
+    popd >/dev/null
+    pushd $TMPDIR/$BUILDDIR >/dev/null
+
+    logmsg "Install Vagrant, Installer and all embedded dependencies"
+    logcmd mkdir -p $DESTDIR/$PREFIX/bin
+    logcmd cp $TMPDIR/$BUILDDIR/$PROG-installers/substrate/launcher/$PROG \
+        $DESTDIR/$PREFIX/bin/$PROG || logerr "cp failed"
+    logcmd cp -r $TMPDIR/$BUILDDIR/$PROG/opt/$PROG/embedded \
+        $DESTDIR/$PREFIX || logerr "cp failed"
+
+    popd >/dev/null
+}
+
+init
+clone_github_source $PROG "$GITHUB/hashicorp/$PROG" v$VER
+clone_github_source $PROG-installers \
+    "$GITHUB/hashicorp/$PROG-installers" v$VER+master
+patch_source
+prep_build
+build
+install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/vagrant/local.mog
+++ b/build/vagrant/local.mog
@@ -1,0 +1,21 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+<transform file path=.*\.py$ -> set pkg.depend.bypass-generate .* >
+<transform file path=.*ssh_tunnel_bug\.rb$ \
+    -> set pkg.depend.bypass-generate .* >
+
+license $(PROG)/LICENSE license=MIT
+
+link path=$(OPREFIX)/bin/$(PROG) target=../$(PROG)/bin/$(PROG)

--- a/build/vagrant/patches/series
+++ b/build/vagrant/patches/series
@@ -1,0 +1,1 @@
+vagrant-installers-main-go.patch

--- a/build/vagrant/patches/vagrant-installers-main-go.patch
+++ b/build/vagrant/patches/vagrant-installers-main-go.patch
@@ -1,0 +1,12 @@
+diff -wpruN '--exclude=*.orig' a~/vagrant-installers/substrate/launcher/main.go a/vagrant-installers/substrate/launcher/main.go
+--- a~/vagrant-installers/substrate/launcher/main.go	1970-01-01 00:00:00
++++ a/vagrant-installers/substrate/launcher/main.go	1970-01-01 00:00:00
+@@ -14,7 +14,7 @@ import (
+ 	"strings"
+ 	"syscall"
+ 
+-	"github.com/mitchellh/osext"
++	"github.com/kardianos/osext"
+ )
+ 
+ const envPrefix = "VAGRANT_OLD_ENV"

--- a/doc/baseline
+++ b/doc/baseline
@@ -9,6 +9,7 @@ extra.omnios ooce/application/php-74
 extra.omnios ooce/application/php-common
 extra.omnios ooce/application/texlive
 extra.omnios ooce/application/tidy
+extra.omnios ooce/application/vagrant
 extra.omnios ooce/audio/flac
 extra.omnios ooce/compress/lz4
 extra.omnios ooce/compress/pbzip2

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -10,6 +10,7 @@
 | ooce/application/php-74	| 7.4.4		| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/texlive	| 20190410	| ftp://tug.org/historic/systems/texlive/2019/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tidy		| 5.6.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/application/vagrant	| 2.2.7		| https://github.com/hashicorp/vagrant/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.3.3		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/lz4		| 1.9.2		| https://github.com/lz4/lz4/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -406,6 +406,8 @@ set_gover() {
     # go binaries contain BMI instructions even when built on an older CPU
     BMI_EXPECTED=1
     export PATH GOROOT_BOOTSTRAP
+
+    BUILD_DEPENDS_IPS+=" ooce/developer/go-${GOVER//./}"
 }
 
 #############################################################################
@@ -418,6 +420,22 @@ set_nodever() {
     NODDEPATH="/opt/ooce/node-$NODEVER"
     PATH="$NODEPATH/bin:$PATH"
     export PATH
+
+    BUILD_DEPENDS_IPS+=" ooce/runtime/node-$NODEVER"
+}
+
+#############################################################################
+# Ruby version
+#############################################################################
+
+set_rubyver() {
+    RUBYVER="$1"
+    logmsg "-- Setting Ruby version to $RUBYVER"
+    RUBYPATH="/opt/ooce/ruby-$RUBYVER"
+    PATH="$RUBYPATH/bin:$PATH"
+    export PATH
+
+    BUILD_DEPENDS_IPS+=" ooce/runtime/ruby-${RUBYVER//./}"
 }
 
 #############################################################################


### PR DESCRIPTION
Build and distribute virtualized development environments

Initial version of Vagrant for OmniOSce. Mostly based on the same setup
used on Arch Linux with embedded gems and the go based vagrant binary
wrapper.