### PR TITLE
mattermost 5.28.0 > 5.28.1

### DIFF
--- a/build/mattermost/build.sh
+++ b/build/mattermost/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=mattermost
-VER=5.28.0
+VER=5.28.1
 MMCTLVER=5.28.0
 PKG=ooce/application/mattermost
 SUMMARY="$PROG"

--- a/build/mattermost/patches-mattermost-server/release.mk.patch
+++ b/build/mattermost/patches-mattermost-server/release.mk.patch
@@ -2,9 +2,9 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
 --- a~/build/release.mk	1970-01-01 00:00:00
 +++ a/build/release.mk	1970-01-01 00:00:00
 @@ -1,6 +1,10 @@
- 
+
  dist: | check-style test package
- 
+
 +build-illumos:
 +	@echo Build illumos amd64
 +	env GOOS=illumos GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./...
@@ -12,10 +12,10 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
  build-linux:
  	@echo Build Linux amd64
  ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
-@@ -78,118 +82,8 @@
+@@ -106,118 +110,8 @@ endif
  	cp NOTICE.txt $(DIST_PATH)
  	cp README.md $(DIST_PATH)
- 
+
 -	@# Import Mattermost plugin public key
 -	gpg --import build/plugin-production-public-key.gpg
 -
@@ -41,7 +41,7 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
 -	cp $(GOBIN)/darwin_amd64/mattermost $(DIST_PATH)/bin # from cross-compiled bin dir
 -	cp $(GOBIN)/darwin_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
 -endif
--	MMCTL_FILE="darwin_amd64.tar" && curl -f -O -L https://github.com/mattermost/mmctl/releases/download/$(MMCTL_REL_TO_DOWNLOAD)/$$MMCTL_FILE && tar -xvf $$MMCTL_FILE -C $(DIST_PATH)/bin && rm $$MMCTL_FILE
+-	MMCTL_FILE="darwin_amd64.tar" && curl -f -O -L https://releases.mattermost.com/mmctl/v5.28.0/$$MMCTL_FILE && tar -xvf $$MMCTL_FILE -C $(DIST_PATH)/bin && rm $$MMCTL_FILE
 -	@# Prepackage plugins
 -	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 -		ARCH="osx-amd64"; \
@@ -65,7 +65,7 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
 -	rm -f $(DIST_PATH)/bin/platform
 -	rm -f $(DIST_PATH)/bin/mmctl
 -	rm -f $(DIST_PATH)/prepackaged_plugins/*
- 
+-
 -	@# Make windows package
 -	@# Copy binary
 -ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
@@ -75,7 +75,7 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
 -	cp $(GOBIN)/windows_amd64/mattermost.exe $(DIST_PATH)/bin # from cross-compiled bin dir
 -	cp $(GOBIN)/windows_amd64/platform.exe $(DIST_PATH)/bin # from cross-compiled bin dir
 -endif
--	MMCTL_FILE="windows_amd64.zip" && curl -f -O -L https://github.com/mattermost/mmctl/releases/download/$(MMCTL_REL_TO_DOWNLOAD)/$$MMCTL_FILE && unzip -o $$MMCTL_FILE -d $(DIST_PATH)/bin && rm $$MMCTL_FILE
+-	MMCTL_FILE="windows_amd64.zip" && curl -f -O -L https://releases.mattermost.com/mmctl/v5.28.0/$$MMCTL_FILE && unzip -o $$MMCTL_FILE -d $(DIST_PATH)/bin && rm $$MMCTL_FILE
 -	@# Prepackage plugins
 -	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 -		ARCH="windows-amd64"; \
@@ -109,7 +109,7 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
 -	cp $(GOBIN)/linux_amd64/mattermost $(DIST_PATH)/bin # from cross-compiled bin dir
 -	cp $(GOBIN)/linux_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
 -endif
--	MMCTL_FILE="linux_amd64.tar" && curl -f -O -L https://github.com/mattermost/mmctl/releases/download/$(MMCTL_REL_TO_DOWNLOAD)/$$MMCTL_FILE && tar -xvf $$MMCTL_FILE -C $(DIST_PATH)/bin && rm $$MMCTL_FILE
+-	MMCTL_FILE="linux_amd64.tar" && curl -f -O -L https://releases.mattermost.com/mmctl/v5.28.0/$$MMCTL_FILE && tar -xvf $$MMCTL_FILE -C $(DIST_PATH)/bin && rm $$MMCTL_FILE
 -	@# Prepackage plugins
 -	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 -		ARCH="linux-amd64"; \
@@ -130,5 +130,5 @@ diff -wpruN '--exclude=*.orig' a/src/github.com/mattermost/mattermost-server~/bu
 -	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-linux-amd64.tar.gz mattermost
 -	@# Don't clean up native package so dev machines will have an unzipped package available
 -	@#rm -f $(DIST_PATH)/bin/mattermost
--
+
 -	rm -rf tmpprepackaged

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -5,7 +5,7 @@
 | ooce/application/gnuplot	| 5.4.0		| https://sourceforge.net/projects/gnuplot/files/gnuplot/ http://www.gnuplot.info/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/graphviz	| 2.44.1	| https://www2.graphviz.org/Packages/stable/portable_source/ https://graphviz.org/download/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/imagemagick	| 7.0.10-34	| https://imagemagick.org/download/ | [omniosorg](https://github.com/omniosorg)
-| ooce/application/mattermost	| 5.28.0	| https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive | [omniosorg](https://github.com/omniosorg)
+| ooce/application/mattermost	| 5.28.1	| https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mc		| 4.8.25	| http://ftp.midnight-commander.org/?C=N;O=D | [omniosorg](https://github.com/omniosorg)
 | ooce/application/munin	| 2.0.64	| http://downloads.munin-monitoring.org/munin/stable/?C=N;O=D | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mutt		| 1.14.7	| http://www.mutt.org/download.html | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
updated build completes without any complications, after updating `release.mk.patch`.