### PR TITLE
Library updates

### DIFF
--- a/build/libjpeg-turbo/build.sh
+++ b/build/libjpeg-turbo/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=libjpeg-turbo
-VER=2.0.5
+VER=2.0.6
 PKG=ooce/library/libjpeg-turbo
 SUMMARY="libjpeg-turbo"
 DESC="SIMD-accelerated libjpeg-compatible JPEG codec library"

--- a/build/protobuf/build.sh
+++ b/build/protobuf/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=protobuf
-VER=3.13.0
+VER=3.14.0
 PKG=ooce/library/protobuf
 SUMMARY="protobuf"
 DESC="Google's language-neutral, platform-neutral, extensible mechanism "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -86,7 +86,7 @@
 | ooce/library/libheif		| 1.9.1		| https://github.com/strukturag/libheif/releases | Currently used solely by ImageMagick
 | ooce/library/libid3tag	| 0.15.1b	| https://sourceforge.net/projects/mad/files/libid3tag/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libidl		| 0.8.14	| https://download.gnome.org/sources/libIDL/cache.json https://download.gnome.org/sources/libIDL/ | [omniosorg](https://github.com/omniosorg)
-| ooce/library/libjpeg-turbo	| 2.0.5		| https://sourceforge.net/projects/libjpeg-turbo/files/ | [omniosorg](https://github.com/omniosorg)
+| ooce/library/libjpeg-turbo	| 2.0.6		| https://sourceforge.net/projects/libjpeg-turbo/files/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libmcrypt	| 2.5.8		| https://sourceforge.net/projects/mcrypt/files/Libmcrypt/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libogg		| 1.3.4		| https://ftp.osuosl.org/pub/xiph/releases/ogg/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libpciaccess	| 0.16		| https://xorg.freedesktop.org/archive/individual/lib | [drscream](https://github.com/drscream)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -97,7 +97,7 @@
 | ooce/library/libzip		| 1.7.3		| https://libzip.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/onig		| 6.9.6		| https://github.com/kkos/oniguruma/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/pango		| 1.48.0	| https://download.gnome.org/sources/pango/cache.json https://ftp.gnome.org/pub/GNOME/sources/pango/ | [omniosorg](https://github.com/omniosorg)
-| ooce/library/protobuf		| 3.13.0	| https://github.com/protocolbuffers/protobuf/releases/ | [omniosorg](https://github.com/omniosorg)
+| ooce/library/protobuf		| 3.14.0	| https://github.com/protocolbuffers/protobuf/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/security/libsasl2 | 2.1.27	| https://github.com/cyrusimap/cyrus-sasl/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/library/serf		| 1.3.9 	| https://downloads.apache.org/serf/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/slang		| 2.3.2		| https://www.jedsoft.org/releases/slang/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Regards `protobuf` library, there is an ABI change, as follows:

`libprotoc ABI change, 24  -> 25 `

It looks like just `mosh` that uses `protobuf`, therefore I have built `mosh` with new `protobuf` and the build completes without errors.

