### PR TITLE
Add consolidated uid/gid list

### DIFF
--- a/doc/idlist.md
+++ b/doc/idlist.md
@@ -1,0 +1,93 @@
+
+### Users
+
+| source | uid | username
+| ---    | --- | ---
+| illumos	| 0	| root
+| illumos	| 1	| daemon
+| illumos	| 2	| bin
+| illumos	| 3	| sys
+| illumos	| 4	| adm
+| illumos	| 5	| uucp
+| illumos	| 9	| nuucp
+| illumos	| 15	| dladm
+| illumos	| 16	| netadm
+| illumos	| 17	| netcfg
+| illumos	| 25	| smmsp
+| omnios	| 18	| dhcpserv
+| extra		| 19	| minidlna
+| omnios	| 26	| dma
+| extra		| 27	| postfix
+| illumos	| 37	| listen
+| illumos	| 50	| gdm
+| illumos	| 51	| zfssnap
+| illumos	| 52	| upnp
+| extra		| 54	| unbound
+| extra		| 55	| nsd
+| illumos	| 60	| xvm
+| extra		| 67	| znc
+| illumos	| 70	| mysql
+| illumos	| 71	| lp
+| illumos	| 75	| openldap
+| extra		| 79	| ooceapps
+| illumos	| 80	| webservd
+| extra		| 81	| nginx
+| extra		| 82	| php
+| extra		| 83	| nagios
+| extra		| 85	| mattermost
+| extra		| 86	| gitea
+| extra		| 87	| minio
+| extra		| 88	| fcgiwrap
+| extra		| 90	| postgres
+| extra		| 91	| subversion
+| omnios	| 92	| sshd
+| illumos	| 95	| svctag
+| illumos	| 96	| unknown
+
+### Groups
+
+| source | gid | group name
+| ---    | --- | ---
+| illumos	| 0	| root
+| illumos	| 1	| other
+| illumos	| 2	| bin
+| illumos	| 3	| sys
+| illumos	| 4	| adm
+| illumos	| 5	| uucp
+| illumos	| 6	| mail
+| illumos	| 7	| tty
+| illumos	| 8	| lp
+| illumos	| 9	| nuucp
+| illumos	| 10	| staff
+| illumos	| 12	| daemon
+| illumos	| 14	| sysadmin
+| extra		| 19	| minidlna
+| illumos	| 20	| games
+| illumos	| 25	| smmsp
+| extra		| 27	| postfix
+| extra		| 28	| postdrop
+| illumos	| 50	| gdm
+| illumos	| 52	| upnp
+| extra		| 54	| unbound
+| extra		| 55	| nsd
+| illumos	| 60	| xvm
+| illumos	| 65	| netadm
+| extra		| 67	| znc
+| illumos	| 70	| mysql
+| illumos	| 75	| openldap
+| extra		| 79	| ooceapps
+| illumos	| 80	| webservd
+| extra		| 81	| nginx
+| extra		| 82	| php
+| extra		| 83	| nagios
+| extra		| 84	| nagcmd
+| extra		| 85	| mattermost
+| extra		| 86	| gitea
+| extra		| 87	| minio
+| extra		| 88	| fcgiwrap
+| extra		| 90	| postgres
+| extra		| 91	| subversion
+| omnios	| 92	| sshd
+| illumos	| 95	| slocate
+| illumos	| 96	| unknown
+


### PR DESCRIPTION
This brings together all allocated uids and gids from illumos-omnios, omnios-build and omnios-extra.
Since most new UIDs will be allocated for the extra repository, it is most at home here.