### PR TITLE
ImageMagick update to 7.0.10-34

### DIFF
--- a/build/imagemagick/build.sh
+++ b/build/imagemagick/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=ImageMagick
-VER=7.0.10-31
+VER=7.0.10-34
 PKG=ooce/application/imagemagick
 SUMMARY="$PROG - Convert, Edit, or Compose Bitmap Images"
 DESC="Use $PROG to create, edit, compose, or convert bitmap images. It can "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -4,7 +4,7 @@
 | ooce/application/gitea	| 1.12.5	| https://github.com/go-gitea/gitea/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/gnuplot	| 5.4.0		| https://sourceforge.net/projects/gnuplot/files/gnuplot/ http://www.gnuplot.info/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/graphviz	| 2.44.1	| https://www2.graphviz.org/Packages/stable/portable_source/ https://graphviz.org/download/source/ | [omniosorg](https://github.com/omniosorg)
-| ooce/application/imagemagick	| 7.0.10-31	| https://imagemagick.org/download/ | [omniosorg](https://github.com/omniosorg)
+| ooce/application/imagemagick	| 7.0.10-34	| https://imagemagick.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mattermost	| 5.28.0	| https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mc		| 4.8.25	| http://ftp.midnight-commander.org/?C=N;O=D | [omniosorg](https://github.com/omniosorg)
 | ooce/application/munin	| 2.0.64	| http://downloads.munin-monitoring.org/munin/stable/?C=N;O=D | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
sub libraries not updated as they are still current
`testsuite.log` output is same as previous version