### PR TITLE
Package updates

### DIFF
--- a/build/gnuplot/build.sh
+++ b/build/gnuplot/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=gnuplot
-VER=5.4.0
+VER=5.4.1
 PKG=ooce/application/gnuplot
 SUMMARY="gnuplot"
 DESC="A portable command-line driven graphing utility"

--- a/build/groovy/build-30.sh
+++ b/build/groovy/build-30.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=groovy
-VER=3.0.6
+VER=3.0.7
 PKG=ooce/runtime/groovy-30
 SUMMARY="Groovy"
 DESC="Java-syntax-compatible object-oriented programming "

--- a/build/nano/build.sh
+++ b/build/nano/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=nano
-VER=5.3
+VER=5.4
 PKG=ooce/editor/nano
 SUMMARY="nano editor"
 DESC="GNU implementation of nano, a text editor emulating pico"

--- a/build/unbound/build.sh
+++ b/build/unbound/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=unbound
-VER=1.12.0
+VER=1.13.0
 PKG=ooce/network/unbound
 SUMMARY="DNS resolver"
 DESC="Unbound is a validating, recursive, caching DNS resolver."
@@ -39,6 +39,7 @@ CONFIGURE_OPTS="
     --sysconfdir=/etc$OPREFIX
     --with-run-dir=/var$PREFIX
     --with-libevent=/opt/ooce
+    --with-libnghttp2
     --with-pthreads
 "
 CONFIGURE_OPTS_64+="

--- a/build/unbound/testsuite.log
+++ b/build/unbound/testsuite.log
@@ -1,4 +1,4 @@
-Start of unbound 1.12.0+libevent unit test.
+Start of unbound 1.13.0+libevent unit test.
 test authzone functions
 test negative cache functions
 test ub_random functions
@@ -59,8 +59,9 @@ test slabhash functions
 test infra cache functions
 test sldns functions
 test message parse functions
-[0] did 10000 in 127.795 msec for 78250.322783 encode/sec size 615
-903837 checks ok.
+[0] did 10000 in 109.593 msec for 91246.703713 encode/sec size 615
+test services/outside_network.c:reuse_tcp_select_id
+1296572 checks ok.
 selftest successful (33 checks).
 ./testdata/acl.rpl OK
 ./testdata/auth_nsec3_ent.rpl OK
@@ -118,7 +119,8 @@ selftest successful (33 checks).
 ./testdata/chaos_trustanchor.rpl OK
 ./testdata/dns64_lookup.rpl OK
 ./testdata/domain_insec_ds.rpl OK
-./testdata/edns_client_tag.rpl OK
+./testdata/edns_client_string.rpl OK
+./testdata/edns_client_string_opcode.rpl OK
 ./testdata/edns_keepalive.rpl OK
 ./testdata/fetch_glue.rpl OK
 ./testdata/fetch_glue_cname.rpl OK

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -118,7 +118,7 @@
 | ooce/network/rclone		| 1.53.3	| https://github.com/rclone/rclone/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/smtp/postfix	| 3.5.8		| https://www.swissrave.ch/mirror/postfix-source/index.html | [omniosorg](https://github.com/omniosorg)
 | ooce/network/tcpdump		| 4.9.3		| https://www.tcpdump.org/release/ | [omniosorg](https://github.com/omniosorg)
-| ooce/network/unbound		| 1.12.0	| https://nlnetlabs.nl/downloads/unbound/ | [omniosorg](https://github.com/omniosorg)
+| ooce/network/unbound		| 1.13.0	| https://nlnetlabs.nl/downloads/unbound/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/znc		| 1.8.2		| https://github.com/znc/znc/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/ooceapps			| github-latest	| https://github.com/omniosorg/ooceapps/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/print/cups		| 2.3.3		| https://github.com/apple/cups/releases | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -123,7 +123,7 @@
 | ooce/ooceapps			| github-latest	| https://github.com/omniosorg/ooceapps/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/print/cups		| 2.3.3		| https://github.com/apple/cups/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/expect		| 5.45.4	| https://sourceforge.net/projects/expect/files/Expect/ | [omniosorg](https://github.com/omniosorg)
-| ooce/runtime/groovy-30	| 3.0.6		| https://groovy.apache.org/download.html | [omniosorg](https://github.com/omniosorg)
+| ooce/runtime/groovy-30	| 3.0.7		| https://groovy.apache.org/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/node-8		| 8.17.0	| https://nodejs.org/en/download/releases/ https://nodejs.org/en/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/node-10		| 10.23.0	| https://nodejs.org/en/download/releases/ https://nodejs.org/en/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/node-12		| 12.20.0	| https://nodejs.org/en/download/releases/ https://nodejs.org/en/download/ | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -2,7 +2,7 @@
 | :------ | :------ | :--- | :--------- |
 | ooce/application/fcgiwrap	| 1.1.0		| https://github.com/gnosek/fcgiwrap/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/gitea	| 1.13.0	| https://github.com/go-gitea/gitea/releases | [omniosorg](https://github.com/omniosorg)
-| ooce/application/gnuplot	| 5.4.0		| https://sourceforge.net/projects/gnuplot/files/gnuplot/ http://www.gnuplot.info/ | [omniosorg](https://github.com/omniosorg)
+| ooce/application/gnuplot	| 5.4.1		| https://sourceforge.net/projects/gnuplot/files/gnuplot/ http://www.gnuplot.info/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/graphviz	| 2.44.1	| https://www2.graphviz.org/Packages/stable/portable_source/ https://graphviz.org/download/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/imagemagick	| 7.0.10-43	| https://imagemagick.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/mattermost	| 5.29.0	| https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -59,7 +59,7 @@
 | ooce/driver/fuse		| 1.4		| https://github.com/jurikm/illumos-fusefs/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/emacs		| 27.1		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
-| ooce/editor/nano		| 5.3		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
+| ooce/editor/nano		| 5.4		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
 | ooce/file/acltool		| 1.16.2	| https://github.com/ptrrkssn/acltool/releases | [Peter Eriksson](https://github.com/ptrrkssn)
 | ooce/file/lsof		| 4.94.0	| https://github.com/lsof-org/lsof/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/file/tree		| 1.8.0		| http://mama.indstate.edu/users/ice/tree/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
I noticed one change on gnuplot. the llibexec files now install into an amd64 sub-directory:
`+dir  path=opt/ooce/gnuplot/libexec/amd64/gnuplot owner=root group=bin mode=0755`

and also with groovy, there has been a minor version changes (3..0.6 . 3.0.7) to libs in groovy-3.0/lib directory. This may need further attention,