### PR TITLE
apache fails to stop properly due to missing privilages

### DIFF
--- a/build/apache/files/apache-template.xml
+++ b/build/apache/files/apache-template.xml
@@ -53,13 +53,19 @@
             <method_context security_flags="aslr">
                 <method_credential user="$(USER)"
                                    group="$(GROUP)"
-                                   privileges="basic,net_privaddr,!proc_info,!file_link_any" />
+                                   limit_privileges="basic,net_privaddr,!proc_info,!file_link_any" />
             </method_context>
 
             <exec_method type="method"
                          name="start"
                          exec="%{config/exec} -k %m -f %{config/file}"
-                         timeout_seconds="60" />
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic,net_privaddr,!proc_info,!proc_session,!file_link_any" />
+                </method_context>
+            </exec_method>
 
             <exec_method type="method"
                          name="stop"

--- a/build/apache/files/apache-template.xml
+++ b/build/apache/files/apache-template.xml
@@ -53,7 +53,7 @@
             <method_context security_flags="aslr">
                 <method_credential user="$(USER)"
                                    group="$(GROUP)"
-                                   privileges="basic,net_privaddr,!proc_info,!proc_session,!file_link_any" />
+                                   privileges="basic,net_privaddr,!proc_info,!file_link_any" />
             </method_context>
 
             <exec_method type="method"


### PR DESCRIPTION
I noticed apache wasn't properly stopping,

```
root@docs:/opt/httpd/logs# svcs apache24
STATE          STIME    FMRI
online         11:15:24 svc:/network/http:apache24
root@docs:/opt/httpd/logs# svcadm disable apache24
root@docs:/opt/httpd/logs# svcs apache24
STATE          STIME    FMRI
online*        11:15:49 svc:/network/http:apache24
root@docs:/opt/httpd/logs# pgrep httpd
13021
13020
13018
13019
root@docs:/opt/httpd/logs# tail -n 25 $(svcs -L apache24)
[ May 17 14:33:48 Disabled. ]
[ May 17 14:33:48 Rereading configuration. ]
[ May 17 14:35:36 Rereading configuration. ]
[ May 25 21:21:23 Disabled. ]
[ May 29 10:42:35 Enabled. ]
[ May 29 10:42:35 Executing start method ("/opt/ooce/apache-2.4/bin/apachectl -k start -f \'/opt/httpd/conf/httpd.conf\'"). ]
httpd: Could not open configuration file /opt/ooce/apache-2.4/'/opt/httpd/conf/httpd.conf': No such file or directory
[ May 29 10:42:35 Method "start" exited with status 1. ]
[ May 29 10:42:35 Executing start method ("/opt/ooce/apache-2.4/bin/apachectl -k start -f \'/opt/httpd/conf/httpd.conf\'"). ]
httpd: Could not open configuration file /opt/ooce/apache-2.4/'/opt/httpd/conf/httpd.conf': No such file or directory
[ May 29 10:42:35 Method "start" exited with status 1. ]
[ May 29 10:42:35 Executing start method ("/opt/ooce/apache-2.4/bin/apachectl -k start -f \'/opt/httpd/conf/httpd.conf\'"). ]
httpd: Could not open configuration file /opt/ooce/apache-2.4/'/opt/httpd/conf/httpd.conf': No such file or directory
[ May 29 10:42:35 Method "start" exited with status 1. ]
[ May 29 10:43:03 Leaving maintenance because disable requested. ]
[ May 29 10:43:03 Disabled. ]
[ May 29 10:44:58 Disabled. ]
[ May 29 10:44:58 Rereading configuration. ]
[ May 29 11:15:24 Enabled. ]
[ May 29 11:15:24 Executing start method ("/opt/ooce/apache-2.4/bin/apachectl -k start -f /etc/opt/ooce/apache-2.4/httpd.conf"). ]
[ May 29 11:15:24 Method "start" exited with status 0. ]
[ May 29 11:15:49 Stopping because service disabled. ]
[ May 29 11:15:49 Executing stop method ("/opt/ooce/apache-2.4/bin/apachectl -k stop -f /etc/opt/ooce/apache-2.4/httpd.conf"). ]
httpd (pid 13018?) not running
[ May 29 11:15:49 Method "stop" exited with status 0. ]
root@docs:/opt/httpd/logs# pgrep httpd
13021
13020
13018
13019
```

The clue here is `httpd (pid 13018?) not running` looks like it can't see and/or signal the process listed in the pid file as it is not in the same session.

`apachectl -k stop` calls `httpd -k stop` which reads the pid file and tries to signal the parent process to stop (or reload via -k graceful).

I believe the httpd process doing the signaling is in a different session as it got exec'd seperately by startd.

Removing `!proc_session` from the manifest fixed the issue and apache now properly stops.

I verified this by:

```
root@docs:~# svccfg -s svc:/network/http:apache24
svc:/network/http:apache24> listprop
loopback                           dependency
loopback/entities                  fmri     svc:/network/loopback
loopback/grouping                  astring  require_any
loopback/restart_on                astring  error
loopback/type                      astring  service
network                            dependency
network/entities                   fmri     svc:/milestone/network
network/grouping                   astring  optional_all
network/restart_on                 astring  error
network/type                       astring  service
filesystem_local                   dependency
filesystem_local/entities          fmri     svc:/system/filesystem/local:default
filesystem_local/grouping          astring  require_all
filesystem_local/restart_on        astring  none
filesystem_local/type              astring  service
dependents                         framework
dependents/apache24_multi-user     fmri     svc:/milestone/multi-user
method_context                     framework
method_context/group               astring  webservd
method_context/privileges          astring  basic,net_privaddr,!proc_info,!proc_session,!file_link_any
method_context/security_flags      astring  aslr
method_context/use_profile         boolean  false
method_context/user                astring  webservd
start                              method
start/exec                         astring  "%{config/exec} -k %m -f %{config/file}"
start/timeout_seconds              count    60
start/type                         astring  method
stop                               method
stop/exec                          astring  "%{config/exec} -k %m -f %{config/file}"
stop/timeout_seconds               count    300
stop/type                          astring  method
refresh                            method
refresh/exec                       astring  "%{config/exec} -k graceful -f %{config/file}"
refresh/timeout_seconds            count    300
refresh/type                       astring  method
config                             application
config/exec                        astring  /opt/ooce/apache-2.4/bin/apachectl
config/file                        astring  /etc/opt/ooce/apache-2.4/httpd.conf
tm_common_name                     template
tm_common_name/C                   ustring  "apache 2.4"
general                            framework
general/comment                    astring
general/enabled                    boolean  false
restarter                          framework	NONPERSISTENT
restarter/start_pid                count    13016
restarter/start_method_timestamp   time     1622286924.832129000
restarter/start_method_waitstatus  integer  0
restarter/logfile                  astring  /var/svc/log/network-http:apache24.log
restarter/transient_contract       count
restarter/contract                 count
restarter/auxiliary_state          astring  disable_request
restarter/next_state               astring  none
restarter/state                    astring  disabled
restarter/state_timestamp          time     1622287095.831631000
restarter_actions                  framework	NONPERSISTENT
restarter_actions/refresh          integer
restarter_actions/auxiliary_tty    boolean  true
restarter_actions/auxiliary_fmri   astring  svc:/system/zone_enter:default
svc:/network/http:apache24> se
select      selectsnap  set         setprop
svc:/network/http:apache24> setprop method_context/privileges
Usage: 	setprop pg/name = [type:] value
	setprop pg/name = [type:] ([value...])

Set the pg/name property of the currently selected entity.  Values may be
enclosed in double-quotes.  Value lists may span multiple lines.
svc:/network/http:apache24> setprop method_context/privileges = astring: "basic,net_privaddr,!proc_info,!file_link_any"
svc:/network/http:apache24> listprop
loopback                           dependency
loopback/entities                  fmri     svc:/network/loopback
loopback/grouping                  astring  require_any
loopback/restart_on                astring  error
loopback/type                      astring  service
network                            dependency
network/entities                   fmri     svc:/milestone/network
network/grouping                   astring  optional_all
network/restart_on                 astring  error
network/type                       astring  service
filesystem_local                   dependency
filesystem_local/entities          fmri     svc:/system/filesystem/local:default
filesystem_local/grouping          astring  require_all
filesystem_local/restart_on        astring  none
filesystem_local/type              astring  service
dependents                         framework
dependents/apache24_multi-user     fmri     svc:/milestone/multi-user
method_context                     framework
method_context/group               astring  webservd
method_context/security_flags      astring  aslr
method_context/use_profile         boolean  false
method_context/user                astring  webservd
method_context/privileges          astring  basic,net_privaddr,!proc_info,!file_link_any
start                              method
start/exec                         astring  "%{config/exec} -k %m -f %{config/file}"
start/timeout_seconds              count    60
start/type                         astring  method
stop                               method
stop/exec                          astring  "%{config/exec} -k %m -f %{config/file}"
stop/timeout_seconds               count    300
stop/type                          astring  method
refresh                            method
refresh/exec                       astring  "%{config/exec} -k graceful -f %{config/file}"
refresh/timeout_seconds            count    300
refresh/type                       astring  method
config                             application
config/exec                        astring  /opt/ooce/apache-2.4/bin/apachectl
config/file                        astring  /etc/opt/ooce/apache-2.4/httpd.conf
tm_common_name                     template
tm_common_name/C                   ustring  "apache 2.4"
general                            framework
general/comment                    astring
general/enabled                    boolean  false
restarter                          framework	NONPERSISTENT
restarter/start_pid                count    13016
restarter/start_method_timestamp   time     1622286924.832129000
restarter/start_method_waitstatus  integer  0
restarter/logfile                  astring  /var/svc/log/network-http:apache24.log
restarter/transient_contract       count
restarter/contract                 count
restarter/auxiliary_state          astring  disable_request
restarter/next_state               astring  none
restarter/state                    astring  disabled
restarter/state_timestamp          time     1622287095.831631000
restarter_actions                  framework	NONPERSISTENT
restarter_actions/refresh          integer
restarter_actions/auxiliary_tty    boolean  true
restarter_actions/auxiliary_fmri   astring  svc:/system/zone_enter:default
svc:/network/http:apache24> exit
root@docs:~# svcadm refresh apache24
root@docs:~# svcs apache24; svcadm enable apache24; sleep 5; pgrep httpd; svcadm disable apache24; sleep 5; pgrep httpd; svcs apache24
STATE          STIME    FMRI
disabled       11:36:20 svc:/network/http:apache24
13148
13151
13149
13150
STATE          STIME    FMRI
disabled       11:36:36 svc:/network/http:apache24
```

