### PR TITLE
postgresql updates

### DIFF
--- a/build/postgresql/build-10.sh
+++ b/build/postgresql/build-10.sh
@@ -19,7 +19,7 @@
 
 PROG=postgresql
 PKG=ooce/database/postgresql-10
-VER=10.13
+VER=10.14
 SUMMARY="PostgreSQL 10"
 DESC="The World's Most Advanced Open Source Relational Database"
 

--- a/build/postgresql/build-11.sh
+++ b/build/postgresql/build-11.sh
@@ -19,7 +19,7 @@
 
 PROG=postgresql
 PKG=ooce/database/postgresql-11
-VER=11.8
+VER=11.9
 SUMMARY="PostgreSQL 11"
 DESC="The World's Most Advanced Open Source Relational Database"
 

--- a/build/postgresql/build-12.sh
+++ b/build/postgresql/build-12.sh
@@ -19,7 +19,7 @@
 
 PROG=postgresql
 PKG=ooce/database/postgresql-12
-VER=12.3
+VER=12.4
 SUMMARY="PostgreSQL 12"
 DESC="The World's Most Advanced Open Source Relational Database"
 

--- a/build/postgresql/build-96.sh
+++ b/build/postgresql/build-96.sh
@@ -19,7 +19,7 @@
 
 PROG=postgresql
 PKG=ooce/database/postgresql-96
-VER=9.6.18
+VER=9.6.19
 SUMMARY="PostgreSQL 9.6"
 DESC="The World's Most Advanced Open Source Relational Database"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -28,7 +28,7 @@
 | ooce/database/lmdb		| 0.9.24	| https://github.com/LMDB/lmdb/releases https://symas.com/lmdb/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-103	| 10.3.24	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-104	| 10.4.14	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
-| ooce/database/postgresql-10	| 10.13		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/postgresql-10	| 10.14		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-11	| 11.8		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-12	| 12.3		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-96	| 9.6.18	| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -29,7 +29,7 @@
 | ooce/database/mariadb-103	| 10.3.24	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-104	| 10.4.14	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-10	| 10.14		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
-| ooce/database/postgresql-11	| 11.8		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/postgresql-11	| 11.9		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-12	| 12.3		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-96	| 9.6.18	| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/rrdtool		| 1.7.2		| https://oss.oetiker.ch/rrdtool/pub/?M=D | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -30,7 +30,7 @@
 | ooce/database/mariadb-104	| 10.4.14	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-10	| 10.14		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-11	| 11.9		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
-| ooce/database/postgresql-12	| 12.3		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/postgresql-12	| 12.4		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-96	| 9.6.18	| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/rrdtool		| 1.7.2		| https://oss.oetiker.ch/rrdtool/pub/?M=D | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/autogen	| 5.18.16	| https://ftp.gnu.org/gnu/autogen/ | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -31,7 +31,7 @@
 | ooce/database/postgresql-10	| 10.14		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-11	| 11.9		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-12	| 12.4		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
-| ooce/database/postgresql-96	| 9.6.18	| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/postgresql-96	| 9.6.19	| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/rrdtool		| 1.7.2		| https://oss.oetiker.ch/rrdtool/pub/?M=D | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/autogen	| 5.18.16	| https://ftp.gnu.org/gnu/autogen/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/ccache		| 3.6		| https://www.samba.org/ftp/ccache/ | [jimklimov](https://github.com/jimklimov)


### PR DESCRIPTION
These build fine and the differences in the pkg diffs seem to be just timezone related.

diffs can be found here:

[pbdigital.org/pkgdiffs/postgresql-10.14.txt](https://pbdigital.org/pkgdiffs/postgresql-10.14.txt)
[pbdigital.org/pkgdiffs/postgresql-11.9.txt](https://pbdigital.org/pkgdiffs/postgresql-11.9.txt)
[pbdigital.org/pkgdiffs/postgresql-12.4.txt](https://pbdigital.org/pkgdiffs/postgresql-12.4.txt)
[pbdigital.org/pkgdiffs/postgresql-9.6.19.txt](https://pbdigital.org/pkgdiffs/postgresql-9.6.19.txt)