### PR TITLE
add imagick php extension

### DIFF
--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -7,6 +7,9 @@ depend fmri=ooce/omnios-build-tools type=require
 depend fmri=driver/tuntap type=require
 depend fmri=library/unixodbc type=require
 depend fmri=ooce/application/graphviz type=require
+depend fmri=ooce/application/imagemagick type=require
+depend fmri=ooce/application/php-73 type=require
+depend fmri=ooce/application/php-74 type=require
 depend fmri=ooce/audio/flac type=require
 depend fmri=ooce/database/bdb type=require
 depend fmri=ooce/database/lmdb type=require

--- a/build/php-imagick/build.sh
+++ b/build/php-imagick/build.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=php-imagick
+VER=3.4.4
+PKG=ooce/application/php-XX/imagick
+SUMMARY="The Imagick PHP extension"
+DESC="The Imagick PHP extension"
+
+PHPVERSIONS="7.3 7.4"
+
+set_arch 64
+set_builddir imagick-$VER
+
+SKIP_LICENCES=PHP
+SKIP_RTIME=1
+
+CONFIGURE_OPTS_64="
+    --with-imagick=$PREFIX/ImageMagick
+"
+
+init
+prep_build
+
+# Needs to be after prep_build which sets DESTDIR
+MAKE_INSTALL_ARGS="
+    INSTALL_ROOT=$DESTDIR
+"
+
+download_source $PROG $VER
+patch_source
+
+for p in $PHPVERSIONS; do
+    [ -n "$FLAVOR" -a "$FLAVOR" != $p ] && continue
+    note -n "Building For PHP $p"
+    run_inbuild $PREFIX/php-$p/bin/phpize --clean
+    logcmd rm -rf $DESTDIR/$PREFIX/
+    run_inbuild $PREFIX/php-$p/bin/phpize
+    PATH="$PREFIX/php-$p/bin:$PATH" build
+    strip_install
+    PKG=${PKG/XX/${p//./}} \
+        RUN_DEPENDS_IPS="${PKG%/*}" \
+        DESC+=" $p" \
+        make_package
+done
+
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/php-imagick/local.mog
+++ b/build/php-imagick/local.mog
@@ -1,0 +1,14 @@
+
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=PHP
+

--- a/build/php-imagick/patches/amd64.patch
+++ b/build/php-imagick/patches/amd64.patch
@@ -1,0 +1,12 @@
+diff -u imagick-3.4.4~/imagemagick.m4 imagick-3.4.4/imagemagick.m4
+--- imagick-3.4.4~/imagemagick.m4	2019-05-02 15:31:59.000000000 +0000
++++ imagick-3.4.4/imagemagick.m4	2020-09-28 20:01:24.591692450 +0000
+@@ -123,7 +123,7 @@
+   AC_MSG_RESULT([found in $IM_WAND_BINARY])
+ 
+ # This is used later for cflags and libs
+-  export PKG_CONFIG_PATH="${IM_IMAGEMAGICK_PREFIX}/${PHP_LIBDIR}/pkgconfig"
++  export PKG_CONFIG_PATH="${IM_IMAGEMAGICK_PREFIX}/${PHP_LIBDIR}/amd64/pkgconfig"
+   
+ # Check version
+ #

--- a/build/php-imagick/patches/series
+++ b/build/php-imagick/patches/series
@@ -1,0 +1,1 @@
+amd64.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -17,6 +17,7 @@
 | ooce/application/php-72	| 7.2.33	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-73	| 7.3.22	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-74	| 7.4.10	| https://www.php.net/downloads.php | [omniosorg](https://github.com/omniosorg)
+| ooce/application/php-XX/imagick	| 3.4.4	| https://github.com/Imagick/imagick/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/texlive	| 20200406	| ftp://tug.org/historic/systems/texlive/2020/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tidy		| 5.6.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vagrant	| 2.2.10	| https://github.com/hashicorp/vagrant/releases | [omniosorg](https://github.com/omniosorg)

--- a/tools/audit
+++ b/tools/audit
@@ -115,6 +115,14 @@ add_target()
                 aver="`grep '^APACHEVER=' $build | cut -d= -f2`"
                 pkg=ooce/server/apache-${aver//./}/modules/subversion
                 ;;
+            */php-XX/*:*)
+                pver=`grep '^PHPVERSIONS=' $build | cut -d= -f2 \
+                    | cut -d '"' -f2`
+                for p in $pver; do
+                    targets[${pkg/XX/${p//./}}]=$ver
+                done
+                pkg=
+                ;;
             *:github-latest*)
                 ver=`github_latest $pkg $ver`
                 ;;
@@ -133,7 +141,7 @@ add_target()
         ## Strip leading zeros in version components.
         ver=`echo $ver | sed -e 's/\.0*\([1-9]\)/.\1/g;'`
 
-        targets[$pkg]=$ver
+        [ -n "$pkg" ] && targets[$pkg]=$ver
     elif [[ $build = *.p5m ]]; then
         egrep -q 'pkg.obsolete.*true' $build && return
         egrep -q 'pkg.renamed.*true' $build && return


### PR DESCRIPTION
Tested that audit picks up PHP versions correctly

```
hawkeye% ./tools/audit -f -p php
Package                                Version          bloody         r151034         r151032         r151030
-------                                -------          ------         -------         -------         -------
application/php-72                      7.2.33          7.2.33          7.2.33          7.2.33          7.2.33
application/php-73                      7.3.22          7.3.22          7.3.22          7.3.22          7.3.22
application/php-73/imagick               3.4.4              --              --              --              --
application/php-74                      7.4.10          7.4.10          7.4.10          7.4.10          7.4.10
application/php-74/imagick               3.4.4              --              --              --              --
hawkeye%
```