### PR TITLE
Add gyp (generate your projects)

### DIFF
--- a/build/gyp/build.sh
+++ b/build/gyp/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=gyp
+VER=20200512
+PKG=ooce/developer/gyp
+SUMMARY="gyp - generate your projects"
+DESC="GYP is a Meta-Build system: "
+DESC+="a build system that generates other build systems."
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+python_build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gyp/local.mog
+++ b/build/gyp/local.mog
@@ -1,0 +1,13 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=modified-BSD
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -43,6 +43,7 @@ extra.omnios ooce/developer/flamegraph
 extra.omnios ooce/developer/go-113
 extra.omnios ooce/developer/go-114
 extra.omnios ooce/developer/gperf
+extra.omnios ooce/developer/gyp
 extra.omnios ooce/developer/llvm-100
 extra.omnios ooce/developer/llvm-90
 extra.omnios ooce/developer/ninja


### PR DESCRIPTION
This is a pre-requisite for switching Mozilla nss/nspr to the new build system.