### PR TITLE
OpenVPN - Fix missing install of man page

### DIFF
--- a/build/openvpn/build.sh
+++ b/build/openvpn/build.sh
@@ -85,6 +85,7 @@ fi
 
 download_source $PROG $PROG $VER
 patch_source
+run_autoreconf -i
 build
 install_config
 install_smf network network-openvpn.xml

--- a/build/openvpn/patches/manpage.patch
+++ b/build/openvpn/patches/manpage.patch
@@ -1,0 +1,17 @@
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 340dd553..df2f54a3 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -67,10 +67,11 @@ dist_html_DATA = openvpn.8.html
+ CLEANFILES = \
+         openvpn.8 openvpn.8.html
+
++endif
++
+ if WIN32
+ else
+ dist_man_MANS = openvpn.8
+ endif
+-endif
+
+ dist-hook : openvpn.8 openvpn.8.html

--- a/build/openvpn/patches/series
+++ b/build/openvpn/patches/series
@@ -1,0 +1,1 @@
+manpage.patch


### PR DESCRIPTION
Regression in 2.5.0 that caused the `openvpn.8` man page not to be installed if `python-docutils` was not installed on the system.

This has been reported upstream and the included patch has been supplied by OpenVPN developers. 

I have tested build on OmniOS and this completes successfully.

However I had to add `run_autoreconf -i` to `build.sh` as `make` failed with:
```
...
configure.ac:59: error: version mismatch.  This is Automake 1.16.2,
configure.ac:59: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:59: comes from Automake 1.16.1.  You should recreate
configure.ac:59: aclocal.m4 with aclocal and run automake again.
WARNING: 'automake-1.16' is probably too old.
...
```
OpenVPN Mailing List message:
https://sourceforge.net/p/openvpn/mailman/message/37140022/