### PR TITLE
add rmvb support to minidlna

### DIFF
--- a/build/minidlna/patches/RMVB.patch
+++ b/build/minidlna/patches/RMVB.patch
@@ -1,0 +1,55 @@
+From e4a045e92b864dc148ca46be94668c5b67132405 Mon Sep 17 00:00:00 2001
+From: VergLsm <vision.lsm.2012@gmail.com>
+Date: Fri, 31 Jan 2020 10:01:12 +0000
+Subject: [PATCH] Added support RMVB.
+
+---
+ metadata.c       | 4 ++++
+ upnpglobalvars.h | 3 ++-
+ utils.c          | 3 +++
+ 3 files changed, 9 insertions(+), 1 deletion(-)
+
+--- a/metadata.c
++++ b/metadata.c
+@@ -862,6 +862,10 @@ GetVideoMetadata(const char *path, const
+ 			xasprintf(&m.mime, "video/x-matroska");
+ 		else if( strcmp(ctx->iformat->name, "flv") == 0 )
+ 			xasprintf(&m.mime, "video/x-flv");
++		else if( strcmp(ctx->iformat->name, "rm") == 0 )
++			xasprintf(&m.mime, "video/x-pn-realvideo");
++		else if( strcmp(ctx->iformat->name, "rmvb") == 0 )
++			xasprintf(&m.mime, "video/x-pn-realvideo");
+ 		if( m.mime )
+ 			goto video_no_dlna;
+ 
+--- a/upnpglobalvars.h
++++ b/upnpglobalvars.h
+@@ -172,7 +172,8 @@
+ 	"http-get:*:audio/x-wav:*," \
+ 	"http-get:*:audio/x-flac:*," \
+ 	"http-get:*:audio/x-dsd:*," \
+-	"http-get:*:application/ogg:*"
++	"http-get:*:application/ogg:*,"\
++	"http-get:*:video/x-pn-realvideo:*"
+ 
+ #define DLNA_FLAG_DLNA_V1_5      0x00100000
+ #define DLNA_FLAG_HTTP_STALLING  0x00200000
+--- a/utils.c
++++ b/utils.c
+@@ -377,6 +377,8 @@ mime_to_ext(const char * mime)
+ 				return "3gp";
+ 			else if( strncmp(mime+6, "x-tivo-mpeg", 11) == 0 )
+ 				return "TiVo";
++			else if( strcmp(mime+6, "x-pn-realvideo") == 0 )
++				return "rm";
+ 			break;
+ 		case 'i':
+ 			if( strcmp(mime+6, "jpeg") == 0 )
+@@ -401,6 +403,7 @@ is_video(const char * file)
+ 		ends_with(file, ".m2t") || ends_with(file, ".mkv")   ||
+ 		ends_with(file, ".vob") || ends_with(file, ".ts")    ||
+ 		ends_with(file, ".flv") || ends_with(file, ".xvid")  ||
++		ends_with(file, ".rm") || ends_with(file, ".rmvb")  ||
+ #ifdef TIVO_SUPPORT
+ 		ends_with(file, ".TiVo") ||
+ #endif

--- a/build/minidlna/patches/series
+++ b/build/minidlna/patches/series
@@ -3,3 +3,4 @@ minidlna.conf.patch
 minissdp.c.patch
 monitor.c.patch
 icons.c.patch
+rmvb.patch

--- a/build/minidlna/patches/series
+++ b/build/minidlna/patches/series
@@ -3,4 +3,4 @@ minidlna.conf.patch
 minissdp.c.patch
 monitor.c.patch
 icons.c.patch
-rmvb.patch
+RMVB.patch

--- a/build/minidlna/patches/series
+++ b/build/minidlna/patches/series
@@ -3,4 +3,5 @@ minidlna.conf.patch
 minissdp.c.patch
 monitor.c.patch
 icons.c.patch
+select_use_after_free.patch
 RMVB.patch


### PR DESCRIPTION
the rmvb support patch is   from openwrt , it very  simple  ,could merge it to minidlna? 
the openwrt patch locate at 
https://github.com/openwrt/packages/blob/master/multimedia/minidlna/patches/005-added-support-RMVB.patch

