### PR TITLE
acltool version 1.16.2

### DIFF
--- a/build/acltool/build.sh
+++ b/build/acltool/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+. ../../lib/functions.sh
+
+PROG=acltool
+VER=1.16.2
+PKG=ooce/file/acltool
+SUMMARY="acltool - display and update NFSv4/ZFS/SMB ACLs"
+DESC="acltool is a program to display and update NFSv4/ZFS/SMB ACLs "
+DESC+="in a more sane way - and also works the same on OmniOS, Linux, "
+DESC+="FreeBSD and MacOS."
+
+set_arch 64
+
+set_mirror "$GITHUB/ptrrkssn/$PROG/archive"
+set_checksum sha256 \
+    d54011efb3d5cc24aedad88e3684d1c9dea218515bb1f18d9caac33f8bbae501
+
+init
+download_source v$VER $PROG $VER
+prep_build
+build
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/acltool/local.mog
+++ b/build/acltool/local.mog
@@ -1,0 +1,18 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+<transform file path=$(PREFIX)/bin/acltool -> set user root>
+<transform file path=$(PREFIX)/bin/acltool -> set group bin>
+<transform file path=$(PREFIX)/bin/acltool -> set mode 755>
+
+license LICENSE license=modified-BSD
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -56,6 +56,7 @@ extra.omnios ooce/editor/emacs
 extra.omnios ooce/editor/joe
 extra.omnios ooce/editor/nano
 extra.omnios ooce/extra-build-tools
+extra.omnios ooce/file/acltool
 extra.omnios ooce/file/lsof
 extra.omnios ooce/file/tree
 extra.omnios ooce/kvmadm

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -52,6 +52,7 @@
 | ooce/editor/emacs		| 26.3		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 4.9.3		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
+| ooce/file/acltool		| 1.16.2	| https://github.com/ptrrkssn/acltool/releases | [Peter Eriksson](https://github.com/ptrrkssn)
 | ooce/file/lsof		| 4.93.2	| https://github.com/lsof-org/lsof/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/file/tree		| 1.8.0		| http://mama.indstate.edu/users/ice/tree/ | [omniosorg](https://github.com/omniosorg)
 | ooce/kvmadm			| 0.12.3	| https://github.com/hadfl/kvmadm/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
New package/program - acltool, a cli tool to manage NFSv4/ZFS ACLs in various ways on Solaris/OmniOS, FreeBSD, Linux & MacOS in a uniform way. 
