### PR TITLE
gnu-st: GNU smalltalk 3.2.5

### DIFF
--- a/build/gnu-smalltalk/build.sh
+++ b/build/gnu-smalltalk/build.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/bash
+#
+# {{{
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2020 David Stes
+# GNU Smalltalk latest stable 3.2.5 with some patches from 3.2.91 alpha
+
+. ../../lib/functions.sh
+
+PROG=gnu-smalltalk
+VER=3.2.5
+PKG=ooce/runtime/gnu-smalltalk
+SUMMARY="GNU Smalltalk"
+DESC="A free implementation of the Smalltalk-80 language, \
+well-versed to scripting tasks and headless processing."
+
+# 64-bit build currently segfaults, needs investigation
+set_arch 32
+set_builddir smalltalk-$VER
+
+HARDLINK_TARGETS="
+    opt/ooce/gnu-smalltalk/bin/gst-load
+"
+
+OPREFIX=$PREFIX
+PREFIX+=/$PROG
+
+reset_configure_opts
+
+TESTSUITE_FILTER='^[A-Z#0-9 ][A-Z#0-9 ]'
+
+# despite the fact that GNU smalltalk uses its own libtool
+# there is a need for a ltdl.h header file, so require libtool
+# GNU Smalltalk can be compiled --without-emacs but conceptually,
+# it seems better to require it as the GNU smalltalk integrates with Emacs
+BUILD_DEPENDS_IPS+="
+    developer/build/libtool
+    ooce/editor/emacs
+"
+
+# deliberately force emacs as dependency;
+# GNU Smalltalk supports emacs and emacs as its IDE
+
+RUN_DEPENDS_IPS+="
+    ooce/editor/emacs
+"
+
+XFORM_ARGS="
+    -DOPREFIX=${OPREFIX#/}
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+"
+
+# disable-generational-gc because libsigsegv not found
+CONFIGURE_OPTS+="
+    --with-gmp
+    --disable-generational-gc
+    --with-emacs
+    --with-lispdir=$OPREFIX/emacs/share/emacs/site-lisp
+    --with-lispstartdir=$OPREFIX/emacs/share/emacs/site-lisp/site-start.d
+"
+
+# GNU Smalltalk does not find gmp headers
+CPPFLAGS+=" -I/usr/include/gmp"
+[ $RELVER -ge 151037 ] && LDFLAGS32+=" -lssp_ns"
+
+# create package functions
+init
+download_source $PROG smalltalk $VER
+patch_source
+prep_build
+build
+strip_install
+run_testsuite check
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gnu-smalltalk/local.mog
+++ b/build/gnu-smalltalk/local.mog
@@ -1,0 +1,19 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 David Stes
+
+license COPYING license=GPLv2
+
+<transform path=$(PREFIX)/share/info -> drop>
+
+<include binlink.mog>
+<include manlink.mog>
+

--- a/build/gnu-smalltalk/patches/01-environ.patch
+++ b/build/gnu-smalltalk/patches/01-environ.patch
@@ -1,0 +1,19 @@
+diff -wpruN '--exclude=*.orig' a~/libgst/cint.c a/libgst/cint.c
+--- a~/libgst/cint.c	1970-01-01 00:00:00
++++ a/libgst/cint.c	1970-01-01 00:00:00
+@@ -396,6 +396,15 @@ my_putenv (const char *str)
+   return (putenv (clone));
+ }
+ 
++/*
++ * From smalltalk-3.2.91/libgst/cint.c (known issue and fixed in 3.2.91alpha):
++ * On FreeBSD and other BSDs there is the environ but it is not
++ * declared in header. Import it like this.
++ */
++#if !HAVE_DECL_ENVIRON
++extern char **environ;
++#endif
++
+ static char **
+ get_environ (void)
+ {

--- a/build/gnu-smalltalk/patches/02-emacs.patch
+++ b/build/gnu-smalltalk/patches/02-emacs.patch
@@ -1,0 +1,14 @@
+diff -wpruN '--exclude=*.orig' a~/smalltalk-mode-init.el.in a/smalltalk-mode-init.el.in
+--- a~/smalltalk-mode-init.el.in	1970-01-01 00:00:00
++++ a/smalltalk-mode-init.el.in	1970-01-01 00:00:00
+@@ -13,7 +13,9 @@
+ 
+ (push '("\\.st\\'" . smalltalk-mode) auto-mode-alist)
+ 
+-(push "\\.star\\'" inhibit-first-line-modes-regexps)
++(if (boundp 'inhibit-local-variables-regexps)
++    (push "\\.star\\'" inhibit-local-variables-regexps)
++    (push "\\.star\\'" inhibit-first-line-modes-regexp))
+ 
+ (autoload 'smalltalk-mode "@lispdir@/smalltalk-mode.elc" "" t)
+ @WITH_EMACS_COMINT_TRUE@(autoload 'gst "@lispdir@/gst-mode.elc" "" t)

--- a/build/gnu-smalltalk/patches/03-relative-symlink.patch
+++ b/build/gnu-smalltalk/patches/03-relative-symlink.patch
@@ -1,0 +1,14 @@
+replace absolute symlink pointing to the proto area with a relative symlink
+
+diff -wpruN '--exclude=*.orig' a~/doc/Makefile.in a/doc/Makefile.in
+--- a~/doc/Makefile.in	1970-01-01 00:00:00
++++ a/doc/Makefile.in	1970-01-01 00:00:00
+@@ -1018,7 +1018,7 @@ uninstall-local:
+ 
+ install-data-local: install-man
+ 	rm -f $(DESTDIR)$(man1dir)/gst-reload.1
+-	$(LN_S) $(DESTDIR)$(man1dir)/gst-load.1 $(DESTDIR)$(man1dir)/gst-reload.1
++	$(LN_S) gst-load.1 $(DESTDIR)$(man1dir)/gst-reload.1
+ 
+ $(srcdir)/blox.texi: $(top_srcdir)/packages/blox/tk/stamp-classes
+ 	files=`$(GST_PACKAGE) $(patsubst %, %/package.xml, $(^D)) \

--- a/build/gnu-smalltalk/patches/series
+++ b/build/gnu-smalltalk/patches/series
@@ -1,0 +1,3 @@
+01-environ.patch
+02-emacs.patch
+03-relative-symlink.patch

--- a/build/gnu-smalltalk/testsuite.log
+++ b/build/gnu-smalltalk/testsuite.log
@@ -1,0 +1,146 @@
+## ------------------------------- ##
+## GNU Smalltalk 3.2.5 test suite. ##
+## ------------------------------- ##
+  1: arrays.st                                       ok
+  2: classes.st                                      ok
+  3: blocks.st                                       ok
+  4: sets.st                                         ok
+  5: processes.st                                    ok
+  6: exceptions.st                                   FAILED (testsuite.at:32)
+  7: intmath.st                                      ok
+  8: floatmath.st                                    ok
+  9: dates.st                                        ok
+ 10: objects.st                                      ok
+ 11: strings.st                                      ok
+ 12: chars.st                                        ok
+ 13: objdump.st                                      ok
+ 14: delays.st                                       ok
+ 15: geometry.st                                     ok
+ 16: cobjects.st                                     ok
+ 17: compiler.st                                     ok
+ 18: fileext.st                                      ok
+ 19: mutate.st                                       ok
+ 20: untrusted.st                                    ok
+ 21: getopt.st                                       ok
+ 22: quit.st                                         ok
+ 23: pools.st                                        ok
+ 24: shape.st                                        ok
+ 25: streams.st                                      ok
+ 26: ackermann.st                                    ok
+ 27: ary3.st                                         ok
+ 28: except.st                                       ok
+ 29: fibo.st                                         ok
+ 30: hash.st                                         ok
+ 31: hash2.st                                        ok
+ 32: heapsort.st                                     ok
+ 33: lists.st                                        ok
+ 34: lists1.st                                       ok
+ 35: lists2.st                                       ok
+ 36: matrix.st                                       ok
+ 37: methcall.st                                     ok
+ 38: nestedloop.st                                   ok
+ 39: objinst.st                                      ok
+ 40: prodcons.st                                     ok
+ 41: random-bench.st                                 ok
+ 42: sieve.st                                        ok
+ 43: strcat.st                                       ok
+ 44: stcompiler.st                                   ok
+ 45: SUnit                                           ok
+ 46: Parser                                          ok
+ANSI compliancy tests.
+ 47: ArrayANSITest                                   ok
+ 48: ArrayFactoryANSITest                            ok
+ 49: BagANSITest                                     ok
+ 50: BagFactoryANSITest                              ok
+ 51: BooleanANSITest                                 ok
+ 52: ByteArrayANSITest                               ok
+ 53: ByteArrayFactoryANSITest                        ok
+ 54: CharacterANSITest                               ok
+ 55: CharacterFactoryANSITest                        ok
+ 56: DateAndTimeANSITest                             ok
+ 57: DateAndTimeFactoryANSITest                      ok
+ 58: DictionaryANSITest                              ok
+ 59: DictionaryFactoryANSITest                       ok
+ 60: DurationANSITest                                ok
+ 61: DurationFactoryANSITest                         ok
+ 62: DyadicValuableANSITest                          ok
+ 63: ErrorANSITest                                   ok
+ 64: ErrorClassANSITest                              ok
+ 65: ExceptionANSITest                               ok
+ 66: ExceptionClassANSITest                          ok
+ 67: ExceptionSetANSITest                            ok
+ 68: FailedMessageANSITest                           ok
+ 69: FileStreamFactoryANSITest                       ok
+ 70: FloatANSITest                                   ok
+ 71: FloatCharacterizationANSITest                   ok
+ 72: FractionANSITest                                ok
+ 73: FractionFactoryANSITest                         ok
+ 74: IdentityDictionaryANSITest                      ok
+ 75: IdentityDictionaryFactoryANSITest               ok
+ 76: IntegerANSITest                                 ok
+ 77: IntervalANSITest                                ok
+ 78: IntervalFactoryANSITest                         ok
+ 79: MessageNotUnderstoodANSITest                    ok
+ 80: MessageNotUnderstoodSelectorANSITest            ok
+ 81: MonadicBlockANSITest                            ok
+ 82: NilANSITest                                     ok
+ 83: NiladicBlockANSITest                            ok
+ 84: NotificationANSITest                            ok
+ 85: NotificationClassANSITest                       ok
+ 86: ObjectANSITest                                  ok
+ 87: ObjectClassANSITest                             ok
+ 88: OrderedCollectionANSITest                       ok
+ 89: OrderedCollectionFactoryANSITest                ok
+ 90: ReadFileStreamANSITest                          ok
+ 91: ReadStreamANSITest                              ok
+ 92: ReadStreamFactoryANSITest                       ok
+ 93: ReadWriteStreamANSITest                         ok
+ 94: ReadWriteStreamFactoryANSITest                  ok
+ 95: ScaledDecimalANSITest                           ok
+ 96: SelectorANSITest                                ok
+ 97: SetANSITest                                     ok
+ 98: SetFactoryANSITest                              ok
+ 99: SortedCollectionANSITest                        ok
+100: SortedCollectionFactoryANSITest                 ok
+101: StringANSITest                                  ok
+102: StringFactoryANSITest                           ok
+103: SymbolANSITest                                  ok
+104: TranscriptANSITest                              ok
+105: WarningANSITest                                 ok
+106: WarningClassANSITest                            ok
+107: WriteFileStreamANSITest                         ok
+108: WriteStreamANSITest                             ok
+109: WriteStreamFactoryANSITest                      ok
+110: ZeroDivideANSITest                              ok
+111: ZeroDivideFactoryANSITest                       ok
+112: Announcements                                   ok
+113: Complex                                         ok
+114: Continuations                                   ok
+115: DBD-MySQL                                       skipped (testsuite.at:153)
+116: DBD-SQLite                                      ok
+117: DebugTools                                      ok
+118: DhbNumericalMethods                             ok
+119: Digest                                          ok
+120: GDBM                                            skipped (testsuite.at:158)
+121: Iconv                                           FAILED (testsuite.at:159)
+122: Magritte                                        ok
+123: ROE                                             ok
+124: SandstoneDb                                     ok
+125: Seaside-Core                                    ok
+126: Sockets                                         expected failure (testsuite.at:164)
+127: Sport                                           ok
+128: Swazoo                                          ok
+129: XML-XMLParser                                   ok
+130: XML-Expat                                       ok
+131: ZLib                                            ok
+## ------------- ##
+## Test results. ##
+## ------------- ##
+ERROR: 129 tests were run,
+3 failed (1 expected failure).
+2 tests were skipped.
+## -------------------------- ##
+## testsuite.log was created. ##
+## -------------------------- ##
+   To: <help-smalltalk@gnu.org>
+   Subject: [GNU Smalltalk 3.2.5] testsuite: 6 121 failed

--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -24,6 +24,7 @@ depend fmri=ooce/developer/gperf type=require
 depend fmri=ooce/developer/llvm-100 type=require
 depend fmri=ooce/developer/llvm-110 type=require
 depend fmri=ooce/developer/rust type=require
+depend fmri=ooce/editor/emacs type=require
 depend fmri=ooce/fonts/liberation type=require
 depend fmri=ooce/library/apr type=require
 depend fmri=ooce/library/apr-util type=require

--- a/doc/baseline
+++ b/doc/baseline
@@ -140,6 +140,7 @@ extra.omnios ooce/omnios-build-tools
 extra.omnios ooce/ooceapps
 extra.omnios ooce/print/cups
 extra.omnios ooce/runtime/expect
+extra.omnios ooce/runtime/gnu-smalltalk
 extra.omnios ooce/runtime/groovy-30
 extra.omnios ooce/runtime/node-10
 extra.omnios ooce/runtime/node-12

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -127,6 +127,7 @@
 | ooce/ooceapps			| github-latest	| https://github.com/omniosorg/ooceapps/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/print/cups		| 2.3.3		| https://github.com/apple/cups/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/expect		| 5.45.4	| https://sourceforge.net/projects/expect/files/Expect/ | [omniosorg](https://github.com/omniosorg)
+| ooce/runtime/gnu-smalltalk	| 3.2.5		| https://ftp.gnu.org/gnu/smalltalk/ | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/groovy-30	| 3.0.7		| https://groovy.apache.org/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/node-8		| 8.17.0	| https://nodejs.org/en/download/releases/ https://nodejs.org/en/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/runtime/node-10		| 10.23.0	| https://nodejs.org/en/download/releases/ https://nodejs.org/en/download/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This package was originally written by Steve Byrne who was a Sun employee I think, longtime ago ...

I can build it in the omnios-extra and it installs ok for me in the https://pkg.omniosce.org/r151036/extra/

Please note that there are some issues where I just type "yes" when it asks "do you want to continue" ?

For example,

1) unused object=/lib/libpthread.so.1      <remove lib or -zignore?>
ELF runtime problems detected

2) -- Checking for library ABI changes
Could not retrieve contents

3) These hardlinks do not have locked targets, resulting in inconsistent builds.
--- Unlocked hardlink: opt/ooce/bin/gst-load <- opt/ooce/bin/gst-blox

However when I just go ahead

===== User elected to continue after prompt. =====

Then it stilll seems to build fine and install OK for me.

When I manually build GNU smalltalk the testsuite reports 2 failures


gmake check testsuite

ERROR: 129 tests were run,
2 failed (1 expected failure).
2 tests were skipped.

## ------------------------ ##
## Summary of the failures. ##
## ------------------------ ##
Failed tests:
GNU Smalltalk 3.2.5 test suite test groups:

In the omnios-extra build, there are 3 failures in the testuite , I believe.

This may be due to more agressive compiler optimizer flags in the omnios-extra build,
but in any case most of the testsuite (run_testsuite) is succesful.

Please consider this pull request for merge.

Regards,
David Stes