### PR TITLE
sysstat: Add -n option in configure ksh script to prevent build error

### DIFF
--- a/build/sysstat/patches/config.patch
+++ b/build/sysstat/patches/config.patch
@@ -1,0 +1,10 @@
+--- a~/configure	Mon Oct 12 21:30:47 2015
++++ a/configure	Mon Apr 27 12:55:04 2020
+@@ -56,6 +56,7 @@
+ 	[h:help?print usage]
+ 	[d:debug?enable debugging]
+ 	[p:prefix?set prefix for installation]:[prefix]
++	[n:nooverwrite?prevent overwriting of an existing mkrules file]
+ 	[c:cc:?set C compiler]:[cc]
+ 	'
+ else

--- a/build/sysstat/patches/series
+++ b/build/sysstat/patches/series
@@ -1,3 +1,4 @@
+config.patch
 local_only.patch
 no_colour.patch
 relocate_bin.patch


### PR DESCRIPTION
The configure script executes two branches. In one, the getopts parameters string doesn't contain -n, thus triggering an error when "configure -n" is called.