### PR TITLE
Cyrus SASL fixes

### DIFF
--- a/build/sasl2/build.sh
+++ b/build/sasl2/build.sh
@@ -55,6 +55,7 @@ CONFIGURE_OPTS="
     --enable-plain
     --enable-login
     --enable-sql
+    --enable-ldapdb \
     --with-ldap
     --with-mysql=$PREFIX/mariadb-$MARIASQLVER
     --with-pgsql=$PREFIX/pgsql-$PGSQLVER

--- a/build/sasl2/patches/ldapdb-quieter.patch
+++ b/build/sasl2/patches/ldapdb-quieter.patch
@@ -1,0 +1,26 @@
+diff -wpruN '--exclude=*.orig' a~/plugins/ldapdb.c a/plugins/ldapdb.c
+--- a~/plugins/ldapdb.c	1970-01-01 00:00:00
++++ a/plugins/ldapdb.c	1970-01-01 00:00:00
+@@ -472,7 +472,7 @@ ldapdb_config(const sasl_utils_t *utils)
+     if(p->inited) return SASL_OK;
+ 
+     utils->getopt(utils->getopt_context, ldapdb, "ldapdb_uri", &p->uri, NULL);
+-    if(!p->uri) return SASL_BADPARAM;
++    if(!p->uri) return SASL_NOMECH;
+ 
+     utils->getopt(utils->getopt_context, ldapdb, "ldapdb_id",
+     	(const char **)&p->id.bv_val, &len);
+diff -wpruN '--exclude=*.orig' a~/lib/canonusr.c a/lib/canonusr.c
+--- a~/lib/canonusr.c	1970-01-01 00:00:00
++++ a/lib/canonusr.c	1970-01-01 00:00:00
+@@ -320,8 +320,10 @@ int sasl_canonuser_add_plugin(const char
+ 			   &out_version, &plug, plugname);
+ 
+     if(result != SASL_OK) {
++        if(result != SASL_NOMECH) {
+ 	_sasl_log(NULL, SASL_LOG_ERR, "%s_canonuser_plug_init() failed in sasl_canonuser_add_plugin(): %z\n",
+ 		  plugname, result);
++        }
+ 	return result;
+     }
+ 

--- a/build/sasl2/patches/series
+++ b/build/sasl2/patches/series
@@ -1,4 +1,5 @@
 sql-quieter.patch
+ldapdb-quieter.patch
 configure-mysql.patch
 configure-pgsql.patch
 configure-ldap.patch

--- a/build/sasl2/patches/sql-quieter.patch
+++ b/build/sasl2/patches/sql-quieter.patch
@@ -1,3 +1,17 @@
+diff -wpruN '--exclude=*.orig' a~/lib/auxprop.c a/lib/auxprop.c
+--- a~/lib/auxprop.c	1970-01-01 00:00:00
++++ a/lib/auxprop.c	1970-01-01 00:00:00
+@@ -822,8 +822,10 @@ int sasl_auxprop_add_plugin(const char *
+     }
+ 
+     if(result != SASL_OK) {
++        if(result != SASL_NOMECH) {
+ 	_sasl_log(NULL, SASL_LOG_ERR, "auxpropfunc error %s\n",
+ 		  sasl_errstring(result, NULL, NULL));
++        }
+ 	return result;
+     }
+ 
 diff -wpruN '--exclude=*.orig' a~/plugins/sql.c a/plugins/sql.c
 --- a~/plugins/sql.c	1970-01-01 00:00:00
 +++ a/plugins/sql.c	1970-01-01 00:00:00
@@ -55,3 +69,12 @@ diff -wpruN '--exclude=*.orig' a~/plugins/sql.c a/plugins/sql.c
  	return -1;
      }
  
+@@ -1349,7 +1349,7 @@ int sql_auxprop_plug_init(const sasl_uti
+     if (!settings->sql_engine->name) return SASL_NOMECH;
+ 
+     if (!sql_exists(settings->sql_select)) {
+-	utils->log(utils->conn, SASL_LOG_ERR, "sql_select option missing");
++	utils->log(utils->conn, SASL_LOG_DEBUG, "sql_select option missing");
+ 	utils->free(settings);	
+ 	return SASL_NOMECH;
+     }


### PR DESCRIPTION
Make auxprop sql plugin even quieter so the plugin init doesn't log anything to auth.error syslog facility when not configured.
Added auxprop ldapdb plugin which is available but was not compiled only ldap support for saslauthd was enabled. This plugin also
needed some coding to make it silent. e.g. it should return SASL_NOMECH just as sql plugin does when not configured and needed to add extra check in sasl_canonuser_add_plugin() so its silent when SASL_NOMECH is returned from an init function.