### PR TITLE
Include pdo-pgsql support in PHP 7.4

### DIFF
--- a/build/php/build-74.sh
+++ b/build/php/build-74.sh
@@ -100,6 +100,7 @@ CONFIGURE_OPTS_64="
     --with-png
     --with-freetype
     --with-pgsql=$OPREFIX/pgsql-$PGSQLVER
+    --with-pdo-pgsql=$OPREFIX/pgsql-$PGSQLVER
 
     --enable-fpm
     --with-fpm-user=php


### PR DESCRIPTION
Requested by OmniOS user ( https://illumos.topicbox.com/groups/omnios-discuss/T64335220c445c7bf-Mf5c08bc1cf2cccadd67cd45e/php74-pdo-pgsql ) and since we already include postgres support, it's a simple addition.

With this change, phpinfo output includes:

```
pdo_pgsql

PDO Driver for PostgreSQL => enabled
PostgreSQL(libpq) Version => 12.4

pgsql

PostgreSQL Support => enabled
PostgreSQL(libpq) Version => 12.4
PostgreSQL(libpq)  => PostgreSQL 12.4 on x86_64-pc-solaris2.11, compiled by gcc (OmniOS 151036/10.2.0-il-0) 10.2.0, 64-bit
Multibyte character support => enabled
SSL support => enabled
Active Persistent Links => 0
Active Links => 0
```