### PR TITLE
Build mod_md for apache-24

### DIFF
--- a/build/apache/build-24.sh
+++ b/build/apache/build-24.sh
@@ -62,6 +62,9 @@ CONFIGURE_OPTS="
     --enable-ldap
     --enable-headers
     --enable-rewrite
+
+    --with-jansson="$OPREFIX"
+    --enable-md
 "
 
 [ $RELVER -ge 151035 ] && CONFIGURE_OPTS+=" --enable-brotli"

--- a/build/cyrus/build.sh
+++ b/build/cyrus/build.sh
@@ -22,7 +22,6 @@ PKG=ooce/network/cyrus-imapd
 SUMMARY="Cyrus IMAP is an email, contacts and calendar server"
 DESC="$SUMMARY"
 
-JANSSONVER=2.13.1
 ICUVER=68.2
 ICALVER=3.0.9
 
@@ -41,20 +40,17 @@ XFORM_ARGS="
     -DPROG=$PROG
     -DUSER=cyrus -DGROUP=cyrus
     -DRUNDIR=var/run/cyrus
-    -DJANSSON=$JANSSONVER
     -DICU=$ICUVER
     -DICAL=$ICALVER
 "
 
 init
-prep_build autoconf -autoreconf
+prep_build
 
 #########################################################################
 # Download and build bundled dependencies
 
 save_buildenv
-
-build_dependency -ctf jansson jansson-$JANSSONVER $PROG/jansson v$JANSSONVER
 
 CONFIGURE_OPTS+=" --disable-tests --disable-samples"
 build_dependency -ctf icu4c icu/source $PROG/icu icu4c-${ICUVER//./_}-src
@@ -123,7 +119,7 @@ make_install() {
     # Copy in the dependency libraries
 
     pushd $deplib >/dev/null
-    for lib in libical* libjansson* libicu*; do
+    for lib in libical* libicu*; do
         [[ $lib = *.so.* && -f $lib && ! -h $lib ]] || continue
         tgt=`echo $lib | cut -d. -f1-3`
         logmsg "--- installing library $lib -> $tgt"

--- a/build/cyrus/local.mog
+++ b/build/cyrus/local.mog
@@ -12,7 +12,6 @@
 
 license COPYING license="BSD with attribution to CMU/MIT/others"
 license ../icu/LICENSE license=modified-BSD
-license ../jansson-$(JANSSON)/LICENSE license=MIT
 license ../libical-$(ICAL)/LICENSE.MPL2.txt license=MPLv2
 
 group groupname=$(GROUP) gid=89

--- a/build/jansson/build.sh
+++ b/build/jansson/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=jansson
+VER=2.13.1
+PKG=ooce/library/jansson
+SUMMARY="jansson"
+DESC="C library for encoding, decoding and manipulating JSON data"
+
+CONFIGURE_OPTS="--disable-static"
+
+init
+download_source $PROG $PROG $VER
+prep_build
+patch_source
+build -ctf
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/jansson/local.mog
+++ b/build/jansson/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT
+

--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -32,6 +32,7 @@ depend fmri=ooce/library/apr-util type=require
 depend fmri=ooce/library/cairo type=require
 depend fmri=ooce/library/fcgi2 type=require
 depend fmri=ooce/library/gnutls type=require
+depend fmri=ooce/library/jansson type=require
 depend fmri=ooce/library/json-c type=require
 depend fmri=ooce/library/libev type=require
 depend fmri=ooce/library/libexif type=require

--- a/doc/baseline
+++ b/doc/baseline
@@ -86,6 +86,7 @@ extra.omnios ooce/library/fontconfig
 extra.omnios ooce/library/freetype2
 extra.omnios ooce/library/gnutls
 extra.omnios ooce/library/guile
+extra.omnios ooce/library/jansson
 extra.omnios ooce/library/json-c
 extra.omnios ooce/library/ldns
 extra.omnios ooce/library/libarchive

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -79,7 +79,7 @@
 | ooce/library/gnutls		| 3.6.15	| https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/ https://www.gnutls.org/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/library/guile		| 2.0.14	| https://ftp.gnu.org/gnu/guile/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/icu4c		| 68.2		| https://github.com/unicode-org/icu/releases | Currently used solely by cyrus-imapd
-| ooce/library/jansson		| 2.13.1	| https://github.com/akheron/jansson/releases | Currently used solely by cyrus-imapd
+| ooce/library/jansson		| 2.13.1	| https://digip.org/jansson/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/json-c		| 0.15		| https://github.com/json-c/json-c/releases https://github.com/json-c/json-c/wiki | [omniosorg](https://github.com/omniosorg)
 | ooce/library/ldns		| 1.7.1		| https://nlnetlabs.nl/downloads/ldns/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/libarchive	| 3.5.1		| https://libarchive.org/downloads/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
https://httpd.apache.org/docs/2.4/mod/mod_md.html

This is pretty nice when grabbing your certificates via letsencrypt or another acme compatible CA.

@citrus-it this is the thing I was blabbering about on IRC.

I'm not super excited about having it pull in libjansson and curl as dependencies though. I there an easy way to split mod_md off to a separate package? Or would that be more work than it's worth?