### PR TITLE
update isc-bind 9.11.23 > 9.11.24

### DIFF
--- a/build/isc-bind9/build-911.sh
+++ b/build/isc-bind9/build-911.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=bind
-VER=9.11.23
+VER=9.11.24
 PKG=ooce/network/bind-911
 SUMMARY="ISC BIND DNS Server & Tools"
 DESC="Server & Client Utilities for DNS"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -105,7 +105,7 @@
 | ooce/multimedia/exif		| 0.6.21	| https://sourceforge.net/projects/libexif/files/exif/ | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/ffmpeg	| 4.3.1		| https://www.ffmpeg.org/download.html#releases | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/minidlna	| 1.2.1		| https://sourceforge.net/projects/minidlna/files/minidlna/ | [omniosorg](https://github.com/omniosorg)
-| ooce/network/bind-911		| 9.11.23	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
+| ooce/network/bind-911		| 9.11.24	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/cyrus-imapd	| 3.2.4		| https://github.com/cyrusimap/cyrus-imapd/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/fping		| 5.0		| https://github.com/schweikert/fping/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/irssi		| 1.2.2		| https://github.com/irssi/irssi/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
--- 9.11.24 released ---

5516.	[func]		The default EDNS buffer size has been changed from 4096
			to 1232 bytes. [GL #2183]

5513.	[doc]		The ARM section describing the "rrset-order" statement
			was rewritten to make it unambiguous and up-to-date with
			the source code. [GL #2139]

5510.	[bug]		Implement the attach/detach semantics for dns_message_t
			to fix a data race in accessing an already-destroyed
			fctx->rmessage. [GL #2124]

5506.	[bug]		Properly handle failed sysconf() calls, so we don't
			report invalid memory size. [GL #2166]

* update installed and tested using dig