### PR TITLE
add nagios-4.4.5 build files

### DIFF
--- a/build/nagios/build.sh
+++ b/build/nagios/build.sh
@@ -47,7 +47,7 @@ MAKE_INSTALL_ARGS="
 
 MAKE_INSTALL_TARGET="
     install
-    install-commandmode 
+    install-commandmode
     install-config
 "
 
@@ -57,7 +57,7 @@ XFORM_ARGS="
     -DPROG=$PROG
 "
 
-CONFIGURE_OPTS_64=" 
+CONFIGURE_OPTS_64="
     --prefix=$PREFIX
     --sysconfdir=/etc$PREFIX
     --localstatedir=/var$PREFIX
@@ -70,6 +70,7 @@ patch_source
 prep_build
 build
 strip_install
+add_notes README.install
 install_smf application $PROG.xml application-$PROG
 make_package
 clean_up

--- a/build/nagios/build.sh
+++ b/build/nagios/build.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition.  All rights reserved.
+
+. ../../lib/functions.sh
+
+PROG=nagios
+VER=4.4.5
+PKG=ooce/application/nagios
+SUMMARY="Extremely powerful network monitoring system"
+DESC="Nagios is a host and service monitor designed to inform you of network \
+problems before your clients, end-users or managers do. It has been \
+designed to run under the Linux operating system, but works fine under \
+most *NIX variants as well. The monitoring daemon runs intermittent \
+checks on hosts and services you specify using external plugins \
+which return status information to Nagios. When problems are \
+encountered, the daemon can send notifications out to administrative \
+contacts in a variety of different ways (email, instant message, SMS, \
+etc.). Current status information, historical logs, and reports can \
+all be accessed via a web browser."
+
+set_arch 64
+
+OPREFIX=$PREFIX
+PREFIX+=/$PROG
+
+MAKE_ARGS="
+    all
+"
+
+MAKE_INSTALL_ARGS="
+    COMMAND_OPTS=
+    INSTALL_OPTS=
+"
+
+MAKE_INSTALL_TARGET="
+    install
+    install-commandmode 
+    install-config
+"
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+"
+
+CONFIGURE_OPTS_64=" 
+    --prefix=$PREFIX
+    --sysconfdir=/etc$PREFIX
+    --localstatedir=/var$PREFIX
+    --with-lockfile=/var$PREFIX/run/nagios.lock
+"
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+strip_install
+install_smf application $PROG.xml application-$PROG
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/nagios/files/README.install
+++ b/build/nagios/files/README.install
@@ -1,0 +1,10 @@
+
+--------------------------
+Nagios Installation Notes
+--------------------------
+
+For instructions on how to configure and integrate Nagios with the system,
+please read /opt/ooce/nagios/share/README.md
+
+--------------------------
+

--- a/build/nagios/files/README.md
+++ b/build/nagios/files/README.md
@@ -1,0 +1,37 @@
+Nagios 4.x
+==========
+
+Nagios is a host/service/network monitoring program written in C and released under the GNU General Public License, version 2. CGI programs are included to allow you to view the current status, history, etc via a web interface if you so desire.
+
+Visit the Nagios homepage at https://www.nagios.org for documentation, new releases, bug reports, information on discussion forums, and more.
+
+Nagios Installation on OmniOS
+-----------------------------
+
+#### Install and Configure
+
+    pkg install fcgiwrap nagios nagios-plugins nginx php-74
+    usermod -G fcgiwrap nginx
+    usermod -G nagcmd fcgiwrap
+    cp nagios-nginx-example.conf /etc/opt/ooce/nginx/nginx.conf
+
+#### Setup htpasswd Authorization
+
+As the Apache *httpasswd* program is not available, it is possible to create the *htpasswd* file as follows:
+
+    echo -e "nagiosadmin:`perl -le 'print crypt("your_password","salt")'`" > /opt/ooce/nginx/htpasswd.users
+
+#### Start Nagios
+
+    svcadm enable php74
+    svcadm enable fcgiwrap
+    svcadm enable nginx
+    svcadm enable nagios
+
+Testing the Installation
+------------------------
+
+You can now monitor Nagios by accessing the Web Interface:
+
+    http://nagios.$hostname
+

--- a/build/nagios/files/application-nagios
+++ b/build/nagios/files/application-nagios
@@ -3,7 +3,7 @@
 # Author : Jorge Sanchez Aymar (jsanchez@lanchile.cl)
 #
 # Original file : https://github.com/NagiosEnterprises/nagioscore/blob/master/startup/default-init.in
-# 
+#
 # Changelog :
 #
 # 1999-07-09 Karl DeBisschop <kdebisschop@infoplease.com>
@@ -28,6 +28,8 @@
 #              used to provide network services status.
 #
 
+. /lib/svc/share/smf_include.sh
+
 # Our install-time configuration.
 NagiosBin=/opt/ooce/nagios/bin/nagios
 NagiosCfgFile=/etc/opt/ooce/nagios/nagios.cfg
@@ -51,7 +53,7 @@ check_config ()
 	rm -f "$NagiosCfgtestFile";
 	if ! touch $NagiosCfgtestFile; then
 		echo "ERROR: Could not create or update '$NagiosCfgtestFile'"
-		exit 8
+		exit $SMF_EXIT_ERR_CONFIG
 	fi
 
 	TMPFILE=$(mktemp /tmp/.configtest.XXXXXXXX)
@@ -74,7 +76,7 @@ check_config ()
 		echo "ERROR: Errors in config files - see log for details: $NagiosCfgtestFile" > $NagiosCfgtestFile
 		egrep -i "(^warning|^error)" "$TMPFILE" >> $NagiosCfgtestFile
 		cat "$TMPFILE"
-		exit 8
+		exit $SMF_EXIT_ERR_CONFIG
 	fi
 }
 
@@ -86,7 +88,7 @@ status_nagios ()
 			return 0
 		fi
 	else
-		if ps -p $NagiosPID > /dev/null 2>&1; then 
+		if [ "`ps -o comm= -p $NagiosPID`" = "$NagiosBin" ]; then
 			return 0
 		fi
 	fi
@@ -121,7 +123,7 @@ case "$1" in
 			NagiosPID=`head -n 1 $NagiosRunFile`
 			if status_nagios; then
 				echo "another instance of nagios is already running."
-				exit 0
+				exit $SMF_EXIT_ERR_FATAL
 			fi
 		fi
 
@@ -138,7 +140,7 @@ case "$1" in
 
 		pid_nagios
 		if [ $? -eq 1 ]; then
-			exit 0
+			exit $SMF_EXIT_OK
 		fi
 		killproc_nagios TERM
 
@@ -147,7 +149,7 @@ case "$1" in
 		# happen, and then the exiting nagios will remove the
 		# new NagiosRunFile, allowing multiple nagios daemons
 		# to (sooner or later) run - John Sellens
-		echo "Waiting for nagios to exit" 
+		echo "Waiting for nagios to exit"
 		for i in {1..90}; do
 			if status_nagios > /dev/null; then
 				echo '.'
@@ -173,5 +175,7 @@ case "$1" in
 		;;
 
 esac
+
+exit $SMF_EXIT_OK
 
 # End of this script

--- a/build/nagios/files/application-nagios
+++ b/build/nagios/files/application-nagios
@@ -1,0 +1,177 @@
+#!/bin/sh
+#
+# Author : Jorge Sanchez Aymar (jsanchez@lanchile.cl)
+#
+# Original file : https://github.com/NagiosEnterprises/nagioscore/blob/master/startup/default-init.in
+# 
+# Changelog :
+#
+# 1999-07-09 Karl DeBisschop <kdebisschop@infoplease.com>
+#  - setup for autoconf
+#  - add reload function
+# 1999-08-06 Ethan Galstad <egalstad@nagios.org>
+#  - Added configuration info for use with RedHat's chkconfig tool
+#    per Fran Boon's suggestion
+# 1999-08-13 Jim Popovitch <jimpop@rocketship.com>
+#  - added variable for nagios/var directory
+#  - cd into nagios/var directory before creating tmp files on startup
+# 1999-08-16 Ethan Galstad <egalstad@nagios.org>
+#  - Added test for rc.d directory as suggested by Karl DeBisschop
+# 2000-07-23 Karl DeBisschop <kdebisschop@users.sourceforge.net>
+#  - Clean out redhat macros and other dependencies
+# 2003-01-11 Ethan Galstad <egalstad@nagios.org>
+#  - Updated su syntax (Gary Miller)
+# 2020-04-01 Philip Brown <philip@pbdigital.org>
+#  - Trimmed down for use with SMF manifest file.
+#
+# Description: Starts and stops the Nagios monitor
+#              used to provide network services status.
+#
+
+# Our install-time configuration.
+NagiosBin=/opt/ooce/nagios/bin/nagios
+NagiosCfgFile=/etc/opt/ooce/nagios/nagios.cfg
+NagiosCfgtestFile=/var/opt/ooce/nagios/nagios.configtest
+NagiosStatusFile=/var/opt/ooce/nagios/status.dat
+NagiosRetentionFile=/var/opt/ooce/nagios/retention.dat
+NagiosCommandFile=/var/opt/ooce/nagios/rw/nagios.cmd
+NagiosRunFile=/var/opt/ooce/nagios/run/nagios.lock
+NagiosLogFile=/var/log/opt/ooce/nagios/nagios.log
+NagiosCGIDir=/opt/ooce/nagios/sbin
+checkconfig="true"
+
+check_config ()
+{
+	if test "$checkconfig" != "true"; then
+		return 0
+	fi
+
+	echo "Running configuration check... "
+
+	rm -f "$NagiosCfgtestFile";
+	if ! touch $NagiosCfgtestFile; then
+		echo "ERROR: Could not create or update '$NagiosCfgtestFile'"
+		exit 8
+	fi
+
+	TMPFILE=$(mktemp /tmp/.configtest.XXXXXXXX)
+	$NagiosBin -vp $NagiosCfgFile > "$TMPFILE"
+	WARN=`grep ^"Total Warnings:" "$TMPFILE" |awk -F: '{print \$2}' |sed s/' '//g`
+	ERR=`grep ^"Total Errors:" "$TMPFILE" |awk -F: '{print \$2}' |sed s/' '//g`
+
+	if test "$WARN" = "0" && test "${ERR}" = "0"; then
+		echo "OK - Configuration check verified" > $NagiosCfgtestFile
+		rm "$TMPFILE"
+		return 0
+	elif test "${ERR}" = "0"; then
+		# Write the errors to a file we can have a script watching for.
+		echo "WARNING: Warnings in config files - see log for details: $NagiosCfgtestFile" > $NagiosCfgtestFile
+		egrep -i "(^warning|^error)" "$TMPFILE" >> $NagiosCfgtestFile
+		rm "$TMPFILE"
+		return 0
+	else
+		# Write the errors to a file we can have a script watching for.
+		echo "ERROR: Errors in config files - see log for details: $NagiosCfgtestFile" > $NagiosCfgtestFile
+		egrep -i "(^warning|^error)" "$TMPFILE" >> $NagiosCfgtestFile
+		cat "$TMPFILE"
+		exit 8
+	fi
+}
+
+
+status_nagios ()
+{
+	if test -x $NagiosCGIDir/daemonchk.cgi; then
+		if $NagiosCGIDir/daemonchk.cgi -l $NagiosRunFile > /dev/null 2>&1; then
+			return 0
+		fi
+	else
+		if ps -p $NagiosPID > /dev/null 2>&1; then 
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+killproc_nagios ()
+{
+	kill -s "$1" $NagiosPID
+}
+
+pid_nagios ()
+{
+	if test ! -f $NagiosRunFile; then
+		echo "No lock file found in $NagiosRunFile"
+		return 1
+	fi
+
+	NagiosPID=`head -n 1 $NagiosRunFile`
+}
+
+# See how we were called.
+case "$1" in
+
+	start)
+		echo "Starting nagios: "
+
+		check_config
+
+		if test -f $NagiosRunFile; then
+			NagiosPID=`head -n 1 $NagiosRunFile`
+			if status_nagios; then
+				echo "another instance of nagios is already running."
+				exit 0
+			fi
+		fi
+
+		touch $NagiosLogFile $NagiosRetentionFile
+		rm -f $NagiosCommandFile
+		touch $NagiosRunFile
+		$NagiosBin -d $NagiosCfgFile
+
+		echo "done."
+		;;
+
+	stop)
+		echo "Stopping nagios: "
+
+		pid_nagios
+		if [ $? -eq 1 ]; then
+			exit 0
+		fi
+		killproc_nagios TERM
+
+		# now we have to wait for nagios to exit and remove its
+		# own NagiosRunFile, otherwise a following "start" could
+		# happen, and then the exiting nagios will remove the
+		# new NagiosRunFile, allowing multiple nagios daemons
+		# to (sooner or later) run - John Sellens
+		echo "Waiting for nagios to exit" 
+		for i in {1..90}; do
+			if status_nagios > /dev/null; then
+				echo '.'
+				sleep 1
+			else
+				break
+			fi
+		done
+		if status_nagios > /dev/null; then
+			echo ""
+			echo "Warning - nagios did not exit in a timely manner - Killing it!"
+			killproc_nagios KILL
+		else
+			echo "done."
+		fi
+
+		rm -f $NagiosStatusFile $NagiosRunFile $NagiosCommandFile
+		;;
+
+	*)
+		echo "Usage: nagios {start|stop}"
+		exit 1
+		;;
+
+esac
+
+# End of this script

--- a/build/nagios/files/nagios-nginx-example.conf
+++ b/build/nagios/files/nagios-nginx-example.conf
@@ -1,0 +1,71 @@
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        server_name     nagios.$hostname;
+        root            /opt/ooce/nagios/share;
+        listen          80;
+        index           index.php index.html index.htm;
+        access_log      nagios.access.log;
+        error_log       nagios.error.log;
+    
+        auth_basic            "Nagios Access";
+        auth_basic_user_file  /opt/ooce/nginx/htpasswd.users;
+    
+        # Fixes frames not working
+        add_header X-Frame-Options "ALLOW";
+    
+        location ~ \.php$ {
+            try_files       $uri = 404;
+            fastcgi_index   index.php;
+            fastcgi_pass    unix:/var/opt/ooce/php/run/www-7.4.sock;
+            include         /etc/opt/ooce/nginx/fastcgi.conf;
+        }
+    
+        location ~ \.cgi$ {
+            root            /opt/ooce/nagios/sbin;
+            rewrite         ^/nagios/cgi-bin/(.*)\.cgi /$1.cgi break;
+            rewrite         ^/cgi-bin/(.*)\.cgi /$1.cgi break;
+            fastcgi_param   AUTH_USER $remote_user;
+            fastcgi_param   REMOTE_USER $remote_user;
+            include         /etc/opt/ooce/nginx/fastcgi.conf;
+            fastcgi_pass    unix:/var/opt/ooce/fcgiwrap/run/fcgiwrap.sock;
+        }
+    
+        # Fixes the fact some links are expected to resolve to /nagios, see here.
+        location /nagios {
+            alias /opt/ooce/nagios/share;
+        }
+    
+    }
+}

--- a/build/nagios/files/nagios.xml
+++ b/build/nagios/files/nagios.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+	{{{ CDDL HEADER
+
+	This file and its contents are supplied under the terms of the
+	Common Development and Distribution License ("CDDL"), version 1.0.
+	You may only use this file in accordance with the terms of version
+	1.0 of the CDDL.
+	A full copy of the text of the CDDL should have accompanied this
+	source. A copy of the CDDL is also available via the Internet at
+	http://www.illumos.org/license/CDDL.
+
+	}}}
+
+	Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+-->
+
+<service_bundle type="manifest" name="nagios">
+
+<service 
+        name="ooce/application/nagios" 
+        type="service" 
+        version="1">
+
+        <instance name='default' enabled='false'>
+
+        <dependency 
+                name='network' 
+                grouping='require_all' 
+                restart_on="error" 
+                type="service">
+                <service_fmri value='svc:/milestone/network:default' />
+        </dependency>
+
+        <dependency 
+                name="filesystem-local" 
+                grouping="require_all" 
+                restart_on="none" 
+                type="service">
+                <service_fmri value="svc:/system/filesystem/local:default"/>
+        </dependency>
+
+        <dependency 
+                name='config-file' 
+                grouping='require_all' 
+                restart_on='refresh' 
+                type='path'>
+                <service_fmri value='file://localhost/etc/opt/ooce/nagios/nagios.cfg' />
+        </dependency>
+
+        <exec_method
+            type="method"
+            name="start"
+            exec="/lib/svc/method/application-nagios start"
+            timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="nagios" group="nagios" />
+            </method_context>
+        </exec_method>
+
+        <exec_method
+            type="method"
+            name="stop"
+            exec="/lib/svc/method/application-nagios stop"
+            timeout_seconds="60"/>
+
+        <property_group name="startd" type="framework">
+                <propval name="duration" type="astring" value="contract"/>
+        </property_group>
+
+        </instance>
+
+        <stability value="Unstable" />
+
+        <template>
+                <common_name>
+                        <loctext xml:lang="C">
+                        Nagios - Extremely powerful network monitoring system
+                        </loctext>
+                </common_name>
+        </template>
+
+</service>
+
+</service_bundle>
+

--- a/build/nagios/local.mog
+++ b/build/nagios/local.mog
@@ -1,0 +1,43 @@
+# {{{ CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition. All rights reserved.
+
+# Create directories 
+dir group=$(PROG) mode=0755 owner=$(PROG) path=var/log/$(PREFIX)
+dir group=$(PROG) mode=0755 owner=$(PROG) path=var/$(PREFIX)/run
+
+# Set permissions
+<transform file path=$(PREFIX)/bin/ -> set mode 0755>
+<transform file path=etc/$(PREFIX) -> set preserve renamenew>
+<transform dir file path=etc/$(PREFIX) -> set owner $(PROG)>
+<transform dir file path=etc/$(PREFIX) -> set group $(PROG)>
+<transform dir file path=var/$(PREFIX) -> set owner $(PROG)>
+<transform dir file path=var/$(PREFIX) -> set group $(PROG)>
+<transform dir file path=var/$(PREFIX)/rw -> set group nagcmd>
+<transform dir file path=var/$(PREFIX)/spool/checkresults -> set group nagcmd>
+<transform dir file path=var/log/$(PREFIX) -> set owner $(PROG)>
+<transform dir file path=var/log/$(PREFIX) -> set group $(PROG)>
+
+# Symlink binaries
+<transform file path=$(PREFIX)/bin/(.*) -> emit \
+    link path=$(OPREFIX)/bin/%<1> target=../$(PROG)/bin/%<1> >
+
+<transform file path=$(PREFIX)/bin/ \
+    -> set restart_fmri svc://ooce/application/$(PROG):default>
+
+group groupname=nagcmd gid=121
+group groupname=$(PROG) gid=120
+user ftpuser=false username=$(PROG) group=$(PROG) uid=120 gcos-field="$(PROG) User" \
+    home-dir=/var/$(PREFIX) password=NP
+
+license LICENSE license=GPLv2

--- a/build/nagios/local.mog
+++ b/build/nagios/local.mog
@@ -12,7 +12,7 @@
 
 # Copyright 2020 OmniOS Community Edition. All rights reserved.
 
-# Create directories 
+# Create directories
 dir group=$(PROG) mode=0755 owner=$(PROG) path=var/log/$(PREFIX)
 dir group=$(PROG) mode=0755 owner=$(PROG) path=var/$(PREFIX)/run
 
@@ -28,6 +28,12 @@ dir group=$(PROG) mode=0755 owner=$(PROG) path=var/$(PREFIX)/run
 <transform dir file path=var/log/$(PREFIX) -> set owner $(PROG)>
 <transform dir file path=var/log/$(PREFIX) -> set group $(PROG)>
 
+# Additional files
+file files/README.md path=$(PREFIX)/share/README.md \
+    mode=0444 owner=root group=bin
+file files/nagios-nginx-example.conf \
+    mode=0444 path=etc/$(PREFIX)/nagios-nginx-example.conf
+
 # Symlink binaries
 <transform file path=$(PREFIX)/bin/(.*) -> emit \
     link path=$(OPREFIX)/bin/%<1> target=../$(PROG)/bin/%<1> >
@@ -35,9 +41,9 @@ dir group=$(PROG) mode=0755 owner=$(PROG) path=var/$(PREFIX)/run
 <transform file path=$(PREFIX)/bin/ \
     -> set restart_fmri svc://ooce/application/$(PROG):default>
 
-group groupname=nagcmd gid=121
-group groupname=$(PROG) gid=120
-user ftpuser=false username=$(PROG) group=$(PROG) uid=120 gcos-field="$(PROG) User" \
-    home-dir=/var/$(PREFIX) password=NP
+group groupname=$(PROG) gid=83
+group groupname=nagcmd gid=84
+user ftpuser=false username=$(PROG) group=$(PROG) uid=83 \
+    gcos-field="$(PROG) User" home-dir=/var/$(PREFIX) password=NP
 
 license LICENSE license=GPLv2

--- a/build/nagios/patches/sample-files.patch
+++ b/build/nagios/patches/sample-files.patch
@@ -1,0 +1,102 @@
+diff -wpruN '--exclude=*.orig' a~/sample-config/nagios.cfg.in a/sample-config/nagios.cfg.in
+--- a~/sample-config/nagios.cfg.in	2019-08-20 17:29:34.000000000 +0000
++++ a/sample-config/nagios.cfg.in	2020-04-21 11:40:10.946565600 +0000
+@@ -15,7 +15,7 @@
+ # for historical purposes.  This should be the first option specified
+ # in the config file!!!
+ 
+-log_file=@localstatedir@/nagios.log
++log_file=/var/log/opt/ooce/nagios/nagios.log
+ 
+ 
+ 
+@@ -31,7 +31,7 @@ cfg_file=@sysconfdir@/objects/contacts.c
+ cfg_file=@sysconfdir@/objects/timeperiods.cfg
+ cfg_file=@sysconfdir@/objects/templates.cfg
+ 
+-# Definitions for monitoring the local (Linux) host
++# Definitions for monitoring the local (OmniOS) host
+ cfg_file=@sysconfdir@/objects/localhost.cfg
+ 
+ # Definitions for monitoring a Windows machine
+diff -wpruN '--exclude=*.orig' a~/sample-config/resource.cfg.in a/sample-config/resource.cfg.in
+--- a~/sample-config/resource.cfg.in	2019-08-20 17:29:34.000000000 +0000
++++ a/sample-config/resource.cfg.in	2020-04-21 11:40:48.223273582 +0000
+@@ -22,7 +22,7 @@
+ ###########################################################################
+ 
+ # Sets $USER1$ to be the path to the plugins
+-$USER1$=@libexecdir@
++$USER1$=/opt/ooce/nagios-plugins/libexec
+ 
+ # Sets $USER2$ to be the path to event handlers
+ #$USER2$=@libexecdir@/eventhandlers
+diff -wpruN '--exclude=*.orig' a~/sample-config/template-object/localhost.cfg.in a/sample-config/template-object/localhost.cfg.in
+--- a~/sample-config/template-object/localhost.cfg.in	2019-08-20 17:29:34.000000000 +0000
++++ a/sample-config/template-object/localhost.cfg.in	2020-04-21 11:38:45.112203565 +0000
+@@ -4,7 +4,7 @@
+ #
+ # NOTE: This config file is intended to serve as an *extremely* simple
+ #       example of how you can create configuration entries to monitor
+-#       the local (Linux) machine.
++#       the local (OmniOS) machine.
+ #
+ ###############################################################################
+ 
+@@ -20,9 +20,9 @@
+ 
+ define host {
+ 
+-    use                     linux-server            ; Name of host template to use
++    use                     omnios-server            ; Name of host template to use
+                                                     ; This host definition will inherit all variables that are defined
+-                                                    ; in (or inherited by) the linux-server host template definition.
++                                                    ; in (or inherited by) the omnios-server host template definition.
+     host_name               localhost
+     alias                   localhost
+     address                 127.0.0.1
+@@ -36,12 +36,12 @@ define host {
+ #
+ ###############################################################################
+ 
+-# Define an optional hostgroup for Linux machines
++# Define an optional hostgroup for OmniOS machines
+ 
+ define hostgroup {
+ 
+-    hostgroup_name          linux-servers           ; The name of the hostgroup
+-    alias                   Linux Servers           ; Long name of the group
++    hostgroup_name          omnios-servers           ; The name of the hostgroup
++    alias                   OmniOS Servers           ; Long name of the group
+     members                 localhost               ; Comma separated list of hosts that belong to this group
+ }
+ 
+diff -wpruN '--exclude=*.orig' a~/sample-config/template-object/templates.cfg.in a/sample-config/template-object/templates.cfg.in
+--- a~/sample-config/template-object/templates.cfg.in	2019-08-20 17:29:34.000000000 +0000
++++ a/sample-config/template-object/templates.cfg.in	2020-04-21 11:35:30.367025180 +0000
+@@ -61,19 +61,19 @@ define host {
+ 
+ 
+ 
+-# Linux host definition template
++# OmniOS host definition template
+ # This is NOT a real host, just a template!
+ 
+ define host {
+ 
+-    name                            linux-server            ; The name of this host template
++    name                            omnios-server            ; The name of this host template
+     use                             generic-host            ; This template inherits other values from the generic-host template
+-    check_period                    24x7                    ; By default, Linux hosts are checked round the clock
++    check_period                    24x7                    ; By default, OmniOS hosts are checked round the clock
+     check_interval                  5                       ; Actively check the host every 5 minutes
+     retry_interval                  1                       ; Schedule host check retries at 1 minute intervals
+-    max_check_attempts              10                      ; Check each Linux host 10 times (max)
+-    check_command                   check-host-alive        ; Default command to check Linux hosts
+-    notification_period             workhours               ; Linux admins hate to be woken up, so we only notify during the day
++    max_check_attempts              10                      ; Check each OmniOS host 10 times (max)
++    check_command                   check-host-alive        ; Default command to check OmniOS hosts
++    notification_period             workhours               ; OmniOS admins hate to be woken up, so we only notify during the day
+                                                             ; Note that the notification_period variable is being overridden from
+                                                             ; the value that is inherited from the generic-host template!
+     notification_interval           120                     ; Resend notifications every 2 hours

--- a/build/nagios/patches/series
+++ b/build/nagios/patches/series
@@ -1,0 +1,1 @@
+sample-files.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -4,6 +4,7 @@ extra.omnios ooce/application/graphviz
 extra.omnios ooce/application/imagemagick
 extra.omnios ooce/application/mattermost
 extra.omnios ooce/application/mc
+extra.omnios ooce/application/nagios
 extra.omnios ooce/application/php-72
 extra.omnios ooce/application/php-73
 extra.omnios ooce/application/php-74

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -6,6 +6,7 @@
 | ooce/application/graphviz	| 2.44.0	| https://graphviz.gitlab.io/_pages/Download/Download_source.html | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mattermost	| 5.22.0	| https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mc		| 4.8.24	| http://ftp.midnight-commander.org/?C=N;O=D | [omniosorg](https://github.com/omniosorg)
+| ooce/application/nagios	| 4.4.5		| https://github.com/NagiosEnterprises/nagioscore | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-72	| 7.2.30	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-73	| 7.3.17	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-74	| 7.4.5		| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
tarball info:
tarball: https://github.com/NagiosEnterprises/nagioscore/releases/download/nagios-4.4.5/nagios-4.4.5.tar.gz
( sha256 bf69e2d2fae218694585677472d355ba676120cbd024164281e635dc467c391d )
extracts to nagios-4.4.5

build info:
pkg install git gcc8 gnu-make ripgrep pigz gnu-tar autoconf automake libtool pkg-config

notes in local.mog
1. only made bin symlinks, so as not to fill up sbin with lots of cgi files
2. changed lots of permissions as this is how nagios normally installs, I kept /opt/ooce/nagios as root bin but had to change these nagios binaries to 755 as they are normally set 744
3. also created group nagcmd as is normal in nagios installation
4. used uid/gid of 120/1 ,as it is pretty crowded in the 90's with system uid's

notes on build.sh
1. MAKE_INSTALL_ARGS: nagios will try to install files as nagios_user/group but package is built before these users are created I set the variable to empty so files can be installed

I also added some helper files under the files directory.