### PR TITLE
Add a section on a possible use of "local" tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,19 @@ GitHub does not supply checksums for downloaded archives, so this can be workd a
 set_checksum "none"
 ```
 
+### Local source tarballs
+
+Sometimes it might be useful to be able to use "local" tarballs without having to go via a Mirror or a GitHub release.
+For example when doing development of the original source and wanting to test the OmniOSCE Extra build process without
+having to publish a temporary "release" every time.
+
+This can be accomplished by preparing a distribution tarball of the project and after having configured stuff per the
+instructions above (for a Mirror or GitHub release case) then - just before you run "./build.sh" - copy the tarball to
+the directory /tmp/build_$USER/$PACKAGE-$VERSION/ (see TMPDIR in lib/config.sh for the exact location of /tmp/build_$USER/).
+For this to work the "download_source" must have atleast tree arguments specified (download_source v$VER $PROG $VER) or it
+won't find the tarball).
+
+
 ### Exceptional cases regarding source tarballs
 
 


### PR DESCRIPTION
A suggestion for a new section in the README.md file on how to use "local" tarballs. It's a bit of a hack but seems to work for me at least. The wording can probably be _much_ improved. But it's nice to be able to test the build process locally without having to publish a release on Github every time (especially when working on the original source and trying to fix it so it is portable to multiple OS:es at the same time... I typically test my code on FreeBSD, OmniOS, Linux and MacOS.

(I got the idea from the MacOS HomeBrew build process where this was possible)

- Peter