### PR TITLE
Add HEIC support to ImageMagick

### DIFF
--- a/build/imagemagick/local.mog
+++ b/build/imagemagick/local.mog
@@ -1,4 +1,3 @@
-# {{{ CDDL HEADER START
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
@@ -8,7 +7,7 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-# }}}
+#
 
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
@@ -25,4 +24,6 @@
 <transform path=$(PREFIX)/share/doc -> drop >
 
 license LICENSE license=ImageMagick
+license ../libde265-$(LIBDE265)/COPYING license=LGPLv3
+license ../libheif-$(LIBHEIF)/COPYING license=LGPLv3
 

--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -37,6 +37,7 @@ depend fmri=ooce/library/libogg type=require
 depend fmri=ooce/library/libpng type=require
 depend fmri=ooce/library/libvncserver type=require
 depend fmri=ooce/library/libvorbis type=require
+depend fmri=ooce/library/libwebp type=require
 depend fmri=ooce/library/onig type=require
 depend fmri=ooce/library/openldap type=require
 depend fmri=ooce/library/pango type=require

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -73,11 +73,13 @@
 | ooce/library/icu4c		| 67.1		| https://github.com/unicode-org/icu/releases | Currently used solely by cyrus-imapd
 | ooce/library/jansson		| 2.13.1	| https://github.com/akheron/jansson/releases | Currently used solely by cyrus-imapd
 | ooce/library/libarchive	| 3.4.3		| https://libarchive.org/downloads/ | [omniosorg](https://github.com/omniosorg)
+| ooce/library/libde265		| 1.0.6		| https://github.com/strukturag/libde265/releases | Currently used solely by ImageMagick
 | ooce/library/libgd		| 2.3.0		| https://github.com/libgd/libgd/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libical		| 3.0.8		| https://github.com/libical/libical/releases | Currently used solely by cyrus-imapd
 | ooce/library/libev		| 4.33		| http://dist.schmorp.de/libev/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libexif		| 0.6.21	| https://sourceforge.net/projects/libexif/files/libexif/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libgif		| 5.2.1		| https://sourceforge.net/projects/giflib/files/ | [omniosorg](https://github.com/omniosorg)
+| ooce/library/libheif		| 1.8.0		| https://github.com/strukturag/libheif/releases | Currently used solely by ImageMagick
 | ooce/library/libid3tag	| 0.15.1b	| https://sourceforge.net/projects/mad/files/libid3tag/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libidl		| 0.8.14	| https://download.gnome.org/sources/libIDL/cache.json https://download.gnome.org/sources/libIDL/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libjpeg-turbo	| 2.0.5		| https://sourceforge.net/projects/libjpeg-turbo/files/ | [omniosorg](https://github.com/omniosorg)

--- a/tools/test
+++ b/tools/test
@@ -54,6 +54,10 @@ add_target()
 				targets["ooce/library/jansson"]=`pver JANSSONVER`
 				targets["ooce/library/libical"]=`pver ICALVER`
 				;;
+			*/imagemagick:*)
+				targets["ooce/library/libde265"]=`pver LIBDE265VER`
+				targets["ooce/library/libheif"]=`pver LIBHEIFVER`
+				;;
 		esac
 		targets[$pkg]=$ver
 	elif [[ $build = *.p5m ]]; then


### PR DESCRIPTION
Adding HEIC image and webp compression support for imagemagick.
HEIC is a format used by default on images taken with recent IOS versions