### PR TITLE
add tree-1.8.0 build files

### DIFF
--- a/build/tree/build.sh
+++ b/build/tree/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition.  All rights reserved.
+
+. ../../lib/functions.sh
+
+PROG=tree
+VER=1.8.0
+PKG=ooce/file/tree
+SUMMARY="File system tree viewer"
+DESC="The tree utility recursively displays the contents of \
+directories in a tree-like format"
+
+set_arch 64
+
+# No configure
+configure64() { :; }
+
+MAKE_ARGS_WS="
+    -e
+    CFLAGS=\"$CFLAGS $CFLAGS64\"
+    LDFLAGS=\"$LDFLAGS $LDFLAGS64\"
+"
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+MAKE_INSTALL_ARGS="prefix=$DESTDIR/$PREFIX" build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/tree/local.mog
+++ b/build/tree/local.mog
@@ -1,0 +1,16 @@
+# {{{ CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition. All rights reserved.
+
+license LICENSE license=GPLv2
+

--- a/build/tree/patches/Makefile.patch
+++ b/build/tree/patches/Makefile.patch
@@ -1,0 +1,14 @@
+diff -wpruN '--exclude=*.orig' a~/Makefile a/Makefile
+--- a~/Makefile	1970-01-01 00:00:00
++++ a/Makefile	1970-01-01 00:00:00
+@@ -50,8 +50,8 @@ CFLAGS=-ggdb -pedantic -Wall -DLINUX -D_
+ #CC=cc
+ #CFLAGS=-xO0 -v
+ #LDFLAGS=
+-#OBJS+=strverscmp.o
+-#MANDIR=${prefix}/share/man/man1
++OBJS+=strverscmp.o
++MANDIR=${prefix}/share/man/man1
+ 
+ # Uncomment for Cygwin:
+ #CFLAGS=-O2 -Wall -fomit-frame-pointer -DCYGWIN

--- a/build/tree/patches/series
+++ b/build/tree/patches/series
@@ -1,0 +1,1 @@
+Makefile.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -48,6 +48,7 @@ extra.omnios ooce/editor/joe
 extra.omnios ooce/editor/nano
 extra.omnios ooce/extra-build-tools
 extra.omnios ooce/file/lsof
+extra.omnios ooce/file/tree
 extra.omnios ooce/kvmadm
 extra.omnios ooce/library/bdw-gc
 extra.omnios ooce/library/cairo

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -45,6 +45,7 @@
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 4.9.2		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
 | ooce/file/lsof		| 4.93.2	| https://github.com/lsof-org/lsof/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/file/tree		| 1.8.0		| http://mama.indstate.edu/users/ice/tree/ | [omniosorg](https://github.com/omniosorg)
 | ooce/kvmadm			| 0.12.3	| https://github.com/hadfl/kvmadm/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/library/bdw-gc		| 8.0.4		| https://www.hboehm.info/gc/gc_source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/cairo		| 1.16.0	| https://cairographics.org/releases/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Tree is a recursive directory listing command that produces a depth indented listing of files, which is colorized ala dircolors if the LS_COLORS environment variable is set and output is to tty. 
Tree has been ported and reported to work under the following operating systems: Linux, FreeBSD, OS X, Solaris, HP/UX, Cygwin, HP Nonstop and OS/2.  And if all this looks good, now for OmniOSce.