### PR TITLE
set mediator-priority to vendor for server packages

### DIFF
--- a/build/mariadb/server.mog
+++ b/build/mariadb/server.mog
@@ -16,3 +16,5 @@ dir group=mysql mode=0700 owner=mysql path=var/$(PREFIX)/data
 <transform file path=$(PREFIX)/bin/mysqld$ \
     -> set restart_fmri svc:/ooce/database/$(PROG)$(sVERSION):default>
 
+<transform link mediator=$(PROG) -> set mediator-priority vendor>
+

--- a/build/postgresql/server.mog
+++ b/build/postgresql/server.mog
@@ -13,6 +13,8 @@
 dir group=postgres mode=0700 owner=postgres \
     path=var/opt/ooce/pgsql/pgsql-$(VERSION)
 
-<transform file path=$(PREFIX)/(lib|bin)/ \
+<transform file path=$(PREFIX)/(?:lib|bin)/ \
     -> set restart_fmri svc:/ooce/database/$(PROG)$(sVERSION):default>
+
+<transform link mediator=$(MEDIATOR) -> set mediator-priority vendor>
 


### PR DESCRIPTION
This is necessary because otherwise installing just the library package from a higher version changes the mediator. The mediator should only be changed automatically by server packages.