### PR TITLE
add manifest tidy tool

### DIFF
--- a/build/apache/files/apache-template.xml
+++ b/build/apache/files/apache-template.xml
@@ -14,85 +14,83 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="http:apache$(sVERSION)">
 
-<service_bundle type='manifest' name='http:apache$(sVERSION)'>
-<service name="network/http" type="service" version="1">
+    <service name="network/http"
+             type="service"
+             version="1">
 
-<instance name='apache$(sVERSION)' enabled='false'>
+        <instance name="apache$(sVERSION)"
+                  enabled="false">
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependent
-	    name='apache$(sVERSION)_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <dependent name="apache$(sVERSION)_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
+            <method_context security_flags="aslr">
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic,net_privaddr,!proc_info,!proc_session,!file_link_any" />
+            </method_context>
 
-	<method_context security_flags="aslr">
-		<method_credential user='$(USER)' group='$(GROUP)'
-		    privileges='basic,net_privaddr,!proc_info,!proc_session,!file_link_any' />
-	</method_context>
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/exec} -k %m -f %{config/file}"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='%{config/exec} -k %m -f %{config/file}'
-	    timeout_seconds='60' />
+            <exec_method type="method"
+                         name="stop"
+                         exec="%{config/exec} -k %m -f %{config/file}"
+                         timeout_seconds="300" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec='%{config/exec} -k %m -f %{config/file}'
-	    timeout_seconds='300' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec="%{config/exec} -k graceful -f %{config/file}"
+                         timeout_seconds="300" />
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec='%{config/exec} -k graceful -f %{config/file}'
-	    timeout_seconds='300' />
+            <property_group name="config"
+                            type="application">
+                <propval name="file"
+                         type="astring"
+                         value="/etc/$(PREFIX)/httpd.conf" />
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/bin/apachectl" />
+            </property_group>
 
-	<property_group name="config" type="application">
-	    <propval name="file" type="astring"
-		value="/etc/$(PREFIX)/httpd.conf"/>
-            <propval name="exec" type="astring"
-                value="/$(PREFIX)/bin/apachectl"/>
-	</property_group>
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">apache $(VERSION)</loctext>
+                </common_name>
+            </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				apache $(VERSION)
-			</loctext>
-		</common_name>
-	</template>
+        </instance>
 
-</instance>
+        <stability value="External" />
 
-<stability value='External' />
+    </service>
 
-</service>
 </service_bundle>
-

--- a/build/cyrus/files/cyrus.xml
+++ b/build/cyrus/files/cyrus.xml
@@ -1,9 +1,9 @@
-<?xml version='1.0'?>
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 
     This file and its contents are supplied under the terms of the
-    Common Development and Distribution License ('CDDL'), version 1.0.
+    Common Development and Distribution License ("CDDL"), version 1.0.
     You may only use this file in accordance with the terms of version
     1.0 of the CDDL.
 
@@ -14,130 +14,125 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="cyrus">
 
-<service_bundle type='manifest' name='cyrus'>
+    <service name="network/cyrus-setup"
+             type="service"
+             version="1">
 
-<service name='network/cyrus-setup' type='service' version='1'>
+        <create_default_instance enabled="true" />
 
-	<create_default_instance enabled='true'/>
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/ooce/cyrus-setup %m /$(RUNDIR)"
+                     timeout_seconds="60"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/lib/svc/method/ooce/cyrus-setup %m /$(RUNDIR)'
-	    timeout_seconds='60'>
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":true"
+                     timeout_seconds="60"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':true'
-	    timeout_seconds='60'>
-	</exec_method>
-
-        <property_group name='startd' type='framework'>
-                <propval name='duration' type='astring' value='transient' />
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="transient" />
         </property_group>
-</service>
 
-<service name='network/cyrus' type='service' version='1'>
+    </service>
 
-	<create_default_instance enabled='false'/>
+    <service name="network/cyrus"
+             type="service"
+             version="1">
 
-	<dependency
-	    name='cyrus-setup'
-	    grouping='require_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/cyrus-setup:default' />
-	</dependency>
+        <create_default_instance enabled="false" />
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="cyrus-setup"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/cyrus-setup:default" />
+        </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependent
-	    name='cyrus-server_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<method_context security_flags='aslr'>
-		<method_credential user='$(USER)' group='$(GROUP)'
-    privileges='basic,net_privaddr,!proc_info,!proc_session,!file_link_any' />
-	</method_context>
+        <dependent name="cyrus-server_multi-user"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user" />
+        </dependent>
+        <method_context security_flags="aslr">
+            <method_credential user="$(USER)"
+                               group="$(GROUP)"
+                               privileges="basic,net_privaddr,!proc_info,!proc_session,!file_link_any" />
+        </method_context>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/$(PREFIX)/libexec/master -d -C %{config/imapd} -M %{config/cyrus} -p %{config/pidfile} -l %{config/backlog}'
-	    timeout_seconds='60'>
-	</exec_method>
+        <exec_method type="method"
+                     name="start"
+                     exec="/$(PREFIX)/libexec/master -d -C %{config/imapd} -M %{config/cyrus} -p %{config/pidfile} -l %{config/backlog}"
+                     timeout_seconds="60"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='180'>
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="180"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':kill -HUP'
-	    timeout_seconds='180'>
-	</exec_method>
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="180"></exec_method>
 
-	<property_group name='config' type='application'>
-	    <propval name='imapd' type='astring'
-		value='/etc/$(PREFIX)/imapd.conf'/>
-	    <propval name='cyrus' type='astring'
-		value='/etc/$(PREFIX)/cyrus.conf'/>
-	    <propval name='pidfile' type='astring'
-		value='/var/$(PREFIX)/master.pid'/>
-	    <propval name='backlog' type='integer' value='32'/>
-	</property_group>
+        <property_group name="config"
+                        type="application">
+            <propval name="imapd"
+                     type="astring"
+                     value="/etc/$(PREFIX)/imapd.conf" />
+            <propval name="cyrus"
+                     type="astring"
+                     value="/etc/$(PREFIX)/cyrus.conf" />
+            <propval name="pidfile"
+                     type="astring"
+                     value="/var/$(PREFIX)/master.pid" />
+            <propval name="backlog"
+                     type="integer"
+                     value="32" />
+        </property_group>
 
-	<stability value='External' />
+        <stability value="External" />
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			Cyrus IMAP Server
-			</loctext>
-		</common_name>
-	</template>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Cyrus IMAP Server</loctext>
+            </common_name>
+        </template>
 
-</service>
+    </service>
 
 </service_bundle>
-

--- a/build/fcgiwrap/files/fcgiwrap.xml
+++ b/build/fcgiwrap/files/fcgiwrap.xml
@@ -1,102 +1,101 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-	{{{ CDDL HEADER
+        {{{ CDDL HEADER
 
-	This file and its contents are supplied under the terms of the
-	Common Development and Distribution License ("CDDL"), version 1.0.
-	You may only use this file in accordance with the terms of version
-	1.0 of the CDDL.
+        This file and its contents are supplied under the terms of the
+        Common Development and Distribution License ("CDDL"), version 1.0.
+        You may only use this file in accordance with the terms of version
+        1.0 of the CDDL.
 
-	A full copy of the text of the CDDL should have accompanied this
-	source. A copy of the CDDL is also available via the Internet at
-	http://www.illumos.org/license/CDDL.
+        A full copy of the text of the CDDL should have accompanied this
+        source. A copy of the CDDL is also available via the Internet at
+        http://www.illumos.org/license/CDDL.
 
-	}}}
+        }}}
 
-	Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+        Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 -->
+<service_bundle type="manifest"
+                name="fcgiwrap">
 
-<service_bundle type='manifest' name='fcgiwrap'>
+    <service name="ooce/application/fcgiwrap"
+             type="service"
+             version="1">
 
-<service
-	name='ooce/application/fcgiwrap'
-	type='service'
-	version='1'>
+        <instance name="default"
+                  enabled="false">
 
-	<instance name='default' enabled='false'>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-		name='loopback'
-		grouping='require_any'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-		name='network'
-		grouping='optional_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependent name="fcgiwrap_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<dependent
-		name='fcgiwrap_multi-user'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="/opt/ooce/sbin/fcgiwrap -s %{config/socket} -c %{config/children}"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="fcgiwrap"
+                                       group="fcgiwrap"
+                                       privileges="basic,!proc_info,!proc_session,!file_link_any" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/opt/ooce/sbin/fcgiwrap -s %{config/socket} -c %{config/children}'
-	    timeout_seconds='60'>
-            <method_context security_flags="aslr">
-		<method_credential user='fcgiwrap' group='fcgiwrap'
-		    privileges='basic,!proc_info,!proc_session,!file_link_any' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="child" />
+            </property_group>
 
-	<property_group name='startd' type='framework'>
-		<propval name='duration' type='astring' value='child' />
-	</property_group>
+            <property_group name="config"
+                            type="application">
+                <propval name="children"
+                         type="count"
+                         value="1" />
+                <propval name="socket"
+                         type="astring"
+                         value="unix:/var/opt/ooce/fcgiwrap/run/fcgiwrap.sock" />
+            </property_group>
 
-	<property_group name='config' type='application'>
-		<propval name='children' type='count' value='1' />
-		<propval name='socket' type='astring'
-		    value='unix:/var/opt/ooce/fcgiwrap/run/fcgiwrap.sock' />
-	</property_group>
+        </instance>
 
-	</instance>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">fcgiwrap</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			fcgiwrap
-			</loctext>
-		</common_name>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>
-

--- a/build/gitea/files/gitea.xml
+++ b/build/gitea/files/gitea.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,97 +14,94 @@ http://www.illumos.org/license/CDDL.
 Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="gitea:default">
 
-<service_bundle type='manifest' name='gitea:default'>
+    <service name="system/gitea"
+             type="service"
+             version="1">
 
-<service
-	name='system/gitea'
-	type='service'
-	version='1'>
+        <create_default_instance enabled="false" />
 
-	<create_default_instance enabled='false' />
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <dependency name="multi_user"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user:default" />
+        </dependency>
 
-	<dependency
-	    name='multi_user'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/milestone/multi-user:default' />
-	</dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependent name="gitea_multi-user-server"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
 
-	<dependent name='gitea_multi-user-server'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user-server' />
-	</dependent>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/gitea %m"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="gitea"
+                                   group="gitea" />
+            </method_context>
+        </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/lib/svc/method/gitea %m'
-	    timeout_seconds='60' >
-	    <method_context security_flags='aslr'>
-                <method_credential user='gitea' group='gitea' />
-	    </method_context>
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="60"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':kill -HUP'
-	    timeout_seconds='60' >
-	</exec_method>
+        <property_group name="config"
+                        type="application">
+            <propval name="file"
+                     type="astring"
+                     value="app.ini" />
+            <propval name="home"
+                     type="astring"
+                     value="/var/opt/ooce/gitea" />
+        </property_group>
 
-	<property_group name='config' type='application'>
-		<propval name='file' type='astring' value='app.ini' />
-		<propval name='home' type='astring'
-		    value='/var/opt/ooce/gitea' />
-	</property_group>
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="child" />
+        </property_group>
 
-	<property_group name='startd' type='framework'>
-		<propval name='duration' type='astring' value='child' />
-	</property_group>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Gitea - git with a cup of tea</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Gitea - git with a cup of tea
-			</loctext>
-		</common_name>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>

--- a/build/isc-bind9/files/named-template.xml
+++ b/build/isc-bind9/files/named-template.xml
@@ -14,100 +14,104 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="named$(sVERSION)">
 
-<service_bundle type='manifest' name='named$(sVERSION)'>
+    <service name="network/dns"
+             type="service"
+             version="1">
 
-<service name="network/dns" type="service" version="1">
+        <instance name="named$(sVERSION)"
+                  enabled="false">
 
-<instance name="named$(sVERSION)" enabled="false">
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependent name="named$(sVERSION)_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<dependent
-	    name='named$(sVERSION)_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/method} %m"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic,net_privaddr,!priv_proc_info,!priv_proc_session" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='%{config/method} %m'
-	    timeout_seconds='60'>
-            <method_context security_flags="aslr">
-		<method_credential user='$(USER)' group='$(GROUP)'
-		    privileges="basic,net_privaddr,!priv_proc_info,!priv_proc_session" />
-		</method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60"></exec_method>
 
-        <exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60'>
-	</exec_method>
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":kill -HUP"
+                         timeout_seconds="60"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':kill -HUP'
-	    timeout_seconds='60'>
-	</exec_method>
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="contract" />
+            </property_group>
 
-	<property_group name="startd" type="framework">
-	    <propval name="duration" type="astring" value="contract"/>
-	</property_group>
+            <property_group name="config"
+                            type="application">
+                <propval name="file"
+                         type="astring"
+                         value="/etc/$(PREFIX)/named.conf" />
+                <propval name="rndc_key"
+                         type="astring"
+                         value="/etc/$(PREFIX)/rndc.key" />
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/sbin/named" />
+                <propval name="method"
+                         type="astring"
+                         value="/lib/svc/method/ooce/named-$(sVERSION)" />
+            </property_group>
 
-	<property_group name="config" type="application">
-	    <propval name="file" type="astring"
-		value="/etc/$(PREFIX)/named.conf"/>
-	    <propval name="rndc_key" type="astring"
-		value="/etc/$(PREFIX)/rndc.key"/>
-	    <propval name="exec" type="astring"
-		value="/$(PREFIX)/sbin/named"/>
-	<propval name='method' type='astring'
-	    value='/lib/svc/method/ooce/named-$(sVERSION)' />
-	</property_group>
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">$(PROG) $(VERSION)</loctext>
+                </common_name>
+                <documentation>
+                    <manpage title="named"
+                             section="8"
+                             manpath="/$(PREFIX)/share/man" />
+                    <doc_link name="named documentation"
+                              uri="https://kb.isc.org/docs/aa-01031" />
+                </documentation>
+            </template>
 
-	<template>
-	    <common_name>
-		<loctext xml:lang='C'>$(PROG) $(VERSION)</loctext>
-	    </common_name>
-	    <documentation>
-		<manpage title="named"
-		    section="8"
-		    manpath="/$(PREFIX)/share/man" />
-		<doc_link name="named documentation"
-		    uri="https://kb.isc.org/docs/aa-01031" />
-	    </documentation>
-	</template>
+        </instance>
 
-</instance>
+        <stability value="External" />
 
-	<stability value='External' />
+    </service>
 
-</service>
 </service_bundle>

--- a/build/mariadb/files/mariadb-template.xml
+++ b/build/mariadb/files/mariadb-template.xml
@@ -14,96 +14,93 @@ http://www.illumos.org/license/CDDL.
 Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="mariadb$(sVERSION)">
 
-<service_bundle type='manifest' name='mariadb$(sVERSION)'>
+    <service name="ooce/database/mariadb$(sVERSION)"
+             type="service"
+             version="1">
 
-<service
-    name='ooce/database/mariadb$(sVERSION)'
-    type='service'
-    version='1'>
+        <instance name="default"
+                  enabled="false">
 
-    <instance name='default' enabled='false' >
+            <dependency name="paths"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="path">
+                <service_fmri value="file://localhost/etc/$(PREFIX)/my.cnf" />
+            </dependency>
 
-    <dependency name='paths'
-        grouping='require_all'
-        restart_on='error'
-        type='path'>
-        <service_fmri value='file://localhost/etc/$(PREFIX)/my.cnf' />
-    </dependency>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-    <dependency
-        name='loopback'
-        grouping='require_any'
-        restart_on='error'
-        type='service'>
-        <service_fmri value='svc:/network/loopback' />
-    </dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-    <dependency
-        name='network'
-        grouping='optional_all'
-        restart_on='error'
-        type='service'>
-        <service_fmri value='svc:/milestone/network' />
-    </dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-    <dependency
-        name='filesystem_local'
-        grouping='require_all'
-        restart_on='none'
-        type='service'>
-        <service_fmri value='svc:/system/filesystem/local:default' />
-    </dependency>
+            <dependent name="mariadb$(sVERSION)_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-    <dependent
-        name='mariadb$(sVERSION)_multi-user'
-        grouping='optional_all'
-        restart_on='none'>
-        <service_fmri value='svc:/milestone/multi-user' />
-    </dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="%{application/method} %m"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)" />
+                </method_context>
+            </exec_method>
 
-    <exec_method
-        type='method'
-        name='start'
-        exec='%{application/method} %m'
-        timeout_seconds='60'>
-        <method_context security_flags="aslr">
-            <method_credential user='$(USER)' group='$(GROUP)' />
-        </method_context>
-    </exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
 
-    <exec_method
-        type='method'
-        name='stop'
-        exec=':kill'
-        timeout_seconds='60' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":kill -HUP"
+                         timeout_seconds="60" />
 
-    <exec_method
-        type='method'
-        name='refresh'
-        exec=':kill -HUP'
-        timeout_seconds='60' />
+            <property_group name="application"
+                            type="application">
+                <propval name="datadir"
+                         type="astring"
+                         value="/var/$(PREFIX)/data" />
+                <propval name="root"
+                         type="astring"
+                         value="/$(PREFIX)" />
+                <propval name="method"
+                         type="astring"
+                         value="/lib/svc/method/ooce/mariadb-$(sVERSION)" />
+            </property_group>
 
-    <property_group name="application" type="application">
-        <propval name='datadir' type='astring'
-            value='/var/$(PREFIX)/data' />
-        <propval name='root' type='astring'
-            value='/$(PREFIX)' />
-        <propval name='method' type='astring'
-            value='/lib/svc/method/ooce/mariadb-$(sVERSION)' />
-    </property_group>
+        </instance>
 
-    </instance>
+        <stability value="External" />
 
-    <stability value='External' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">MariaDB $(VERSION)</loctext>
+            </common_name>
+        </template>
 
-    <template>
-        <common_name>
-            <loctext xml:lang='C'>
-                MariaDB $(VERSION)
-            </loctext>
-        </common_name>
-    </template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/mattermost/files/mattermost.xml
+++ b/build/mattermost/files/mattermost.xml
@@ -20,41 +20,61 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
+<service_bundle type="manifest"
+                name="mattermost:default">
 
-<service_bundle type="manifest" name="mattermost:default">
-<service name="ooce/application/mattermost" type="service" version="1">
-    <create_default_instance enabled="false" />
-        <dependency name='network' grouping='require_all' restart_on="error" type="service">
-            <service_fmri value='svc:/milestone/network:default' />
+    <service name="ooce/application/mattermost"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
         </dependency>
-        <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <dependency name='config-file' grouping='require_all' restart_on='refresh' type='path'>
-            <service_fmri value='file://localhost/etc/opt/ooce/mattermost/config.json' />
+
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/mattermost/config.json" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/mattermost/bin/mattermost -c /etc/opt/ooce/mattermost/config.json &amp;"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/mattermost/bin/mattermost -c /etc/opt/ooce/mattermost/config.json &amp;"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user='mattermost' group='mattermost' />
+                <method_credential user="mattermost"
+                                   group="mattermost" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec=":kill"
-            timeout_seconds="60">
-        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
+
         <stability value="Unstable" />
+
         <template>
             <common_name>
-                <loctext xml:lang="C">
-                    Mattermost - All your team communication in one place, instantly searchable and accessible anywhere.
-                </loctext>
+                <loctext xml:lang="C">Mattermost - All your team communication
+                in one place, instantly searchable and accessible
+                anywhere.</loctext>
             </common_name>
         </template>
-</service>
+
+    </service>
+
 </service_bundle>

--- a/build/minidlna/files/minidlna.xml
+++ b/build/minidlna/files/minidlna.xml
@@ -19,41 +19,60 @@ fields enclosed by brackets "[]" replaced with your own identifying
 information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 -->
+<service_bundle type="manifest"
+                name="minidlna:default">
 
-<service_bundle type="manifest" name="minidlna:default">
-<service name="ooce/multimedia/minidlna" type="service" version="1">
-    <create_default_instance enabled="false" />
-        <dependency name='network' grouping='require_all' restart_on="error" type="service">
-            <service_fmri value='svc:/milestone/network:default' />
+    <service name="ooce/multimedia/minidlna"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
         </dependency>
-        <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <dependency name='config-file' grouping='require_all' restart_on='refresh' type='path'>
-            <service_fmri value='file://localhost/etc/opt/ooce/minidlna/minidlna.conf' />
+
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/minidlna/minidlna.conf" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/minidlna/sbin/minidlnad -R -f /etc/opt/ooce/minidlna/minidlna.conf -P /var/opt/ooce/minidlna/minidlna.pid"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/minidlna/sbin/minidlnad -R -f /etc/opt/ooce/minidlna/minidlna.conf -P /var/opt/ooce/minidlna/minidlna.pid"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="minidlna" group="minidlna" />
+                <method_credential user="minidlna"
+                                   group="minidlna" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec=":kill"
-            timeout_seconds="60">
-        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
+
         <stability value="Unstable" />
+
         <template>
             <common_name>
-                <loctext xml:lang="C">
-                    MiniDLNA - DLNA/UPnP-AV media server
-                </loctext>
+                <loctext xml:lang="C">MiniDLNA - DLNA/UPnP-AV media
+                server</loctext>
             </common_name>
         </template>
-</service>
+
+    </service>
+
 </service_bundle>

--- a/build/minio/files/application-minio.xml
+++ b/build/minio/files/application-minio.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,95 +14,94 @@ http://www.illumos.org/license/CDDL.
 Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="minio:default">
 
-<service_bundle type='manifest' name='minio:default'>
+    <service name="application/minio"
+             type="service"
+             version="1">
 
-<service
-    name='application/minio'
-    type='service'
-    version='1'>
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-    <dependency
-        name='filesystem_local'
-        grouping='require_all'
-        restart_on='none'
-        type='service'>
-        <service_fmri value='svc:/system/filesystem/local:default' />
-    </dependency>
+        <dependency name="multi_user"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user:default" />
+        </dependency>
 
-    <dependency
-        name='multi_user'
-        grouping='require_all'
-        restart_on='none'
-        type='service'>
-        <service_fmri value='svc:/milestone/multi-user:default' />
-    </dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-    <dependency
-        name='loopback'
-        grouping='require_any'
-        restart_on='error'
-        type='service'>
-        <service_fmri value='svc:/network/loopback' />
-    </dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-    <dependency
-        name='network'
-        grouping='optional_all'
-        restart_on='error'
-        type='service'>
-        <service_fmri value='svc:/milestone/network' />
-    </dependency>
+        <dependent name="minio_multi-user-server"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
 
-    <dependent name='minio_multi-user-server'
-        grouping='optional_all'
-        restart_on='none'>
-        <service_fmri value='svc:/milestone/multi-user-server' />
-    </dependent>
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/minio/bin/minio server %{datadir} &amp;"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="minio"
+                                   group="minio" />
+            </method_context>
+        </exec_method>
 
-    <exec_method
-        type='method'
-        name='start'
-        exec="/opt/ooce/minio/bin/minio server %{datadir} &amp;"
-        timeout_seconds='60' >
-        <method_context security_flags='aslr'>
-            <method_credential user='minio' group='minio' />
-        </method_context>
-    </exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-    <exec_method
-        type='method'
-        name='stop'
-        exec=':kill'
-        timeout_seconds='60' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="60"></exec_method>
 
-    <exec_method
-        type='method'
-        name='refresh'
-        exec=':kill -HUP'
-        timeout_seconds='60' >
-    </exec_method>
-
-    <property_group name="startd" type="framework">
-        <propval name="duration" type="astring" value="contract"/>
-    </property_group>
-
-    <instance name="default" enabled="false">
-        <property_group name="application" type="application">
-            <propval name="datadir" type="astring" value="/var/opt/ooce/minio"/>
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
-    </instance>
 
-    <stability value='Unstable' />
+        <instance name="default"
+                  enabled="false">
 
-    <template>
-        <common_name>
-            <loctext xml:lang='C'>
-                MinIO server
-            </loctext>
-        </common_name>
-    </template>
+            <property_group name="application"
+                            type="application">
+                <propval name="datadir"
+                         type="astring"
+                         value="/var/opt/ooce/minio" />
+            </property_group>
 
-</service>
+        </instance>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">MinIO server</loctext>
+            </common_name>
+        </template>
+
+    </service>
 
 </service_bundle>

--- a/build/munin/files/munin-node.xml
+++ b/build/munin/files/munin-node.xml
@@ -14,85 +14,80 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="munin:node">
 
-<service_bundle type='manifest' name='munin:node'>
-<service name='application/munin' type='service' version='1'>
+    <service name="application/munin"
+             type="service"
+             version="1">
 
-	<instance name='node' enabled='false'>
+        <instance name="node"
+                  enabled="false">
 
-	<dependency name='paths'
-	    grouping='require_all'
-	    restart_on='error'
-	    type='path'>
-		<service_fmri
-		   value='file://localhost/etc/$(PREFIX)/munin-node.conf' />
-	</dependency>
+            <dependency name="paths"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="path">
+                <service_fmri value="file://localhost/etc/$(PREFIX)/munin-node.conf" />
+            </dependency>
 
-	<dependency
-		name='loopback'
-		grouping='require_any'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-		name='network'
-		grouping='optional_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependent
-		name='muninnode_multi-user'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <dependent name="muninnode_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/$(PREFIX)/sbin/munin-node'
-	    timeout_seconds='30'>
-	    <method_context security_flags='aslr'>
-		<method_credential user='root' group='root' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="start"
+                         exec="/$(PREFIX)/sbin/munin-node"
+                         timeout_seconds="30">
+                <method_context security_flags="aslr">
+                    <method_credential user="root"
+                                       group="root" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':true'
-	    timeout_seconds='60' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":true"
+                         timeout_seconds="60" />
 
-	</instance>
+        </instance>
 
-	<stability value='Unstable' />
+        <stability value="Unstable" />
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Munin Node
-			</loctext>
-		</common_name>
-	</template>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Munin Node</loctext>
+            </common_name>
+        </template>
 
-</service>
+    </service>
+
 </service_bundle>
-

--- a/build/munin/files/munin-server.xml
+++ b/build/munin/files/munin-server.xml
@@ -14,82 +14,89 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="munin:server">
 
-<service_bundle type='manifest' name='munin:server'>
-<service name="application/munin" type="service" version="1">
+    <service name="application/munin"
+             type="service"
+             version="1">
 
-	<instance name='server' enabled='false'>
+        <instance name="server"
+                  enabled="false">
 
-	<dependency name='cron'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/cron:default' />
-	</dependency>
+            <dependency name="cron"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/cron:default" />
+            </dependency>
 
-	<dependent name='muninserver_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <dependent name="muninserver_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/lib/svc/method/ooce/munin-server %m'
-	    timeout_seconds='60'>
-            <method_context>
-		<method_credential user='$(USER)' group='$(GROUP)'
-		    privileges='basic' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="start"
+                         exec="/lib/svc/method/ooce/munin-server %m"
+                         timeout_seconds="60">
+                <method_context>
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec='/lib/svc/method/ooce/munin-server %m'
-	    timeout_seconds='60'>
-            <method_context>
-		<method_credential user='$(USER)' group='$(GROUP)'
-		    privileges='basic' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="refresh"
+                         exec="/lib/svc/method/ooce/munin-server %m"
+                         timeout_seconds="60">
+                <method_context>
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec='/lib/svc/method/ooce/munin-server %m'
-	    timeout_seconds='60'>
-            <method_context>
-		<method_credential user='$(USER)' group='$(GROUP)'
-		    privileges='basic' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec="/lib/svc/method/ooce/munin-server %m"
+                         timeout_seconds="60">
+                <method_context>
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic" />
+                </method_context>
+            </exec_method>
 
-        <property_group name='startd' type='framework'>
-                <propval name='duration' type='astring' value='transient' />
-        </property_group>
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="transient" />
+            </property_group>
 
-	<property_group name="cronjobs" type="application">
-	    <property name='$(USER)' type='astring'>
-		<astring_list>
-		    <value_node value='*/5 * * * * /$(PREFIX)/bin/munin-cron' />
-		</astring_list>
-	    </property>
-	</property_group>
+            <property_group name="cronjobs"
+                            type="application">
+                <property name="$(USER)"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="*/5 * * * * /$(PREFIX)/bin/munin-cron" />
+                    </astring_list>
+                </property>
+            </property_group>
 
-	</instance>
+        </instance>
 
-	<stability value='Unstable' />
+        <stability value="Unstable" />
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			Munin Server
-			</loctext>
-		</common_name>
-	</template>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Munin Server</loctext>
+            </common_name>
+        </template>
 
-</service>
+    </service>
+
 </service_bundle>
-

--- a/build/nagios-nrpe/files/nrpe.xml
+++ b/build/nagios-nrpe/files/nrpe.xml
@@ -19,42 +19,60 @@ fields enclosed by brackets "[]" replaced with your own identifying
 information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 -->
+<service_bundle type="manifest"
+                name="nrpe:default">
 
-<service_bundle type="manifest" name="nrpe:default">
-<service name="ooce/application/nrpe" type="service" version="1">
-    <create_default_instance enabled="false" />
-        <dependency name='network' grouping='require_all' restart_on="error" type="service">
-            <service_fmri value='svc:/milestone/network:default' />
+    <service name="ooce/application/nrpe"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
         </dependency>
-        <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <dependency name='config-file' grouping='require_all' restart_on='refresh' type='path'>
-            <service_fmri value='file://localhost/etc/opt/ooce/nagios/nrpe.cfg' />
+
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/nagios/nrpe.cfg" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/nagios/bin/nrpe -c /etc/opt/ooce/nagios/nrpe.cfg -d"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/nagios/bin/nrpe -c /etc/opt/ooce/nagios/nrpe.cfg -d"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="nagios" group="nagios" />
+                <method_credential user="nagios"
+                                   group="nagios" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec=":kill"
-            timeout_seconds="60">
-        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
+
         <stability value="Unstable" />
+
         <template>
             <common_name>
-                <loctext xml:lang="C">
-                    NRPE - Nagios Remote Plugin Executor"
-                </loctext>
+                <loctext xml:lang="C">NRPE - Nagios Remote Plugin
+                Executor"</loctext>
             </common_name>
         </template>
-</service>
-</service_bundle>
 
+    </service>
+
+</service_bundle>

--- a/build/nagios-nsca/files/nsca.xml
+++ b/build/nagios-nsca/files/nsca.xml
@@ -19,42 +19,60 @@ fields enclosed by brackets "[]" replaced with your own identifying
 information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 -->
+<service_bundle type="manifest"
+                name="nsca:default">
 
-<service_bundle type="manifest" name="nsca:default">
-<service name="ooce/application/nsca" type="service" version="1">
-    <create_default_instance enabled="false" />
-        <dependency name='network' grouping='require_all' restart_on="error" type="service">
-            <service_fmri value='svc:/milestone/network:default' />
+    <service name="ooce/application/nsca"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
         </dependency>
-        <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <dependency name='config-file' grouping='require_all' restart_on='refresh' type='path'>
-            <service_fmri value='file://localhost/etc/opt/ooce/nagios/nsca.cfg' />
+
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/nagios/nsca.cfg" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/nagios/sbin/nsca -c /etc/opt/ooce/nagios/nsca.cfg"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/nagios/sbin/nsca -c /etc/opt/ooce/nagios/nsca.cfg"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="nagios" group="nagios" />
+                <method_credential user="nagios"
+                                   group="nagios" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec=":kill"
-            timeout_seconds="60">
-        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
+
         <stability value="Unstable" />
+
         <template>
             <common_name>
-                <loctext xml:lang="C">
-                    NSCA - Nagios Service Check Acceptor
-                </loctext>
+                <loctext xml:lang="C">NSCA - Nagios Service Check
+                Acceptor</loctext>
             </common_name>
         </template>
-</service>
-</service_bundle>
 
+    </service>
+
+</service_bundle>

--- a/build/nagios/files/nagios.xml
+++ b/build/nagios/files/nagios.xml
@@ -1,86 +1,84 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-	{{{ CDDL HEADER
+        {{{ CDDL HEADER
 
-	This file and its contents are supplied under the terms of the
-	Common Development and Distribution License ("CDDL"), version 1.0.
-	You may only use this file in accordance with the terms of version
-	1.0 of the CDDL.
-	A full copy of the text of the CDDL should have accompanied this
-	source. A copy of the CDDL is also available via the Internet at
-	http://www.illumos.org/license/CDDL.
+        This file and its contents are supplied under the terms of the
+        Common Development and Distribution License ("CDDL"), version 1.0.
+        You may only use this file in accordance with the terms of version
+        1.0 of the CDDL.
+        A full copy of the text of the CDDL should have accompanied this
+        source. A copy of the CDDL is also available via the Internet at
+        http://www.illumos.org/license/CDDL.
 
-	}}}
+        }}}
 
-	Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+        Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 -->
+<service_bundle type="manifest"
+                name="nagios">
 
-<service_bundle type="manifest" name="nagios">
+    <service name="ooce/application/nagios"
+             type="service"
+             version="1">
 
-<service
-        name="ooce/application/nagios"
-        type="service"
-        version="1">
+        <instance name="default"
+                  enabled="false">
 
-        <instance name='default' enabled='false'>
+            <dependency name="network"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network:default" />
+            </dependency>
 
-        <dependency
-                name='network'
-                grouping='require_all'
-                restart_on="error"
-                type="service">
-                <service_fmri value='svc:/milestone/network:default' />
-        </dependency>
+            <dependency name="filesystem-local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-        <dependency
-                name="filesystem-local"
-                grouping="require_all"
-                restart_on="none"
-                type="service">
-                <service_fmri value="svc:/system/filesystem/local:default"/>
-        </dependency>
+            <dependency name="config-file"
+                        grouping="require_all"
+                        restart_on="refresh"
+                        type="path">
+                <service_fmri value="file://localhost/etc/opt/ooce/nagios/nagios.cfg" />
+            </dependency>
 
-        <dependency
-                name='config-file'
-                grouping='require_all'
-                restart_on='refresh'
-                type='path'>
-                <service_fmri value='file://localhost/etc/opt/ooce/nagios/nagios.cfg' />
-        </dependency>
+            <exec_method type="method"
+                         name="start"
+                         exec="/lib/svc/method/application-nagios start"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="nagios"
+                                       group="nagios" />
+                </method_context>
+            </exec_method>
 
-        <exec_method
-            type="method"
-            name="start"
-            exec="/lib/svc/method/application-nagios start"
-            timeout_seconds="60">
-            <method_context security_flags="aslr">
-                <method_credential user="nagios" group="nagios" />
-            </method_context>
-        </exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec="/lib/svc/method/application-nagios stop"
+                         timeout_seconds="60" />
 
-        <exec_method
-            type="method"
-            name="stop"
-            exec="/lib/svc/method/application-nagios stop"
-            timeout_seconds="60"/>
-
-        <property_group name="startd" type="framework">
-                <propval name="duration" type="astring" value="contract"/>
-        </property_group>
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="contract" />
+            </property_group>
 
         </instance>
 
         <stability value="Unstable" />
 
         <template>
-                <common_name>
-                        <loctext xml:lang="C">
-                        Nagios - Extremely powerful network monitoring system
-                        </loctext>
-                </common_name>
+            <common_name>
+                <loctext xml:lang="C">Nagios - Extremely powerful network
+                monitoring system</loctext>
+            </common_name>
         </template>
 
-</service>
+    </service>
 
 </service_bundle>

--- a/build/nginx/files/http-nginx-template.xml
+++ b/build/nginx/files/http-nginx-template.xml
@@ -20,90 +20,106 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 -->
-<service_bundle type="manifest" name="http:nginx$(sVERSION)">
-<service name="network/http" type="service" version="1">
+<service_bundle type="manifest"
+                name="http:nginx$(sVERSION)">
 
-    <instance name="nginx$(sVERSION)" enabled="false">
+    <service name="network/http"
+             type="service"
+             version="1">
 
-        <dependency name="network" grouping="require_all"
-          restart_on="error" type="service">
-            <service_fmri value="svc:/milestone/network:default"/>
-        </dependency>
+        <instance name="nginx$(sVERSION)"
+                  enabled="false">
 
-        <dependency name="filesystem-local"
-          grouping="require_all" restart_on="none" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
-        </dependency>
+            <dependency name="network"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network:default" />
+            </dependency>
 
-        <dependency name="autofs" grouping="optional_all"
-          restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/autofs:default"/>
-        </dependency>
+            <dependency name="filesystem-local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-        <dependent
-          name='nginx_$(sVERSION)_multi-user'
-          grouping='optional_all'
-          restart_on='none'>
-            <service_fmri value='svc:/milestone/multi-user' />
-        </dependent>
+            <dependency name="autofs"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/autofs:default" />
+            </dependency>
 
-        <exec_method
-          type="method"
-          name="start"
-          exec="%{config/method} %m"
-          timeout_seconds="60">
-            <method_context security_flags="aslr">
-                <method_credential user="nginx" group="nginx"
-                  privileges="basic,net_privaddr,!proc_info,!proc_session" />
-            </method_context>
-        </exec_method>
+            <dependent name="nginx_$(sVERSION)_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-        <exec_method
-          type="method"
-          name="stop"
-          exec="%{config/exec} -s quit"
-          timeout_seconds="60" />
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/method} %m"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="nginx"
+                                       group="nginx"
+                                       privileges="basic,net_privaddr,!proc_info,!proc_session" />
+                </method_context>
+            </exec_method>
 
-        <exec_method
-          type="method"
-          name="refresh"
-          exec="%{config/exec} -s reload"
-          timeout_seconds="60" />
+            <exec_method type="method"
+                         name="stop"
+                         exec="%{config/exec} -s quit"
+                         timeout_seconds="60" />
 
-        <property_group name="startd" type="framework">
-            <propval name="ignore_error" type="astring" value="core,signal" />
-        </property_group>
+            <exec_method type="method"
+                         name="refresh"
+                         exec="%{config/exec} -s reload"
+                         timeout_seconds="60" />
 
-        <property_group name="config" type="application">
-            <propval name="file" type="astring"
-                value="/etc/$(PREFIX)/nginx.conf"/>
-            <propval name="pidfile" type="astring"
-                value="/var/$(OPREFIX)/nginx/run/nginx-$(VERSION).pid"/>
-            <propval name="exec" type="astring"
-                value="/$(PREFIX)/sbin/nginx"/>
-            <propval name="method" type="astring"
-                value="/lib/svc/method/http-nginx$(DsVERSION)"/>
-        </property_group>
+            <property_group name="startd"
+                            type="framework">
+                <propval name="ignore_error"
+                         type="astring"
+                         value="core,signal" />
+            </property_group>
 
-        <template>
-            <common_name>
-                <loctext xml:lang="C"> nginx web server </loctext>
-            </common_name>
-            <documentation>
-                <doc_link name="nginx.org" uri="http://nginx.org/" />
-            </documentation>
-        </template>
+            <property_group name="config"
+                            type="application">
+                <propval name="file"
+                         type="astring"
+                         value="/etc/$(PREFIX)/nginx.conf" />
+                <propval name="pidfile"
+                         type="astring"
+                         value="/var/$(OPREFIX)/nginx/run/nginx-$(VERSION).pid" />
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/sbin/nginx" />
+                <propval name="method"
+                         type="astring"
+                         value="/lib/svc/method/http-nginx$(DsVERSION)" />
+            </property_group>
 
-</instance>
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">nginx web server</loctext>
+                </common_name>
+                <documentation>
+                    <doc_link name="nginx.org"
+                              uri="http://nginx.org/" />
+                </documentation>
+            </template>
 
-<stability value="External" />
+        </instance>
 
-</service>
+        <stability value="External" />
+
+    </service>
+
 </service_bundle>
-

--- a/build/nsd/files/dns-nsd.xml
+++ b/build/nsd/files/dns-nsd.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,92 +14,84 @@ http://www.illumos.org/license/CDDL.
 Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="nsd:default">
 
-<service_bundle type='manifest' name='nsd:default'>
+    <service name="network/dns/nsd"
+             type="service"
+             version="1">
 
-<service
-	name='network/dns/nsd'
-	type='service'
-	version='1'>
+        <create_default_instance enabled="false" />
 
-	<create_default_instance enabled='false' />
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <dependency name="multi_user"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user:default" />
+        </dependency>
 
-	<dependency
-	    name='multi_user'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/milestone/multi-user:default' />
-	</dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependent name="nsd_multi-user-server"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
 
-	<dependent name='nsd_multi-user-server'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user-server' />
-	</dependent>
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/sbin/nsd"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="nsd"
+                                   group="nsd"
+                                   privileges="basic,net_privaddr,!proc_info,!proc_session" />
+            </method_context>
+        </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/opt/ooce/sbin/nsd'
-	    timeout_seconds='60' >
-	    <method_context security_flags='aslr'>
-		<method_credential user='nsd' group='nsd'
-		    privileges='basic,net_privaddr,!proc_info,!proc_session' />
-	    </method_context>
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec="/opt/ooce/sbin/nsd-control reload"
+                     timeout_seconds="60">
+            <method_context>
+                <method_credential user="nsd"
+                                   group="nsd"
+                                   privileges="basic,net_privaddr,!proc_info,!proc_session" />
+            </method_context>
+        </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec='/opt/ooce/sbin/nsd-control reload'
-	    timeout_seconds='60' >
-	    <method_context>
-		<method_credential user='nsd' group='nsd'
-		    privileges='basic,net_privaddr,!proc_info,!proc_session' />
-	    </method_context>
-	</exec_method>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">NSD DNS server</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				NSD DNS server
-			</loctext>
-		</common_name>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>

--- a/build/ooceapps/files/ooceapps.xml
+++ b/build/ooceapps/files/ooceapps.xml
@@ -20,48 +20,70 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="ooceapps">
-<service name="ooce/ooceapps" type="service" version="1">
-    <create_default_instance enabled="false" />
-    <dependency name="network" grouping="require_all" restart_on="error" type="service">
-        <service_fmri value="svc:/milestone/network:default"/>
-    </dependency>
-    <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-        <service_fmri value="svc:/system/filesystem/local:default"/>
-    </dependency>
-    <dependency name="autofs" grouping="optional_all" restart_on="error" type="service">
-        <service_fmri value="svc:/system/filesystem/autofs:default"/>
-    </dependency>
-    <dependency name="config-file" grouping="require_all" restart_on="refresh" type="path">
-        <service_fmri value="file://localhost/etc/opt/ooce/ooceapps/ooceapps.conf" />
-    </dependency>
-    <method_context>
-        <method_credential user="ooceapps" group="ooceapps" />
-    </method_context>
-    <exec_method
-        type="method"
-        name="start"
-        exec="/opt/ooce/ooceapps/bin/ooceapps prefork -m production -l http://127.0.0.1:8000 &amp;"
-        timeout_seconds="60">
-    </exec_method>
-    <exec_method
-        type="method"
-        name="stop"
-        exec=":kill"
-        timeout_seconds="60">
-    </exec_method>
-    <stability value="Unstable" />
-    <template>
-        <common_name>
-            <loctext xml:lang="C">
-            Mattermost integrations for OmniOS Community Edition (OmniOSce) Association.
-            </loctext>
-        </common_name>
-    </template>
-</service>
+<service_bundle type="manifest"
+                name="ooceapps">
+
+    <service name="ooce/ooceapps"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
+        </dependency>
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
+
+        <dependency name="autofs"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/autofs:default" />
+        </dependency>
+
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/ooceapps/ooceapps.conf" />
+        </dependency>
+        <method_context>
+            <method_credential user="ooceapps"
+                               group="ooceapps" />
+        </method_context>
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/ooceapps/bin/ooceapps prefork -m production -l http://127.0.0.1:8000 &amp;"
+                     timeout_seconds="60"></exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Mattermost integrations for OmniOS
+                Community Edition (OmniOSce) Association.</loctext>
+            </common_name>
+        </template>
+
+    </service>
+
 </service_bundle>

--- a/build/openldap/files/openldap.xml
+++ b/build/openldap/files/openldap.xml
@@ -1,9 +1,9 @@
-<?xml version='1.0'?>
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 
     This file and its contents are supplied under the terms of the
-    Common Development and Distribution License ('CDDL'), version 1.0.
+    Common Development and Distribution License ("CDDL"), version 1.0.
     You may only use this file in accordance with the terms of version
     1.0 of the CDDL.
 
@@ -14,95 +14,88 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="openldap">
 
-<service_bundle type='manifest' name='openldap'>
+    <service name="network/openldap"
+             type="service"
+             version="1">
 
-<service name='network/openldap' type='service' version='1'>
+        <instance name="slapd"
+                  enabled="false">
 
-	<instance name='slapd' enabled='false'>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependent name="openldap-server_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
+            <method_context security_flags="aslr">
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic,net_privaddr,!proc_info,!proc_session,!file_link_any" />
+            </method_context>
 
-	<dependent
-	    name='openldap-server_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="/$(PREFIX)/libexec/slapd -f %{config/file} -h '%{config/urls}'"
+                         timeout_seconds="60"></exec_method>
 
-	<method_context security_flags='aslr'>
-		<method_credential user='$(USER)' group='$(GROUP)'
-    privileges='basic,net_privaddr,!proc_info,!proc_session,!file_link_any' />
-	</method_context>
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="300"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/$(PREFIX)/libexec/slapd -f %{config/file} -h "%{config/urls}"'
-	    timeout_seconds='60'>
-	</exec_method>
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":kill -HUP"
+                         timeout_seconds="60"></exec_method>
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='300'>
-	</exec_method>
+            <property_group name="config"
+                            type="application">
+                <propval name="file"
+                         type="astring"
+                         value="/etc/$(PREFIX)/slapd.conf" />
+                <property name="urls"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="ldapi:///" />
+                        <value_node value="ldap:///" />
+                        <value_node value="ldaps:///" />
+                    </astring_list>
+                </property>
+            </property_group>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':kill -HUP'
-	    timeout_seconds='60'>
-	</exec_method>
+        </instance>
 
-	<property_group name='config' type='application'>
-		<propval name='file' type='astring'
-		    value='/etc/$(PREFIX)/slapd.conf'/>
-		<property name='urls' type='astring'>
-			<astring_list>
-				<value_node value='ldapi:///' />
-				<value_node value='ldap:///' />
-				<value_node value='ldaps:///' />
-			</astring_list>
-		</property>
-	</property_group>
+        <stability value="External" />
 
-	</instance>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Openldap LDAP Server</loctext>
+            </common_name>
+        </template>
 
-	<stability value='External' />
-
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Openldap LDAP Server
-			</loctext>
-		</common_name>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>
-

--- a/build/openvpn/files/network-openvpn.xml
+++ b/build/openvpn/files/network-openvpn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,53 +14,70 @@ http://www.illumos.org/license/CDDL.
 Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="openvpn">
 
-<service_bundle type="manifest" name="openvpn">
-    <service name="ooce/network/openvpn" type="service" version="1">
+    <service name="ooce/network/openvpn"
+             type="service"
+             version="1">
 
-        <dependency
-            name='filesystem_local'
-            grouping='require_all'
-            restart_on='none'
-            type='service'>
-            <service_fmri value='svc:/system/filesystem/local:default' />
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
 
-        <dependency
-            name='network'
-            grouping='optional_all'
-            restart_on='error'
-            type='service'>
-            <service_fmri value='svc:/milestone/network' />
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
         </dependency>
 
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/openvpn/sbin/openvpn --cd /etc/opt/ooce/openvpn --config '/etc/opt/ooce/openvpn/%i.conf' --daemon openvpn:%i --log-append '/var/log/opt/ooce/openvpn/%i.log'"
-            timeout_seconds="60">
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/openvpn/sbin/openvpn --cd /etc/opt/ooce/openvpn --config "/etc/opt/ooce/openvpn/%i.conf" --daemon openvpn:%i --log-append "/var/log/opt/ooce/openvpn/%i.log""
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="root" group="root"/>
+                <method_credential user="root"
+                                   group="root" />
             </method_context>
         </exec_method>
 
-        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
 
-        <instance name="server" enabled="false" />
-        <instance name="client" enabled="false" />
+        <instance name="server"
+                  enabled="false" />
+
+        <instance name="client"
+                  enabled="false" />
 
         <stability value="Unstable" />
 
         <template>
-            <common_name> <loctext xml:lang="C"> OpenVPN </loctext> </common_name>
+            <common_name>
+                <loctext xml:lang="C">OpenVPN</loctext>
+            </common_name>
             <documentation>
-                <manpage title="openvpn" section="8" manpath="/opt/ooce/openvpn/share/man" />
-                <doc_link name="openvpn.net" uri="https://openvpn.net/community/" />
+                <manpage title="openvpn"
+                         section="8"
+                         manpath="/opt/ooce/openvpn/share/man" />
+                <doc_link name="openvpn.net"
+                          uri="https://openvpn.net/community/" />
             </documentation>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/php/files/php-template.xml
+++ b/build/php/files/php-template.xml
@@ -14,99 +14,97 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="php$(sVERSION):fpm">
 
-<service_bundle type='manifest' name='php$(sVERSION):fpm'>
+    <service name="application/php$(sVERSION)"
+             type="service"
+             version="1">
 
-<service
-	name='application/php$(sVERSION)'
-	type='service'
-	version='1'>
+        <instance name="default"
+                  enabled="false">
 
-	<instance name='default' enabled='false' >
+            <dependency name="paths"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="path">
+                <service_fmri value="file://localhost/etc/opt/ooce/php-$(VERSION)/php-fpm.conf" />
+            </dependency>
 
-	<dependency name='paths'
-	    grouping='require_all'
-	    restart_on='error'
-	    type='path'>
-		<service_fmri value='file://localhost/etc/opt/ooce/php-$(VERSION)/php-fpm.conf' />
-	</dependency>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependent name="php$(sVERSION)-fpm_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<dependent
-	    name='php$(sVERSION)-fpm_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/method} %m"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="php"
+                                       group="php"
+                                       privileges="basic,!proc_info,!proc_session,!file_link_any" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='%{config/method} %m'
-	    timeout_seconds='60'>
-            <method_context security_flags="aslr">
-		<method_credential user='php' group='php'
-		    privileges='basic,!proc_info,!proc_session,!file_link_any' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec="%{config/method} %m %{restarter/contract}"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec='%{config/method} %m %{restarter/contract}'
-	    timeout_seconds='60' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec="%{config/method} %m %{restarter/contract}"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec='%{config/method} %m %{restarter/contract}'
-	    timeout_seconds='60' />
+            <property_group name="config"
+                            type="application">
+                <propval name="file"
+                         type="astring"
+                         value="/etc/$(PREFIX)/php.ini" />
+                <propval name="pidfile"
+                         type="astring"
+                         value="/var/$(OPREFIX)/php/run/php-$(VERSION)-fpm.pid" />
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/sbin/php-fpm" />
+                <propval name="method"
+                         type="astring"
+                         value="/lib/svc/method/php-$(sVERSION)" />
+            </property_group>
 
-	<property_group name="config" type="application">
-	    <propval name="file" type="astring"
-		value="/etc/$(PREFIX)/php.ini"/>
-	    <propval name="pidfile" type="astring"
-		value="/var/$(OPREFIX)/php/run/php-$(VERSION)-fpm.pid"/>
-            <propval name="exec" type="astring"
-                value="/$(PREFIX)/sbin/php-fpm"/>
-	    <propval name="method" type="astring"
-		value="/lib/svc/method/php-$(sVERSION)"/>
-	</property_group>
+        </instance>
 
-	</instance>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">PHP $(VERSION) FPM</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			PHP $(VERSION) FPM
-			</loctext>
-		</common_name>
-	</template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/postfix/files/smtp-postfix.xml
+++ b/build/postfix/files/smtp-postfix.xml
@@ -1,49 +1,62 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-<service_bundle type="manifest" name="postfix">
-    <service name="network/smtp/postfix" type="service" version="1">
+<service_bundle type="manifest"
+                name="postfix">
 
-        <create_default_instance enabled="false"/>
-        <single_instance/>
+    <service name="network/smtp/postfix"
+             type="service"
+             version="1">
 
-        <dependency name="network" grouping="require_all"
-            restart_on="error" type="service">
-            <service_fmri value="svc:/milestone/network:default"/>
+        <create_default_instance enabled="false" />
+
+        <single_instance />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
         </dependency>
-        <dependency name="filesystem" grouping="require_all"
-            restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/local"/>
+
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
         </dependency>
 
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/sbin/postfix start"
-            timeout_seconds="60">
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/sbin/postfix start"
+                     timeout_seconds="60">
             <method_context security_flags="aslr" />
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec="/opt/ooce/sbin/postfix stop"
-            timeout_seconds="60"/>
-        <exec_method
-            type="method"
-            name="refresh"
-            exec="/opt/ooce/sbin/postfix reload"
-            timeout_seconds="60"/>
 
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+        <exec_method type="method"
+                     name="stop"
+                     exec="/opt/ooce/sbin/postfix stop"
+                     timeout_seconds="60" />
+
+        <exec_method type="method"
+                     name="refresh"
+                     exec="/opt/ooce/sbin/postfix reload"
+                     timeout_seconds="60" />
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
 
-        <stability value="Evolving"/>
+        <stability value="Evolving" />
+
         <template>
             <common_name>
-                <loctext xml:lang="C">
-                    Postfix MTA
-                </loctext>
+                <loctext xml:lang="C">Postfix MTA</loctext>
             </common_name>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/postgresql/files/postgresql-10.xml
+++ b/build/postgresql/files/postgresql-10.xml
@@ -20,48 +20,78 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="postgresql10">
-    <service name="ooce/database/postgresql10" type="service" version="1">
-        <dependency name="filesystem-local" grouping="require_all" restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+<service_bundle type="manifest"
+                name="postgresql10">
+
+    <service name="ooce/database/postgresql10"
+             type="service"
+             version="1">
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/pgsql-10/bin/pg_ctl -D %{datadir} -w start"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/pgsql-10/bin/pg_ctl -D %{datadir} -w start"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec="/opt/ooce/pgsql-10/bin/pg_ctl -D %{datadir} stop"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="stop"
+                     exec="/opt/ooce/pgsql-10/bin/pg_ctl -D %{datadir} stop"
+                     timeout_seconds="60">
             <method_context>
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
-        <instance name="default" enabled="false">
-            <property_group name="application" type="application">
-                <propval name="datadir" type="astring" value="/var/opt/ooce/pgsql/pgsql-10"/>
+
+        <instance name="default"
+                  enabled="false">
+
+            <property_group name="application"
+                            type="application">
+                <propval name="datadir"
+                         type="astring"
+                         value="/var/opt/ooce/pgsql/pgsql-10" />
             </property_group>
+
         </instance>
+
         <stability value="External" />
-        <template> <common_name> <loctext xml:lang="C"> PostgreSQL 10 </loctext> </common_name>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">PostgreSQL 10</loctext>
+            </common_name>
             <documentation>
-                <manpage title="postgres" section="1" manpath="/opt/ooce/pgsql-10/share/man" />
-                <doc_link name="postgresql.org" uri="https://www.postgresql.org/" />
+                <manpage title="postgres"
+                         section="1"
+                         manpath="/opt/ooce/pgsql-10/share/man" />
+                <doc_link name="postgresql.org"
+                          uri="https://www.postgresql.org/" />
             </documentation>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/postgresql/files/postgresql-11.xml
+++ b/build/postgresql/files/postgresql-11.xml
@@ -20,48 +20,78 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="postgresql11">
-    <service name="ooce/database/postgresql11" type="service" version="1">
-        <dependency name="filesystem-local" grouping="require_all" restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+<service_bundle type="manifest"
+                name="postgresql11">
+
+    <service name="ooce/database/postgresql11"
+             type="service"
+             version="1">
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/pgsql-11/bin/pg_ctl -D %{datadir} -w start"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/pgsql-11/bin/pg_ctl -D %{datadir} -w start"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec="/opt/ooce/pgsql-11/bin/pg_ctl -D %{datadir} stop"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="stop"
+                     exec="/opt/ooce/pgsql-11/bin/pg_ctl -D %{datadir} stop"
+                     timeout_seconds="60">
             <method_context>
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
-        <instance name="default" enabled="false">
-            <property_group name="application" type="application">
-                <propval name="datadir" type="astring" value="/var/opt/ooce/pgsql/pgsql-11"/>
+
+        <instance name="default"
+                  enabled="false">
+
+            <property_group name="application"
+                            type="application">
+                <propval name="datadir"
+                         type="astring"
+                         value="/var/opt/ooce/pgsql/pgsql-11" />
             </property_group>
+
         </instance>
+
         <stability value="External" />
-        <template> <common_name> <loctext xml:lang="C"> PostgreSQL 11 </loctext> </common_name>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">PostgreSQL 11</loctext>
+            </common_name>
             <documentation>
-                <manpage title="postgres" section="1" manpath="/opt/ooce/pgsql-11/share/man" />
-                <doc_link name="postgresql.org" uri="https://www.postgresql.org/" />
+                <manpage title="postgres"
+                         section="1"
+                         manpath="/opt/ooce/pgsql-11/share/man" />
+                <doc_link name="postgresql.org"
+                          uri="https://www.postgresql.org/" />
             </documentation>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/postgresql/files/postgresql-12.xml
+++ b/build/postgresql/files/postgresql-12.xml
@@ -20,48 +20,78 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="postgresql12">
-    <service name="ooce/database/postgresql12" type="service" version="1">
-        <dependency name="filesystem-local" grouping="require_all" restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+<service_bundle type="manifest"
+                name="postgresql12">
+
+    <service name="ooce/database/postgresql12"
+             type="service"
+             version="1">
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/pgsql-12/bin/pg_ctl -D %{datadir} -w start"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/pgsql-12/bin/pg_ctl -D %{datadir} -w start"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec="/opt/ooce/pgsql-12/bin/pg_ctl -D %{datadir} stop"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="stop"
+                     exec="/opt/ooce/pgsql-12/bin/pg_ctl -D %{datadir} stop"
+                     timeout_seconds="60">
             <method_context>
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
-        <instance name="default" enabled="false">
-            <property_group name="application" type="application">
-                <propval name="datadir" type="astring" value="/var/opt/ooce/pgsql/pgsql-12"/>
+
+        <instance name="default"
+                  enabled="false">
+
+            <property_group name="application"
+                            type="application">
+                <propval name="datadir"
+                         type="astring"
+                         value="/var/opt/ooce/pgsql/pgsql-12" />
             </property_group>
+
         </instance>
+
         <stability value="External" />
-        <template> <common_name> <loctext xml:lang="C"> PostgreSQL 12 </loctext> </common_name>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">PostgreSQL 12</loctext>
+            </common_name>
             <documentation>
-                <manpage title="postgres" section="1" manpath="/opt/ooce/pgsql-12/share/man" />
-                <doc_link name="postgresql.org" uri="https://www.postgresql.org/" />
+                <manpage title="postgres"
+                         section="1"
+                         manpath="/opt/ooce/pgsql-12/share/man" />
+                <doc_link name="postgresql.org"
+                          uri="https://www.postgresql.org/" />
             </documentation>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/postgresql/files/postgresql-96.xml
+++ b/build/postgresql/files/postgresql-96.xml
@@ -20,48 +20,78 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="postgresql96">
-    <service name="ooce/database/postgresql96" type="service" version="1">
-        <dependency name="filesystem-local" grouping="require_all" restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/local:default"/>
+<service_bundle type="manifest"
+                name="postgresql96">
+
+    <service name="ooce/database/postgresql96"
+             type="service"
+             version="1">
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/pgsql-9.6/bin/pg_ctl -D %{datadir} -w start"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/pgsql-9.6/bin/pg_ctl -D %{datadir} -w start"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <exec_method
-            type="method"
-            name="stop"
-            exec="/opt/ooce/pgsql-9.6/bin/pg_ctl -D %{datadir} stop"
-            timeout_seconds="60">
+
+        <exec_method type="method"
+                     name="stop"
+                     exec="/opt/ooce/pgsql-9.6/bin/pg_ctl -D %{datadir} stop"
+                     timeout_seconds="60">
             <method_context>
-                <method_credential user="postgres" group="postgres" />
+                <method_credential user="postgres"
+                                   group="postgres" />
             </method_context>
         </exec_method>
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
-        <instance name="default" enabled="false">
-            <property_group name="application" type="application">
-                <propval name="datadir" type="astring" value="/var/opt/ooce/pgsql/pgsql-9.6"/>
+
+        <instance name="default"
+                  enabled="false">
+
+            <property_group name="application"
+                            type="application">
+                <propval name="datadir"
+                         type="astring"
+                         value="/var/opt/ooce/pgsql/pgsql-9.6" />
             </property_group>
+
         </instance>
+
         <stability value="External" />
-        <template> <common_name> <loctext xml:lang="C"> PostgreSQL 9.6 </loctext> </common_name>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">PostgreSQL 9.6</loctext>
+            </common_name>
             <documentation>
-                <manpage title="postgres" section="1" manpath="/opt/ooce/pgsql-9.6/share/man" />
-                <doc_link name="postgresql.org" uri="https://www.postgresql.org/" />
+                <manpage title="postgres"
+                         section="1"
+                         manpath="/opt/ooce/pgsql-9.6/share/man" />
+                <doc_link name="postgresql.org"
+                          uri="https://www.postgresql.org/" />
             </documentation>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/sasl2/files/saslauthd.xml
+++ b/build/sasl2/files/saslauthd.xml
@@ -1,9 +1,9 @@
-<?xml version='1.0'?>
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 
     This file and its contents are supplied under the terms of the
-    Common Development and Distribution License ('CDDL'), version 1.0.
+    Common Development and Distribution License ("CDDL"), version 1.0.
     You may only use this file in accordance with the terms of version
     1.0 of the CDDL.
 
@@ -14,82 +14,81 @@
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="saslauthd">
 
-<service_bundle type='manifest' name='saslauthd'>
-<service name='system/saslauthd' type='service' version='1'>
+    <service name="system/saslauthd"
+             type="service"
+             version="1">
 
-	<create_default_instance enabled='false'/>
+        <create_default_instance enabled="false" />
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<dependent
-	    name='saslauthd_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+        <dependent name="saslauthd_multi-user"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user" />
+        </dependent>
+        <method_context security_flags="aslr">
+            <method_credential user="root"
+                               group="sasl"
+                               privileges="basic,!proc_info,!proc_session,!file_link_any" />
+        </method_context>
 
-	<method_context security_flags='aslr'>
-		<method_credential user='root' group='sasl'
-                  privileges='basic,!proc_info,!proc_session,!file_link_any' />
-	</method_context>
+        <exec_method type="method"
+                     name="start"
+                     exec="/$(PREFIX)/sbin/saslauthd -a %{config/mech} -c -m %{config/dir}"
+                     timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/$(PREFIX)/sbin/saslauthd -a %{config/mech} -c -m %{config/dir}'
-	    timeout_seconds='60' />
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="180" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='180' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':kill -HUP'
-	    timeout_seconds='60' />
+        <property_group name="config"
+                        type="application">
+            <propval name="mech"
+                     type="astring"
+                     value="pam" />
+            <propval name="dir"
+                     type="astring"
+                     value="/var/run/saslauthd" />
+        </property_group>
 
-	<property_group name='config' type='application'>
-		<propval name='mech' type='astring' value='pam'/>
-		<propval name='dir' type='astring'
-		    value='/var/run/saslauthd'/>
-	</property_group>
+        <stability value="External" />
 
-	<stability value='External' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Cyrus SaSL authentication
+                Server</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Cyrus SaSL authentication Server
-			</loctext>
-		</common_name>
-	</template>
+    </service>
 
-</service>
 </service_bundle>
-

--- a/build/smartmontools/files/system-smartd.xml
+++ b/build/smartmontools/files/system-smartd.xml
@@ -20,52 +20,66 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
     Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="smartd">
-<service name="system/smartd" type="service" version="1">
-    <create_default_instance
-        enabled="false" />
+<service_bundle type="manifest"
+                name="smartd">
 
-    <single_instance/>
+    <service name="system/smartd"
+             type="service"
+             version="1">
 
-    <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-        <service_fmri value="svc:/system/filesystem/local:default"/>
-    </dependency>
-    <dependency name="autofs" grouping="optional_all" restart_on="error" type="service">
-        <service_fmri value="svc:/system/filesystem/autofs:default"/>
-    </dependency>
-    <dependency name="config-file" grouping="require_all" restart_on="refresh" type="path">
-        <service_fmri value="file://localhost/etc/opt/ooce/smartmontools/smartd.conf" />
-    </dependency>
+        <create_default_instance enabled="false" />
 
-    <exec_method
-        type="method"
-        name="start"
-        exec="/opt/ooce/sbin/smartd --pidfile=/var/opt/ooce/smartmontools/run/smartd.pid --savestates=/var/opt/ooce/smartmontools/"
-        timeout_seconds="60">
-        <method_context security_flags="aslr">
-            <method_credential
-                user='root'
-                group='root' />
-        </method_context>
-    </exec_method>
-    <exec_method
-        type="method"
-        name="stop"
-        exec=":kill"
-        timeout_seconds="60">
-    </exec_method>
+        <single_instance />
 
-    <stability value="Unstable" />
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-    <template>
-        <common_name>
-            <loctext xml:lang="C"> smartmontools - Control and monitor storage systems using SMART </loctext>
-        </common_name>
-    </template>
-</service>
+        <dependency name="autofs"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/autofs:default" />
+        </dependency>
+
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/smartmontools/smartd.conf" />
+        </dependency>
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/sbin/smartd --pidfile=/var/opt/ooce/smartmontools/run/smartd.pid --savestates=/var/opt/ooce/smartmontools/"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="root"
+                                   group="root" />
+            </method_context>
+        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">smartmontools - Control and monitor
+                storage systems using SMART</loctext>
+            </common_name>
+        </template>
+
+    </service>
+
 </service_bundle>

--- a/build/subversion/files/subversion.xml
+++ b/build/subversion/files/subversion.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,61 +14,79 @@ http://www.illumos.org/license/CDDL.
 Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="subversion">
 
-<service_bundle type="manifest" name="subversion">
-    <service name="ooce/network/subversion" type="service" version="1">
+    <service name="ooce/network/subversion"
+             type="service"
+             version="1">
 
-
-        <dependency
-            name='filesystem_local'
-            grouping='require_all'
-            restart_on='none'
-            type='service'>
-            <service_fmri value='svc:/system/filesystem/local:default' />
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
         </dependency>
 
-        <dependency
-            name='network'
-            grouping='optional_all'
-            restart_on='error'
-            type='service'>
-            <service_fmri value='svc:/milestone/network' />
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
         </dependency>
 
-        <exec_method
-            type="method"
-            name="start"
-            exec="/opt/ooce/subversion/bin/svnserve -d -r %{repository_root}
-                    --log-file  %{logfile}"
-            timeout_seconds="60">
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/subversion/bin/svnserve -d -r %{repository_root} --log-file %{logfile}"
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="subversion" group="subversion"/>
+                <method_credential user="subversion"
+                                   group="subversion" />
             </method_context>
         </exec_method>
 
-        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-        <property_group name="startd" type="framework">
-            <propval name="duration" type="astring" value="contract"/>
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
         </property_group>
-  
-        <instance name='default' enabled='false'>
-            <property_group name='application' type='application'>
-                <propval name='repository_root' type='astring'
-                                  value='/var/opt/ooce/subversion' />
-                <propval name='logfile' type='astring'
-                                  value='/var/log/opt/ooce/subversion/svnserve.log'/>
+
+        <instance name="default"
+                  enabled="false">
+
+            <property_group name="application"
+                            type="application">
+                <propval name="repository_root"
+                         type="astring"
+                         value="/var/opt/ooce/subversion" />
+                <propval name="logfile"
+                         type="astring"
+                         value="/var/log/opt/ooce/subversion/svnserve.log" />
             </property_group>
+
         </instance>
 
         <stability value="Unstable" />
 
         <template>
-            <common_name> <loctext xml:lang="C"> Subversion </loctext> </common_name>
+            <common_name>
+                <loctext xml:lang="C">Subversion</loctext>
+            </common_name>
             <documentation>
-                <manpage title="svnserve" section="8" manpath="/opt/ooce/subversion/share/man" />
-                <doc_link name="subversion.apache.org" uri="https://subversion.apache.org/docs/" />
+                <manpage title="svnserve"
+                         section="8"
+                         manpath="/opt/ooce/subversion/share/man" />
+                <doc_link name="subversion.apache.org"
+                          uri="https://subversion.apache.org/docs/" />
             </documentation>
         </template>
+
     </service>
+
 </service_bundle>

--- a/build/unbound/files/dns-unbound.xml
+++ b/build/unbound/files/dns-unbound.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,101 +14,91 @@ http://www.illumos.org/license/CDDL.
 Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="unbound:default">
 
-<service_bundle type='manifest' name='unbound:default'>
+    <service name="network/dns/unbound"
+             type="service"
+             version="1">
 
-<service
-	name='network/dns/unbound'
-	type='service'
-	version='1'>
+        <create_default_instance enabled="false" />
 
-	<create_default_instance enabled='false' />
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <dependency name="multi_user"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user:default" />
+        </dependency>
 
-	<dependency
-	    name='multi_user'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/milestone/multi-user:default' />
-	</dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependency name="config_data"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="path">
+            <service_fmri value="file://localhost/etc/opt/ooce/unbound/unbound.conf" />
+        </dependency>
 
-	<dependency
-	    name='config_data'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='path'>
-		<service_fmri
-		    value='file://localhost/etc/opt/ooce/unbound/unbound.conf' />
-	</dependency>
+        <dependent name="unbound_multi-user-server"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
 
-	<dependent name='unbound_multi-user-server'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user-server' />
-	</dependent>
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/unbound/sbin/unbound"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="unbound"
+                                   group="unbound"
+                                   privileges="basic,net_privaddr,!proc_info,!proc_session" />
+            </method_context>
+        </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/opt/ooce/unbound/sbin/unbound'
-	    timeout_seconds='60' >
-	    <method_context security_flags='aslr'>
-		<method_credential user='unbound' group='unbound'
-		    privileges='basic,net_privaddr,!proc_info,!proc_session' />
-	    </method_context>
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec="/opt/ooce/unbound/sbin/unbound-control reload"
+                     timeout_seconds="60">
+            <method_context>
+                <method_credential user="unbound"
+                                   group="unbound"
+                                   privileges="basic,net_privaddr,!proc_info,!proc_session" />
+            </method_context>
+        </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec='/opt/ooce/unbound/sbin/unbound-control reload'
-	    timeout_seconds='60' >
-	    <method_context>
-		<method_credential user='unbound' group='unbound'
-		    privileges='basic,net_privaddr,!proc_info,!proc_session' />
-	    </method_context>
-	</exec_method>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Unbound DNS resolver</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Unbound DNS resolver
-			</loctext>
-		</common_name>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>

--- a/build/zabbix/files/zabbix-agent.xml
+++ b/build/zabbix/files/zabbix-agent.xml
@@ -1,88 +1,80 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest"
+                name="zabbix:agent">
 
-<service_bundle type='manifest' name='zabbix:agent'>
+    <service name="network/zabbix"
+             type="service"
+             version="1">
 
-<service
-	name='network/zabbix'
-	type='service'
-	version='1'>
+        <instance name="agent"
+                  enabled="false">
 
-	<instance name='agent' enabled='false'>
+            <dependency name="paths"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="path">
+                <service_fmri value="file://localhost/etc/$(PREFIX)/zabbix_agentd.conf" />
+            </dependency>
 
-	<dependency name='paths'
-	    grouping='require_all'
-	    restart_on='error'
-	    type='path'>
-		<service_fmri
-		   value='file://localhost/etc/$(PREFIX)/zabbix_agentd.conf' />
-	</dependency>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-		name='loopback'
-		grouping='require_any'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-		name='network'
-		grouping='optional_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependent name="zabbixagent_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<dependent
-		name='zabbixagent_multi-user'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="/$(PREFIX)/sbin/zabbix_agentd"
+                         timeout_seconds="30">
+                <method_context security_flags="aslr">
+                    <method_credential user="$(AGENTUSER)"
+                                       group="$(GROUP)"
+                                       privileges="basic" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/$(PREFIX)/sbin/zabbix_agentd'
-	    timeout_seconds='30'>
-	    <method_context security_flags='aslr'>
-		<method_credential user='$(AGENTUSER)' group='$(GROUP)'
-		    privileges='basic' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":true"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':true'
-	    timeout_seconds='60' />
+        </instance>
 
-	</instance>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Zabbix Agent</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Zabbix Agent
-			</loctext>
-		</common_name>
-	</template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/zabbix/files/zabbix-server.xml
+++ b/build/zabbix/files/zabbix-server.xml
@@ -1,88 +1,80 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest"
+                name="zabbix:server">
 
-<service_bundle type='manifest' name='zabbix:server'>
+    <service name="network/zabbix"
+             type="service"
+             version="1">
 
-<service
-	name='network/zabbix'
-	type='service'
-	version='1'>
+        <instance name="server"
+                  enabled="false">
 
-	<instance name='server' enabled='false'>
+            <dependency name="paths"
+                        grouping="require_all"
+                        restart_on="error"
+                        type="path">
+                <service_fmri value="file://localhost/etc/$(PREFIX)/zabbix_server.conf" />
+            </dependency>
 
-	<dependency name='paths'
-	    grouping='require_all'
-	    restart_on='error'
-	    type='path'>
-		<service_fmri
-		   value='file://localhost/etc/$(PREFIX)/zabbix_server.conf' />
-	</dependency>
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
 
-	<dependency
-		name='loopback'
-		grouping='require_any'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
 
-	<dependency
-		name='network'
-		grouping='optional_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+            <dependent name="zabbixserver_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
 
-	<dependent
-		name='zabbixserver_multi-user'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="/$(PREFIX)/sbin/zabbix_server"
+                         timeout_seconds="30">
+                <method_context security_flags="aslr">
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic,!proc_info,!proc_session,!file_link_any" />
+                </method_context>
+            </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/$(PREFIX)/sbin/zabbix_server'
-	    timeout_seconds='30'>
-	    <method_context security_flags='aslr'>
-		<method_credential user='$(USER)' group='$(GROUP)'
-		    privileges='basic,!proc_info,!proc_session,!file_link_any' />
-	    </method_context>
-	</exec_method>
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":true"
+                         timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':true'
-	    timeout_seconds='60' />
+        </instance>
 
-	</instance>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Zabbix Server</loctext>
+            </common_name>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				Zabbix Server
-			</loctext>
-		</common_name>
-	</template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/znapzend/files/system-znapzend.xml
+++ b/build/znapzend/files/system-znapzend.xml
@@ -20,40 +20,64 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!--
 Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 Use is subject to license terms.
 -->
-<service_bundle type="manifest" name="znapzend">
-<service name="ooce/system/znapzend" type="service" version="1">
-	<create_default_instance enabled="false" />
-	<single_instance/>
-    <dependency name="filesystem-local" grouping="require_all" restart_on="none" type="service">
-        <service_fmri value="svc:/system/filesystem/local:default"/>
-    </dependency>
-    <dependency name="autofs" grouping="optional_all" restart_on="error" type="service">
-        <service_fmri value="svc:/system/filesystem/autofs:default"/>
-    </dependency>
-    <exec_method
-        type="method"
-        name="start"
-        exec="/opt/ooce/znapzend/bin/znapzend --daemonize --features=recvu --pidfile=/var/opt/ooce/znapzend/run/znapzend.pid"
-        timeout_seconds="180">
-    </exec_method>
-    <exec_method
-        type="method"
-        name="stop"
-        exec=":kill"
-        timeout_seconds="30">
-    </exec_method>
-    <stability value="Unstable" />
-    <template> <common_name> <loctext xml:lang="C"> ZnapZend - ZFS backup system </loctext> </common_name>
-        <documentation>
-            <manpage title="znapzend" section="1" manpath="/opt/ooce/share/man" />
-            <manpage title="znapzendzetup" section="1" manpath="/opt/ooce/share/man" />
-            <manpage title="znapzendztatz" section="1" manpath="/opt/ooce/share/man" />
-        </documentation>
-    </template>
-</service>
+<service_bundle type="manifest"
+                name="znapzend">
+
+    <service name="ooce/system/znapzend"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <single_instance />
+
+        <dependency name="filesystem-local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
+
+        <dependency name="autofs"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/autofs:default" />
+        </dependency>
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/znapzend/bin/znapzend --daemonize --features=recvu --pidfile=/var/opt/ooce/znapzend/run/znapzend.pid"
+                     timeout_seconds="180"></exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="30"></exec_method>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">ZnapZend - ZFS backup system</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="znapzend"
+                         section="1"
+                         manpath="/opt/ooce/share/man" />
+                <manpage title="znapzendzetup"
+                         section="1"
+                         manpath="/opt/ooce/share/man" />
+                <manpage title="znapzendztatz"
+                         section="1"
+                         manpath="/opt/ooce/share/man" />
+            </documentation>
+        </template>
+
+    </service>
+
 </service_bundle>

--- a/build/znc/files/znc.xml
+++ b/build/znc/files/znc.xml
@@ -1,8 +1,8 @@
-<?xml version='1.0'?>
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
  This file and its contents are supplied under the terms of the
- Common Development and Distribution License ('CDDL'), version 1.0.
+ Common Development and Distribution License ("CDDL"), version 1.0.
  You may only use this file in accordance with the terms of version
  1.0 of the CDDL.
 
@@ -10,60 +10,70 @@
  source. A copy of the CDDL is also available via the Internet at
  http://www.illumos.org/license/CDDL.
 -->
-
 <!--
     Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 -->
-<service_bundle type='manifest' name='network:znc'>
-<service name='network/znc' type='service' version='1'>
+<service_bundle type="manifest"
+                name="network:znc">
 
-	<create_default_instance enabled='false' />
-	<single_instance/>
+    <service name="network/znc"
+             type="service"
+             version="1">
 
-	<dependency name='network' grouping='require_all'
-	    restart_on='error' type='service'>
-	    <service_fmri value='svc:/milestone/network:default'/>
-	</dependency>
+        <create_default_instance enabled="false" />
 
-	<dependency name='filesystem' grouping='require_all'
-	    restart_on='error' type='service'>
-	    <service_fmri value='svc:/system/filesystem/local'/>
-	</dependency>
+        <single_instance />
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/opt/ooce/bin/znc --datadir=/var/opt/ooce/znc'
-	    timeout_seconds='60'>
-	     <method_context security_flags='aslr'>
-		<method_credential user='znc' group='znc'
-		    privileges='basic,!proc_info,!proc_session' />
-	    </method_context>
-	</exec_method>
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
+        </dependency>
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60'/>
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':true'
-	    timeout_seconds='60'/>
+        <exec_method type="method"
+                     name="start"
+                     exec="/opt/ooce/bin/znc --datadir=/var/opt/ooce/znc"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="znc"
+                                   group="znc"
+                                   privileges="basic,!proc_info,!proc_session" />
+            </method_context>
+        </exec_method>
 
-	<property_group name='startd' type='framework'>
-	    <propval name='duration' type='astring' value='contract'/>
-	</property_group>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<stability value='Evolving'/>
-	<template>
-	    <common_name>
-		<loctext xml:lang='C'>
-		    ZNC IRC Bouncer
-		</loctext>
-	    </common_name>
-	</template>
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":true"
+                     timeout_seconds="60" />
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
+        </property_group>
+
+        <stability value="Evolving" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">ZNC IRC Bouncer</loctext>
+            </common_name>
+        </template>
+
     </service>
+
 </service_bundle>

--- a/build/zrepl/files/zrepl.xml
+++ b/build/zrepl/files/zrepl.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-
 <!--
 
 This file and its contents are supplied under the terms of the
@@ -15,98 +14,89 @@ http://www.illumos.org/license/CDDL.
 Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="zrepl:default">
 
-<service_bundle type='manifest' name='zrepl:default'>
+    <service name="system/zrepl"
+             type="service"
+             version="1">
 
-<service
-	name='system/zrepl'
-	type='service'
-	version='1'>
+        <create_default_instance enabled="false" />
 
-	<create_default_instance enabled='false' />
+        <single_instance />
 
-	<single_instance/>
+        <dependency name="filesystem_local"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local:default" />
+        </dependency>
 
-	<dependency
-	    name='filesystem_local'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/system/filesystem/local:default' />
-	</dependency>
+        <dependency name="multi_user"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user:default" />
+        </dependency>
 
-	<dependency
-	    name='multi_user'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-		<service_fmri value='svc:/milestone/multi-user:default' />
-	</dependency>
+        <dependency name="loopback"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency
-	    name='loopback'
-	    grouping='require_any'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="network"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependency
-	    name='network'
-	    grouping='optional_all'
-	    restart_on='error'
-	    type='service'>
-		<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependent name="zrepl_multi-user-server"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
 
-	<dependent name='zrepl_multi-user-server'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user-server' />
-	</dependent>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/zrepl start %{config/file}"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr" />
+        </exec_method>
 
-	<exec_method
-	    type='method'
-	    name='start'
-	    exec='/lib/svc/method/zrepl start %{config/file}'
-	    timeout_seconds='60' >
-	    <method_context security_flags='aslr' />
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-	    type='method'
-	    name='stop'
-	    exec=':kill'
-	    timeout_seconds='60' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="60"></exec_method>
+        <!--
 
-	<exec_method
-	    type='method'
-	    name='refresh'
-	    exec=':kill -HUP'
-	    timeout_seconds='60' >
-	</exec_method>
-
-<!--
-	<property_group name='startd' type='framework'>
-		<propval name='duration' type='astring' value='child' />
-	</property_group>
+        <property_group name="startd" type="framework">
+                <propval name="duration" type="astring" value="child" />
+        </property_group>
 -->
 
-	<property_group name='config' type='application'>
-		<propval name='file' type='astring'
-		    value='/etc/opt/ooce/zrepl/zrepl.yml' />
-	</property_group>
+        <property_group name="config"
+                        type="application">
+            <propval name="file"
+                     type="astring"
+                     value="/etc/opt/ooce/zrepl/zrepl.yml" />
+        </property_group>
 
-	<stability value='Unstable' />
+        <stability value="Unstable" />
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				zrepl - ZFS Replication Service
-			</loctext>
-		</common_name>
-	</template>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">zrepl - ZFS Replication Service</loctext>
+            </common_name>
+        </template>
 
-</service>
+    </service>
 
 </service_bundle>

--- a/doc/tidy.conf
+++ b/doc/tidy.conf
@@ -1,0 +1,7 @@
+indent: yes
+indent-spaces: 4
+indent-attributes: yes
+wrap: 80
+wrap-attributes: yes
+output-xml: yes
+input-xml: yes

--- a/tools/tidy-manifests
+++ b/tools/tidy-manifests
@@ -1,0 +1,55 @@
+#!/bin/ksh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+tidy=/opt/ooce/bin/tidy
+__SCRIPTDIR="${0%/*}"
+
+ELEMENTS=(
+        '<service '
+        '<create_default_instance'
+        '<single_instance'
+        '<instance'
+        '<dependency'
+        '<dependent'
+        '<exec_method'
+        '<property_group'
+        '<template'
+        '<stability'
+        '<\/service'
+        '<\/instance'
+)
+
+echo "PROCESSING: $1"
+
+# tidy manifest according to doc/tidy.conf
+$tidy -q -config $__SCRIPTDIR/../doc/tidy.conf -m $1
+if [ $? -gt 0 ]; then
+    echo "An error occurred processing $1!"
+    exit 0
+fi
+
+# use only double quotes in manifest and check for nested quotes
+gsed -i 's/'"'"'/"/g' $1
+gsed 's/[^"]//g' $1 | awk '{ if(length !=2 && length !=0) print \
+    "WARNING: may contain nested quotes!";}'
+
+# introduce spacing for readability between elements
+for i in "${ELEMENTS[@]}"
+do
+    gsed -i "/$i/s/^/\n/" $1
+    if [ $? -gt 0 ]; then
+        echo "An error occurred processing $1!"
+        exit 0
+    fi
+done
+


### PR DESCRIPTION
OK, this is a starting point...
does not format quotes as this may need manual inspection for nested quotes.
formatting for license indentation is needed, will look at adding this tomorrow.
At the moment I am not familiar with which base directories to use etc, tomorrow I will inspect the other `tools/` scripts and update this script. 
For the moment, this will give us formatted manifests and then the conf file can be discussed with which preferences are desired.