### PR TITLE
ffmpeg enable ssl

### DIFF
--- a/build/ffmpeg/build.sh
+++ b/build/ffmpeg/build.sh
@@ -50,7 +50,7 @@ CONFIGURE_OPTS="
     --enable-gpl
     --enable-libx264
     --enable-libx265
-    --enable-openssl
+	--enable-gnutls
 "
 [ $RELVER -ge 151036 ] && CONFIGURE_OPTS+=" --enable-libdav1d"
 CONFIGURE_OPTS_32="

--- a/build/ffmpeg/build.sh
+++ b/build/ffmpeg/build.sh
@@ -50,6 +50,7 @@ CONFIGURE_OPTS="
     --enable-gpl
     --enable-libx264
     --enable-libx265
+    --enable-openssl
 "
 [ $RELVER -ge 151036 ] && CONFIGURE_OPTS+=" --enable-libdav1d"
 CONFIGURE_OPTS_32="

--- a/build/gnutls/build.sh
+++ b/build/gnutls/build.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=gnutls
+VER=3.7.1
+VER_MAJ=3.7
+PKG=ooce/security/gnutls
+SUMMARY="gnutls"
+DESC="GnuTLS is a portable ANSI C based library which implements the TLS 1.0 and SSL"
+DESC+="3.0 protocols. The library does not include any patented algorithms and is"
+DESC+="available under the GNU Lesser GPL license."
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+CFLAGS+=" -I/usr/include/gmp"
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+"
+
+export MAKE
+CONFIGURE_OPTS="
+	--disable-openssl-compatibility
+	--without-idn
+	--without-tpm
+	--disable-valgrind-tests
+	--enable-local-libopts
+	--with-included-libtasn1
+	--with-included-unistring
+	--without-p11-kit
+	--disable-hardware-acceleration
+"
+
+init
+set_mirror "https://gnupg.org/ftp/gcrypt"
+set_checksum sha256 "3777d7963eca5e06eb315686163b7b3f5045e2baac5e54e038ace9835e5cac6f"
+download_source $PROG/v$VER_MAJ $PROG $VER
+patch_source
+prep_build
+build
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gnutls/local.mog
+++ b/build/gnutls/local.mog
@@ -1,0 +1,16 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+<include binlink.mog>
+<include manlink.mog>
+
+license LICENSE license=LGPLv3

--- a/build/nettle/build.sh
+++ b/build/nettle/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=nettle
+VER=3.7.2
+PKG=ooce/security/nettle
+SUMMARY="nettle"
+DESC="Cryptographic library"
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+CFLAGS+=" -I/usr/include/gmp"
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+"
+
+CONFIGURE_OPTS="
+	--disable-openssl
+	--disable-shared
+"
+
+init
+set_mirror "http://ftp.gnu.org/gnu"
+set_checksum sha256 "8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162"
+download_source $PROG $PROG $VER
+prep_build
+build
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/nettle/local.mog
+++ b/build/nettle/local.mog
@@ -1,0 +1,16 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+<include binlink.mog>
+<include manlink.mog>
+
+license COPYING.LESSERv3 license=LGPLv3


### PR DESCRIPTION
Currently ffmpeg doesn't support ssl. I tripped over this when trying to capture a HLS livestream from a https server using youtube-dl.
This commit has `--enable-openssl`, some linux distros seem to prefer gnutls instead but that isn't packaged for omnios.