### PR TITLE
add nagios-plugins-2.3.3 build files

### DIFF
--- a/build/nagios-plugins/build.sh
+++ b/build/nagios-plugins/build.sh
@@ -42,7 +42,7 @@ MAKE_INSTALL_TARGET="
     install-root
 "
 
-CONFIGURE_OPTS_64=" 
+CONFIGURE_OPTS_64="
     --prefix=$PREFIX
 "
 
@@ -50,12 +50,12 @@ CFLAGS64+=" -I/opt/ooce/pgsql-12/include"
 LDFLAGS64+=" -L/opt/ooce/pgsql-12/lib -R/opt/ooce/pgsql-12/lib"
 
 init
-download_source $PROG $PROG $VER
+download_source nagios $PROG $VER
 patch_source
 prep_build
 build
 strip_install
-make_package
+make_package local.mog final.mog
 clean_up
 
 # Vim hints

--- a/build/nagios-plugins/build.sh
+++ b/build/nagios-plugins/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition.  All rights reserved.
+
+. ../../lib/functions.sh
+
+PROG=nagios-plugins
+VER=2.3.3
+PKG=ooce/application/nagios-plugins
+SUMMARY="Plugins for Nagios"
+DESC="This is the nagios-plugins package for Nagios."
+
+set_arch 64
+
+BUILD_DEPENDS_IPS+="
+    ooce/database/mariadb-104
+    ooce/database/postgresql-12
+"
+
+RUN_DEPENDS_IPS+="
+    ?pkg:/ooce/database/mariadb-104
+    ?pkg:/ooce/database/postgresql-12
+"
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+
+MAKE_INSTALL_TARGET="
+    install
+    install-root
+"
+
+CONFIGURE_OPTS_64=" 
+    --prefix=$PREFIX
+"
+
+CFLAGS64+=" -I/opt/ooce/pgsql-12/include"
+LDFLAGS64+=" -L/opt/ooce/pgsql-12/lib -R/opt/ooce/pgsql-12/lib"
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/nagios-plugins/final.mog
+++ b/build/nagios-plugins/final.mog
@@ -1,0 +1,18 @@
+# {{{ CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition. All rights reserved.
+
+# Remove the automatically detected 'require' dependencies.
+# Optional dependencies have already been explicitly added.
+<transform depend type=require fmri=.*(?:mariadb|postgresql) -> drop>
+

--- a/build/nagios-plugins/local.mog
+++ b/build/nagios-plugins/local.mog
@@ -1,0 +1,15 @@
+# {{{ CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition. All rights reserved.
+
+license COPYING license=GPLv3

--- a/build/nagios-plugins/patches/check_dhcp.c.patch
+++ b/build/nagios-plugins/patches/check_dhcp.c.patch
@@ -1,0 +1,12 @@
+diff -wpruN '--exclude=*.orig' a~/plugins-root/check_dhcp.c a/plugins-root/check_dhcp.c
+--- a~/plugins-root/check_dhcp.c	2019-12-04 22:53:08.000000000 +0000
++++ a/plugins-root/check_dhcp.c	2020-04-20 19:57:02.645330615 +0000
+@@ -82,7 +82,7 @@ const char *email = "devel@nagios-plugin
+ #include <signal.h>
+ #include <sys/dlpi.h>
+ #include <sys/poll.h>
+-#include <sys/stropts.h>
++#include <stropts.h>
+ 
+ #define bcopy(source, destination, length) memcpy(destination, source, length)
+ 

--- a/build/nagios-plugins/patches/pst3.c.patch
+++ b/build/nagios-plugins/patches/pst3.c.patch
@@ -1,0 +1,11 @@
+diff -wpruN '--exclude=*.orig' a~/plugins-root/pst3.c a/plugins-root/pst3.c
+--- a~/plugins-root/pst3.c	2019-12-04 22:53:08.000000000 +0000
++++ a/plugins-root/pst3.c	2020-04-20 20:01:36.311284937 +0000
+@@ -230,6 +230,7 @@ try_again:
+ 
+       /* Remove newlines from args output - consistent with "normal" ps */
+       printf(" ");
++      int j = 0;
+       for (j=0;j<strlen(args);j++) {
+         if (args[j] != '\n') {
+           printf("%c", args[j]);

--- a/build/nagios-plugins/patches/series
+++ b/build/nagios-plugins/patches/series
@@ -1,0 +1,2 @@
+check_dhcp.c.patch
+pst3.c.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -5,6 +5,7 @@ extra.omnios ooce/application/imagemagick
 extra.omnios ooce/application/mattermost
 extra.omnios ooce/application/mc
 extra.omnios ooce/application/nagios
+extra.omnios ooce/application/nagios-plugins
 extra.omnios ooce/application/php-72
 extra.omnios ooce/application/php-73
 extra.omnios ooce/application/php-74

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -7,6 +7,7 @@
 | ooce/application/mattermost	| 5.22.0	| https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mc		| 4.8.24	| http://ftp.midnight-commander.org/?C=N;O=D | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios	| 4.4.5		| https://github.com/NagiosEnterprises/nagioscore | [omniosorg](https://github.com/omniosorg)
+| ooce/application/nagios-plugins | 2.3.3	| http://www.nagios-plugins.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-72	| 7.2.30	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-73	| 7.3.17	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-74	| 7.4.5		| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
tarball: http://www.nagios-plugins.org/download/nagios-plugins-2.3.3.tar.gz
( sha256 07859071632ded58c5135d613438137022232da75f8bdc1687f3f75da2fe597f )
extracts to nagios-plugins-2.3.3



notes on build.sh
1. RUN_DEPENDS_IPS: was not sure how to make build dependent packages optional for run_depends. looking under functions.sh I saw it possibe to "case" with variable symbols as the first character. 
however, this did not remove the original "required" dependency so I added the following line in my functions.sh to drop the required package in the final.mog



```
             #functions.sh - lines 1318-1320
             if grep -q "^depend .*fmri=[^ ]*$depname" "${P5M_INT3}.res"; then
+                logcmd sed -i "\%^depend .*fmri=[^ ]*$depname%d" ${P5M_INT3}.res
                 autoresolved=true
```

without this the build will have duplicate dependencies. one required, the other optional.

just a note, check_ldap was not built as it depends on lldap and lber. ldap is there. libber is not, however `/usr/include/liber.h` exists. 