### PR TITLE
Build postfix with sqlite3, mariadb and postgresql support

### DIFF
--- a/build/postfix/build.sh
+++ b/build/postfix/build.sh
@@ -40,6 +40,8 @@ BUILD_DEPENDS_IPS="
     library/pcre
     ooce/database/bdb
     ooce/database/lmdb
+    ooce/library/postgresql-${PGSQLVER//./}
+    ooce/library/mariadb-${MARIASQLVER//./}
     ooce/library/security/libsasl2
 "
 
@@ -56,7 +58,7 @@ configure64() {
     LIBDIR=${OPREFIX}/lib/${ISAPART64}
     logcmd $MAKE makefiles CCARGS='-m64 \
         -DUSE_TLS -DHAS_DB -DHAS_LMDB -DNO_NIS -DHAS_LDAP \
-        -DUSE_SASL_AUTH -DUSE_CYRUS_SASL \
+        -DHAS_SQLITE -DHAS_MYSQL -DHAS_PGSQL -DUSE_SASL_AUTH -DUSE_CYRUS_SASL \
         -DDEF_COMMAND_DIR=\"'${PREFIX}/sbin'\" \
         -DDEF_CONFIG_DIR=\"'${CONFPATH}'\" \
         -DDEF_DAEMON_DIR=\"'${PREFIX}/libexec/postfix'\" \
@@ -66,9 +68,14 @@ configure64() {
         -DDEF_SENDMAIL_PATH=\"'${PREFIX}/sbin/sendmail'\" \
         -I'${OPREFIX}/include' \
         -I'${OPREFIX}/include/sasl' \
+        -I'${OPREFIX}/mariadb-${MARIASQLVER}/include/mysql' \
+        -I'${OPREFIX}/pgsql-${PGSQLVER}/include' \
         ' \
         AUXLIBS="-R$LIBDIR -L$LIBDIR -ldb -lsasl2 -lssl -lcrypto" \
         AUXLIBS_LDAP="-lldap_r -llber" \
+        AUXLIBS_SQLITE="-lsqlite3" \
+        AUXLIBS_MYSQL="-L${OPREFIX}/mariadb-${MARIASQLVER}/lib/${ISAPART64} -R ${OPREFIX}/mariadb-${MARIASQLVER}/lib/${ISAPART64} -lmysqlclient" \
+        AUXLIBS_PGSQL="-L${OPREFIX}/pgsql-${PGSQLVER}/lib/${ISAPART64} -R ${OPREFIX}/pgsql-${PGSQLVER}/lib/${ISAPART64} -lpq" \
         AUXLIBS_LMDB="-R$LIBDIR -L$LIBDIR -llmdb" \
             || logerr "Failed make makefiles command"
 }


### PR DESCRIPTION
Given we now depend on cyrus sasl libs which depends on mariadb and PostgreSQL this change is low hanging fruit that
has little impact on the postfix package. The only changes are:

+depend type=require fmri=pkg:/ooce/library/mariadb-104
+depend type=require fmri=pkg:/ooce/library/postgresql-12

for the newly published package. I myself don't use mysql or postgresql tables in my postfix installs but people might
and we can give them what they want for no additional costs other than these small build changes.