### PR TITLE
nginx: want proper paths in nginx.8

### DIFF
--- a/build/nginx/build-116.sh
+++ b/build/nginx/build-116.sh
@@ -95,7 +95,7 @@ copy_man_page() {
     logcmd mkdir -p $DESTDIR$PREFIX/share/man/man8 || \
         logerr "--- creating man page directory failed"
 
-    logcmd cp $TMPDIR/$BUILDDIR/man/$PROG.8 $DESTDIR$PREFIX/share/man/man8 || \
+    logcmd cp $TMPDIR/$BUILDDIR/objs/$PROG.8 $DESTDIR$PREFIX/share/man/man8 || \
         logerr "--- copying man page failed"
 }
 

--- a/build/nginx/build-118.sh
+++ b/build/nginx/build-118.sh
@@ -87,7 +87,7 @@ copy_man_page() {
     logcmd mkdir -p $DESTDIR$PREFIX/share/man/man8 || \
         logerr "--- creating man page directory failed"
 
-    logcmd cp $TMPDIR/$BUILDDIR/man/$PROG.8 $DESTDIR$PREFIX/share/man/man8 || \
+    logcmd cp $TMPDIR/$BUILDDIR/objs/$PROG.8 $DESTDIR$PREFIX/share/man/man8 || \
         logerr "--- copying man page failed"
 }
 

--- a/build/nginx/build.sh
+++ b/build/nginx/build.sh
@@ -88,7 +88,7 @@ copy_man_page() {
     logcmd mkdir -p $DESTDIR$PREFIX/share/man/man8 || \
         logerr "--- creating man page directory failed"
 
-    logcmd cp $TMPDIR/$BUILDDIR/man/$PROG.8 $DESTDIR$PREFIX/share/man/man8 || \
+    logcmd cp $TMPDIR/$BUILDDIR/objs/$PROG.8 $DESTDIR$PREFIX/share/man/man8 || \
         logerr "--- copying man page failed"
 }
 


### PR DESCRIPTION
The file nginx.8 in $TMPDIR/$BUILDDIR/man is a template containing %% parameters to be substituted with the correct values during build.  The generated file nginx.8 is in $TMPDIR/$BUILDDIR/objs.