### PR TITLE
stop building lxadm which has been superseded by zadm

### DIFF
--- a/build/lxadm/build.sh
+++ b/build/lxadm/build.sh
@@ -34,6 +34,9 @@ DESC=$SUMMARY   # Longer description, must be filled in
 BUILDARCH=32    # or 64 or both ... for libraries we want both for tools 32 bit only
 PREFIX=/opt/ooce
 
+# lxadm has been superseded by zadm
+[ $RELVER -ge 151035 ] && exit 0
+
 set_mirror "$GITHUB/hadfl/$PROG/releases/download"
 set_checksum sha256 \
     9dd4f70767dd3d04e1df9b45e931cd71cb9868da3f7532395244ad23e2993dc4

--- a/doc/baseline
+++ b/doc/baseline
@@ -102,7 +102,6 @@ extra.omnios ooce/library/serf
 extra.omnios ooce/library/slang
 extra.omnios ooce/library/tiff
 extra.omnios ooce/library/unistring
-extra.omnios ooce/lxadm
 extra.omnios ooce/multimedia/exif
 extra.omnios ooce/multimedia/ffmpeg
 extra.omnios ooce/multimedia/minidlna

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -97,7 +97,6 @@
 | ooce/library/slang		| 2.3.2		| https://www.jedsoft.org/releases/slang/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/tiff		| 4.1.0		| https://download.osgeo.org/libtiff/ https://libtiff.gitlab.io/libtiff/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/unistring	| 0.9.10	| https://ftp.gnu.org/gnu/libunistring/ | [omniosorg](https://github.com/omniosorg)
-| ooce/lxadm			| 0.1.6		| https://github.com/hadfl/lxadm/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/exif		| 0.6.21	| https://sourceforge.net/projects/libexif/files/exif/ | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/ffmpeg	| 4.3.1		| https://www.ffmpeg.org/download.html#releases | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/minidlna	| 1.2.1		| https://sourceforge.net/projects/minidlna/files/minidlna/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
bye bye `lxadm`