### PR TITLE
Build upstream mod_md instead of bundle copy

### DIFF
--- a/build/apache/build-24.sh
+++ b/build/apache/build-24.sh
@@ -62,9 +62,6 @@ CONFIGURE_OPTS="
     --enable-ldap
     --enable-headers
     --enable-rewrite
-
-    --with-jansson="$OPREFIX"
-    --enable-md
 "
 
 [ $RELVER -ge 151035 ] && CONFIGURE_OPTS+=" --enable-brotli"

--- a/build/mod_md/build.sh
+++ b/build/mod_md/build.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=mod_md
+VER=2.4.0
+# Hard-coded here for now. If we ship more than one apache version, this will
+# need restructuring.
+PKG=ooce/server/apache-24/modules/md
+SUMMARY="$PROG Let's Encrypt (ACME) support for Apache httpd"
+DESC="$SUMMARY"
+
+APACHEVER=2.4
+sAPACHEVER=${APACHEVER//./}
+
+RUN_DEPENDS_IPS+=" ooce/server/apache-$sAPACHEVER"
+
+set_arch 64
+
+set_mirror 'https://github.com/icing/mod_md/releases/download/'
+set_checksum sha256 \
+    '1710ffe0931a396f155c922d6873e56e3d4947c46f39094a428a766672f1ef91'
+
+OPREFIX=$PREFIX
+PREFIX+="/apache-$APACHEVER"
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+"
+
+export PATH+=":$PREFIX/bin"
+LDFLAGS64+=" -L$OPREFIX/lib/$ISAPART64 -R$OPREFIX/lib/$ISAPART64"
+CFLAGS64+=" -D_XOPEN_SOURCE=700"
+CPPFLAGS64+=" -I /usr/include"
+
+CONFIGURE_CMD="./configure --with-apxs="$PREFIX/bin/apxs""
+
+init
+download_source "v.$VER" "$PROG-$VER"
+patch_source
+prep_build
+build -ctf
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/mod_md/files/httpd-md.conf
+++ b/build/mod_md/files/httpd-md.conf
@@ -1,0 +1,8 @@
+LoadModule	watchdog_module libexec/mod_watchdog.so
+LoadModule	md_module	libexec/mod_md.so
+
+# NOTE: uncomment to accept the letsencrypt license agreement
+#MDCertificateAgreement accepted
+
+# NOTE: uncomment to automatically redirect http -> https
+#MDRequireHttps temporary

--- a/build/mod_md/local.mog
+++ b/build/mod_md/local.mog
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=Apache2
+
+<transform path=$(PREFIX)/manual -> drop>
+
+file files/httpd-md.conf path=etc/$(PREFIX)/extra/httpd-md.conf \
+    owner=root group=bin mode=0644 preserve=renamenew
+
+file files/httpd-md.conf path=etc/$(PREFIX)/original/extra/httpd-md.conf \
+    owner=root group=bin mode=0444
+

--- a/build/mod_md/patches/arc4random_buf.patch
+++ b/build/mod_md/patches/arc4random_buf.patch
@@ -1,0 +1,22 @@
+Patch origin: in-house
+Patch status: fixes: md_crypt.c:86:5: error: implicit declaration of function 'arc4random_buf' [-Werror=implicit-function-declaration]
+Although this should be in stdlib.h which is include
+
+diff -wpruN '--exclude=*.orig' a~/configure a/configure
+--- a~/configure   Mon Mar  8 16:27:00 2021
++++ a/configure    Thu May 13 16:34:07 2021
+@@ -15077,14 +15077,7 @@
+ done
+
+
+-# we'd like to use this, if it exists
+-ac_fn_c_check_func "$LINENO" "arc4random_buf" "ac_cv_func_arc4random_buf"
+-if test "x$ac_cv_func_arc4random_buf" = xyes; then :
+-  CFLAGS="$CFLAGS -DMD_HAVE_ARC4RANDOM"
+-fi
+
+-
+-
+ # Checks for typedefs, structures, and compiler characteristics.
+ ac_fn_c_find_intX_t "$LINENO" "32" "ac_cv_c_int32_t"
+ case $ac_cv_c_int32_t in #(

--- a/build/mod_md/patches/series
+++ b/build/mod_md/patches/series
@@ -1,0 +1,1 @@
+arc4random_buf.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -166,6 +166,7 @@ extra.omnios ooce/runtime/tcl
 extra.omnios ooce/security/gnupg
 extra.omnios ooce/server/apache-24
 extra.omnios ooce/server/apache-24/modules/fcgid
+extra.omnios ooce/server/apache-24/modules/md
 extra.omnios ooce/server/apache-24/modules/subversion
 extra.omnios ooce/server/haproxy
 extra.omnios ooce/server/nginx

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -151,6 +151,7 @@
 | ooce/security/gnupg		| 1.4.23	| https://gnupg.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/apache-24		| 2.4.47	| https://downloads.apache.org/httpd/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/apache-24/modules/fcgid | 2.3.9	| https://downloads.apache.org/httpd/mod_fcgid/ | [omniosorg](https://github.com/omniosorg)
+| ooce/server/apache-24/modules/md | 2.4.0	| https://github.com/icing/mod_md
 | ooce/server/haproxy		| 2.3.10	| https://www.haproxy.org/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx		| 1.19.10	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx-120		| 1.20.0	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Apache syncs from upstream every so often, unfortunately it seems it is currently a bit behind.

The bundled mod_md works fine with boulder based acme registries (aka letsencrypt) but segfaults when using others e.g. pebble based or something like smallstalk's step-ca. (Guess what I am using for my non internet exposed hosts)

This builds mod_md seperately from apache, as a small bonus this drops the web/curl and ooce/library/jansson dependencies again for the main apache-24 package, as only mod_md needs them.

I'm not sure happy with this as I'd prefer to use the bundled one, as that is one package less to track/update. But this is better than having httpd die with a segfault.
