### PR TITLE
cyrus: Replace patches with upstream PR version

### DIFF
--- a/build/cyrus/patches/memrchr.patch
+++ b/build/cyrus/patches/memrchr.patch
@@ -1,25 +1,100 @@
-diff -wpruN '--exclude=*.orig' a~/imap/conversations.c a/imap/conversations.c
---- a~/imap/conversations.c	1970-01-01 00:00:00
-+++ a/imap/conversations.c	1970-01-01 00:00:00
-@@ -513,6 +513,21 @@ EXPORTED int conversations_commit(struct
-     return r;
- }
+
+Raised as PR upstream - https://github.com/cyrusimap/cyrus-imapd/pull/3172
+
+commit 61dc24a8235c0f5cd379135d436b05a2b8c808d1
+Author: Andy Fiddaman <omnios@citrus-it.co.uk>
+Date:   Fri Sep 4 16:14:57 2020 +0000
+
+    Not all systems have memrchr()
+
+diff -wpruN '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -193,7 +193,7 @@ dnl check for -R, etc. switch
+ CMU_GUESS_RUNPATH_SWITCH
  
-+static void *
-+memrchr(const void *s, int c, size_t n)
-+{
-+    const unsigned char *cp;
+ AC_CHECK_HEADERS(unistd.h sys/select.h sys/param.h stdarg.h)
+-AC_REPLACE_FUNCS(memmove strcasecmp ftruncate strerror posix_fadvise strsep memmem)
++AC_REPLACE_FUNCS(memmove strcasecmp ftruncate strerror posix_fadvise strsep memmem memrchr)
+ AC_CHECK_FUNCS(strlcat strlcpy strnchr getgrouplist fmemopen pselect futimes futimesat)
+ AC_HEADER_DIRENT
+ 
+@@ -2352,6 +2352,10 @@ extern char *strsep(char **, const char
+ extern void *memmem(const void *, size_t, const void *, size_t);
+ #endif
+ 
++#ifndef HAVE_MEMRCHR
++extern void *memrchr(const void *, int, size_t);
++#endif
 +
+ /* compile time options; think carefully before modifying */
+ enum {
+     /* should we send an UNAVAILABLE message to master when
+diff -wpruN '--exclude=*.orig' a~/lib/memrchr.c a/lib/memrchr.c
+--- a~/lib/memrchr.c	1970-01-01 00:00:00
++++ a/lib/memrchr.c	1970-01-01 00:00:00
+@@ -0,0 +1,64 @@
++/* memrchr.c -- replacement memrchr() routine
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *
++ * 3. The name "Carnegie Mellon University" must not be used to
++ *    endorse or promote products derived from this software without
++ *    prior written permission. For permission or any legal
++ *    details, please contact
++ *      Carnegie Mellon University
++ *      Center for Technology Transfer and Enterprise Creation
++ *      4615 Forbes Avenue
++ *      Suite 302
++ *      Pittsburgh, PA  15213
++ *      (412) 268-7393, fax: (412) 268-7395
++ *      innovation@andrew.cmu.edu
++ *
++ * 4. Redistributions of any form whatsoever must retain the following
++ *    acknowledgment:
++ *    "This product includes software developed by Computing Services
++ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
++ *
++ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
++ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
++ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
++ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
++ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
++ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++#include <config.h>
++#ifdef HAVE_STRING_H
++#include <string.h>
++#endif
++
++/*
++ * Reverse memchr()
++ * memrchr() is a GNU extension and not available on all platforms
++ */
++void *
++memrchr(const void *s, int c1, size_t n)
++{
 +    if (n != 0) {
-+	cp = (unsigned char *)s + n;
-+	do {
-+	    if (*(--cp) == (unsigned char)c)
-+		return (void *)cp;
-+	} while (--n != 0);
++        const unsigned char *sp = (unsigned char *)s + n;
++        unsigned char c = (unsigned char)c1;
++
++        do {
++            if (*(--sp) == c)
++                return((void *)sp);
++        } while (--n != 0);
 +    }
 +    return NULL;
 +}
 +
- static int check_msgid(const char *msgid, size_t len, size_t *lenp)
- {
-     if (msgid == NULL)

--- a/build/cyrus/patches/timespec.patch
+++ b/build/cyrus/patches/timespec.patch
@@ -1,21 +1,55 @@
+
+Raised as PR upstream - https://github.com/cyrusimap/cyrus-imapd/pull/3174
+
+commit 98bf19e382b0161386adece9ff9a1ba07ed0bf60
+Author: Andy Fiddaman <omnios@citrus-it.co.uk>
+Date:   Sat Sep 5 15:06:29 2020 +0000
+
+    Not all systems have futimes() or TIMESPEC_TO_TIMEVAL()
+
+diff -wpruN '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -194,7 +194,7 @@ CMU_GUESS_RUNPATH_SWITCH
+ 
+ AC_CHECK_HEADERS(unistd.h sys/select.h sys/param.h stdarg.h)
+ AC_REPLACE_FUNCS(memmove strcasecmp ftruncate strerror posix_fadvise strsep memmem)
+-AC_CHECK_FUNCS(strlcat strlcpy strnchr getgrouplist fmemopen pselect)
++AC_CHECK_FUNCS(strlcat strlcpy strnchr getgrouplist fmemopen pselect futimes futimesat)
+ AC_HEADER_DIRENT
+ 
+ dnl check whether to use getpassphrase or getpass
 diff -wpruN '--exclude=*.orig' a~/lib/util.c a/lib/util.c
 --- a~/lib/util.c	1970-01-01 00:00:00
 +++ a/lib/util.c	1970-01-01 00:00:00
-@@ -572,9 +572,17 @@ static int _copyfile_helper(const char *
- 
-     if (keeptime) {
+@@ -574,7 +574,13 @@ static int _copyfile_helper(const char *
          struct timeval tv[2];
-+#ifdef __sun
-+	tv[0].tv_sec = sbuf.st_atime;
-+	tv[0].tv_usec = 0;
-+ 	tv[1].tv_sec = sbuf.st_mtime;
-+ 	tv[1].tv_usec = 0;
-+        if (futimesat(destfd, NULL, tv)) {
-+#else
          TIMESPEC_TO_TIMEVAL(&tv[0], &sbuf.st_atim);
          TIMESPEC_TO_TIMEVAL(&tv[1], &sbuf.st_mtim);
++#if defined(HAVE_FUTIMES)
          if (futimes(destfd, tv)) {
++#elif defined(HAVE_FUTIMESAT)
++	if (futimesat(destfd, NULL, tv)) {
++#else
++	if (utimes(to, tv)) {
 +#endif
              syslog(LOG_ERR, "IOERROR: setting times on %s: %m", to);
              r = -1;
          }
+diff -wpruN '--exclude=*.orig' a~/lib/util.h a/lib/util.h
+--- a~/lib/util.h	1970-01-01 00:00:00
++++ a/lib/util.h	1970-01-01 00:00:00
+@@ -148,6 +148,13 @@ extern const unsigned char convert_to_up
+ /* Calculate the number of entries in a vector */
+ #define VECTOR_SIZE(vector) (sizeof(vector)/sizeof(vector[0]))
+ 
++#ifndef TIMESPEC_TO_TIMEVAL
++#define TIMESPEC_TO_TIMEVAL(tv, ts) { \
++        (tv)->tv_sec = (ts)->tv_sec; \
++        (tv)->tv_usec = (ts)->tv_nsec / 1000; \
++}
++#endif
++
+ typedef struct keyvalue {
+     char *key, *value;
+ } keyvalue;


### PR DESCRIPTION
Since the cyrus work, I've opened a couple of upstream PRs against cyrus-imapd.
This is to replace the previous local patches with the versions that are hopefully going upstream.