### PR TITLE
Enable package-local rtime file for overrides

### DIFF
--- a/build/acltool/rtime
+++ b/build/acltool/rtime
@@ -1,0 +1,7 @@
+
+# libreadline needs either one of libtermcap | libcurses | libncurses,
+# but is not linked with either one of them
+UNREF_OBJ libtermcap\.so\.1
+UNREF_OBJ libcurses\.so\.1
+UNREF_OBJ libncurses\.so\.6
+

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -2422,10 +2422,15 @@ check_rtime() {
 
     logmsg "-- Checking ELF runtime attributes"
     logcmd -p $FIND_ELF -fr $destdir/ > $TMPDIR/rtime.files
+
+    cp $ROOTDIR/doc/rtime $TMPDIR/rtime.cfg
+    [ -f $SRCDIR/rtime ] && cat $SRCDIR/rtime >> $TMPDIR/rtime.cfg
+
     logcmd $CHECK_RTIME \
-        -e $ROOTDIR/doc/rtime \
+        -e $TMPDIR/rtime.cfg \
         -E $TMPDIR/rtime.err \
         -f $TMPDIR/rtime.files
+
     if [ -s "$TMPDIR/rtime.err" ]; then
         cat $TMPDIR/rtime.err | tee -a $LOGFILE
         logerr "ELF runtime problems detected"


### PR DESCRIPTION
This patch adds support for package-local "rtime" files to override/add exceptions defined in "doc/rtime" file on a per-package basis. This can be useful if a package has special needs.

One such example is libreadline which must be linked with either libtermcap, libcurses or libncurses - but neither one of then is referenced by libreadline - so the check_rtime tool will always complain about libtermcap/libcurses/libncurses been unneeded. With this patch one can add a local "rtime" file in the package directory like this:

```
# libreadline needs either one of libtermcap | libcurses | libncurses,
# but is not linked with either one of them
UNREF_OBJ libtermcap\.so\.1
UNREF_OBJ libcurses\.so\.1
UNREF_OBJ libncurses\.so\.6
```