### PR TITLE
Fix package name extraction

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -56,11 +56,14 @@ add_manifests() {
 }
 
 extract_pkgs() {
-    grep 'PKG=' $1 | grep -v '##IGNORE##' | sed -e '
-        s/^ +//
-        s/ +#.+//
-        s/=/ /g
-    ' | nawk '$1 == "PKG" { print $2 }'
+    sed -En '
+        /##IGNORE##/d
+        /\<PKG=[^[:space:]]+[[:space:]]*(#.*)?$/ {
+            s/.*PKG=/PKG=/
+            s/[[:space:]]+#.+//
+            s/=/ /g
+            p
+    }' $1 | nawk '$1 == "PKG" { print $2 }'
 }
 
 add_buildscripts() {

--- a/build/mariadb/build-104.sh
+++ b/build/mariadb/build-104.sh
@@ -161,7 +161,8 @@ install_smf -oocemethod ooce $PROG-$sMAJVER.xml $PROG-$sMAJVER
 build_manifests
 PKG=${PKG/database/library} SUMMARY+=" client and libraries" \
     make_package -seed $TMPDIR/manifest.client
-make_package -seed $TMPDIR/manifest.server server.mog
+RUN_DEPENDS_IPS=${PKG/database/library} \
+    make_package -seed $TMPDIR/manifest.server server.mog
 clean_up
 
 # Vim hints

--- a/build/mariadb/build-105.sh
+++ b/build/mariadb/build-105.sh
@@ -161,7 +161,8 @@ install_smf -oocemethod ooce $PROG-$sMAJVER.xml $PROG-$sMAJVER
 build_manifests
 PKG=${PKG/database/library} SUMMARY+=" client and libraries" \
     make_package -seed $TMPDIR/manifest.client
-make_package -seed $TMPDIR/manifest.server server.mog
+RUN_DEPENDS_IPS=${PKG/database/library} \
+    make_package -seed $TMPDIR/manifest.server server.mog
 clean_up
 
 # Vim hints

--- a/build/subversion/build.sh
+++ b/build/subversion/build.sh
@@ -69,7 +69,7 @@ strip_install
 install_smf application $PROG.xml
 make_package svn.mog
 
-PKG=ooce/server/apache-$sAPACHEVER/modules/subversion
+PKG=ooce/server/apache-$sAPACHEVER/modules/subversion ##IGNORE##
 SUMMARY="Subversion module for Apache Web Server $APACHEVER"
 DESC="$SUMMARY"
 make_package module.mog

--- a/build/zabbix/build.sh
+++ b/build/zabbix/build.sh
@@ -154,8 +154,8 @@ done
 add_notes README.server-install
 
 build_manifests
-PKG=$PKG-agent make_package -seed $TMPDIR/mf.agent agent.mog ##IGNORE##
-PKG=$PKG-server make_package -seed $TMPDIR/mf.server server.mog ##IGNORE##
+PKG=$PKG-agent make_package -seed $TMPDIR/mf.agent agent.mog
+PKG=$PKG-server make_package -seed $TMPDIR/mf.server server.mog
 
 clean_up
 

--- a/tools/audit
+++ b/tools/audit
@@ -148,11 +148,14 @@ add_target()
 
 extract_pkgs()
 {
-    grep 'PKG=' $1 | grep -v '##IGNORE##' | sed -e '
-        s/^ +//
-        s/ +#.+//
-        s/=/ /g
-    ' | nawk '$1 == "PKG" { print $2 }'
+    sed -nE '
+        /##IGNORE##/d
+        /\<PKG=[^[:space:]]+[[:space:]]*(#.*)?$/ {
+            s/.*PKG=/PKG=/
+            s/[[:space:]]+#.+//
+            s/=/ /g
+            p
+    }' $1 | nawk '$1 == "PKG" { print $2 }'
 }
 
 add_buildscripts()

--- a/tools/test
+++ b/tools/test
@@ -88,11 +88,14 @@ add_manifests()
 
 extract_pkgs()
 {
-	grep 'PKG=' $1 | grep -v '##IGNORE##' | sed -e '
-		s/^ +//
-		s/ +#.+//
-		s/=/ /g
-	' | nawk '$1 == "PKG" { print $2 }'
+    sed -nE '
+        /##IGNORE##/d
+        /\<PKG=[^[:space:]]+[[:space:]]*(#.*)?$/ {
+            s/.*PKG=/PKG=/
+            s/[[:space:]]+#.+//
+            s/=/ /g
+            p
+    }' $1 | nawk '$1 == "PKG" { print $2 }'
 }
 
 add_buildscripts()


### PR DESCRIPTION
```
build:omnios-extra:split% ./buildctl list > new
build:omnios-extra:split% git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
build:omnios-extra:master% yes | ./buildctl list > old

--- old 2020-09-17 19:22:09.947301641 +0000
+++ new 2020-09-17 19:19:01.039124478 +0000
@@ -1,10 +1,4 @@
- * ${PKG/database/library}
- * ${PKG/network/library}
  * ooce/application/fcgiwrap
  * ooce/application/gitea
  * ooce/application/gnuplot
@@ -142,7 +136,6 @@
  * ooce/runtime/ruby-27
  * ooce/runtime/tcl
  * ooce/security/gnupg
- * ooce/server/apache-$sAPACHEVER/modules/subversion
  * ooce/server/apache-24
  * ooce/server/nginx
  * ooce/server/nginx-118
```