### PR TITLE
freeradius 3.0

### DIFF
--- a/build/freeradius/build.sh
+++ b/build/freeradius/build.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=freeradius
+PKG=ooce/server/freeradius
+VER=3.0.23
+TALLOCVER=2.3.2
+MAJVER=${VER%.*}            # M.m
+sMAJVER=${MAJVER//./}       # Mm
+SUMMARY="FreeRADIUS $MAJVER"
+DESC="The open source implementation of RADIUS, an IETF protocol for AAA "
+DESC+="(Authorisation, Authentication, and Accounting)."
+
+OPREFIX=$PREFIX
+PREFIX+=/$PROG
+
+# talloc ships its own licence that refers out to LGPLv3
+SKIP_LICENCES=LGPLv3
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG-$MAJVER
+    -DVERSION=$MAJVER
+    -DsVERSION=$sMAJVER
+    -DDsVERSION=-$sMAJVER
+    -DUSER=radius -DUID=74
+    -DGROUP=radius -DGID=74
+"
+
+set_builddir $PROG-server-$VER
+set_arch 64
+set_standard XPG4v2
+
+init
+prep_build
+
+## build talloc dependency
+save_buildenv
+
+CONFIGURE_OPTS="
+    --prefix=$PREFIX
+    --disable-python
+"
+build_dependency -merge talloc talloc-$TALLOCVER $PROG talloc $TALLOCVER
+# Extract the talloc licence
+sed '/^\*/q' < $TMPDIR/talloc-$TALLOCVER/talloc.c > $TMPDIR/LICENCE.talloc
+
+restore_buildenv
+
+note -n "Building $PROG"
+
+CONFIGURE_OPTS="
+    --prefix=$PREFIX
+    --sysconfdir=/etc$PREFIX
+    --with-logdir=/var/log/$PREFIX
+    --localstatedir=/var/$PREFIX
+    --with-raddbdir=/etc$PREFIX
+    --libdir=$PREFIX/lib/$ISAPART64
+    --with-talloc-include-dir=$DESTDIR$PREFIX/include
+    --with-talloc-lib-dir=$DESTDIR$PREFIX/lib/$ISAPART64
+"
+
+# This prevents the build from embedding the temporary build directory into the
+# runpath of every object.
+MAKE_ARGS_WS="
+    TALLOC_LDFLAGS=\"-L$DESTDIR$PREFIX/lib/$ISAPART64 \
+        -R$PREFIX/lib/$ISAPART64\"
+"
+
+# To find OpenLDAP
+CPPFLAGS+=" -I$OPREFIX/include"
+LDFLAGS64+=" -L$OPREFIX/lib/$ISAPART64 -R$OPREFIX/lib/$ISAPART64"
+
+download_source $PROG "$PROG-server" $VER
+MAKE_INSTALL_ARGS="R=$DESTDIR" build -ctf
+xform files/freeradius-template.xml > $TMPDIR/$PROG-$sMAJVER.xml
+install_smf ooce $PROG-$sMAJVER.xml
+add_notes README.server-install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/freeradius/files/README.server-install
+++ b/build/freeradius/files/README.server-install
@@ -1,0 +1,12 @@
+
+------------------------------------------------------------------
+Freeradius Server Installation Notes
+------------------------------------------------------------------
+
+To generate example SSL certificates for this installation, change
+directory to /etc/opt/ooce/freeradius/certs and run:
+
+	gmake
+
+------------------------------------------------------------------
+

--- a/build/freeradius/files/freeradius-template.xml
+++ b/build/freeradius/files/freeradius-template.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="manifest"
+                name="$(PROG)$(sVERSION)">
+
+    <service name="network/radius"
+             type="service"
+             version="1">
+
+        <instance name="$(PROG)"
+                  enabled="false">
+
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
+
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
+
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
+
+            <dependent name="$(PROG)$(sVERSION)_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
+            <method_context security_flags="aslr">
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)" />
+            </method_context>
+
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/exec} -d %{config/dir}"
+                         timeout_seconds="60" />
+
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
+
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":kill -HUP"
+                         timeout_seconds="60" />
+
+            <property_group name="config"
+                            type="application">
+                <propval name="dir"
+                         type="astring"
+                         value="/etc/$(OPREFIX)/$(PROG)" />
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/sbin/radiusd" />
+            </property_group>
+
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">$(PROG) $(VERSION)</loctext>
+                </common_name>
+            </template>
+
+        </instance>
+
+        <stability value="External" />
+
+    </service>
+
+</service_bundle>

--- a/build/freeradius/local.mog
+++ b/build/freeradius/local.mog
@@ -1,0 +1,74 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=GPLv2
+license ../LICENCE.talloc license=LGPLv3
+
+# Create user and group
+group groupname=$(GROUP) gid=$(GID)
+user ftpuser=false username=$(USER) uid=$(UID) group=$(GROUP) \
+    gcos-field="RADIUS Daemon" \
+    home-dir=/var/$(PREFIX) password=NP
+
+# Skip dependency resolution for python components
+<transform file path=.*/python/(?:example|radiusd)\.py$ \
+    -> set pkg.depend.bypass-generate .*>
+
+# Drop docs
+<transform path=$(PREFIX)/share/doc -> drop>
+
+# Drop rc.radiusd
+<transform path=$(PREFIX)/sbin/rc.radiusd -> drop>
+
+# Drop talloc header and .pc
+<transform file path=.*/talloc.(?:pc|h)$ -> drop>
+
+# Drop static libs
+<transform file path=.*\.a$ -> drop>
+
+# Drop example certificates and bootstrap
+<transform file path=etc/$(PREFIX)/certs/.*~$ -> drop>
+<transform file path=etc/$(PREFIX)/certs/(?:dh|bootstrap) -> drop>
+<transform file \
+    path=etc/$(PREFIX)/certs/.*\.(?:key|csr|crl|crt|der|old|pem|p12|0|1) \
+    -> drop>
+<transform file path=etc/$(PREFIX)/certs/(?:serial|index\.txt) -> drop>
+
+# Copy default configuration files to distrib/ and set preserve on originals
+<transform dir path=etc/$(PREFIX)/(.*)$ -> emit \
+    dir path=X/etc/$(PREFIX)/distrib/%<1> \
+    owner=%(owner) group=%(group) mode=%(mode)>
+<transform file path=etc/$(PREFIX)/(.*)$ -> emit \
+    file %(path) path=X/etc/$(PREFIX)/distrib/%<1> \
+    owner=%(owner) group=%(group) mode=%(mode)>
+<transform link path=etc/$(PREFIX)/(.*)$ -> emit \
+    link path=X/etc/$(PREFIX)/distrib/%<1> target=%(target)>
+<transform link file path=etc/$(PREFIX) -> set preserve true>
+<transform path=X/ -> edit path X/ "">
+
+# Correct permissions and add home directory
+dir path=var/$(PREFIX) owner=$(USER) group=$(GROUP) mode=0750
+
+<transform file dir path=var/log/$(PREFIX) -> set owner $(USER)>
+<transform file dir path=var/log/$(PREFIX) -> set group $(GROUP)>
+<transform file dir path=var/log/$(PREFIX) -> set mode 0755>
+
+<transform file dir path=etc/$(PREFIX) -> set group $(GROUP)>
+<transform dir path=etc/$(PREFIX)$ -> set mode 0750>
+
+<include binlink.mog>
+<include manlink.mog>
+
+# Restart service on upgrade
+<transform file path=$(PREFIX)/sbin/ \
+    -> set restart_fmri svc:/network/radius:$(PROG)>
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -166,6 +166,7 @@ extra.omnios ooce/security/gnupg
 extra.omnios ooce/server/apache-24
 extra.omnios ooce/server/apache-24/modules/fcgid
 extra.omnios ooce/server/apache-24/modules/subversion
+extra.omnios ooce/server/freeradius
 extra.omnios ooce/server/haproxy
 extra.omnios ooce/server/nginx
 extra.omnios ooce/server/nginx-120

--- a/doc/idlist.md
+++ b/doc/idlist.md
@@ -30,6 +30,7 @@
 | illumos	| 70	| mysql
 | illumos	| 71	| lp
 | extra		| 72	| haproxy
+| extra		| 74	| radius
 | illumos	| 75	| openldap
 | extra		| 76	| zabbixa (agent)
 | extra		| 77	| zabbix
@@ -83,6 +84,7 @@
 | extra		| 67	| znc
 | illumos	| 70	| mysql
 | extra		| 72	| haproxy
+| extra		| 74	| radius
 | illumos	| 75	| openldap
 | extra		| 77	| zabbix
 | extra		| 78	| munin

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -150,6 +150,7 @@
 | ooce/security/gnupg		| 2.3.1		| https://gnupg.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/apache-24		| 2.4.48	| https://downloads.apache.org/httpd/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/apache-24/modules/fcgid | 2.3.9	| https://downloads.apache.org/httpd/mod_fcgid/ | [omniosorg](https://github.com/omniosorg)
+| ooce/server/freeradius	| 3.0.23	| https://freeradius.org/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/server/haproxy		| 2.4.2	| https://www.haproxy.org/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx		| 1.21.1	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx-120		| 1.20.1	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This adds freeradius 3.0, and libtalloc as this is a dependency we do not have.

The svc methode will copy the example config if no user config is provided, as sometimes you delete files from the example config, we don't want an update/upgrade to put them back.

```
root@build:~# ls -l /etc/opt/ooce/freeradius-3.0/
total 0
root@build:~# svcadm enable freeradius
root@build:~# ls -l /etc/opt/ooce/freeradius-3.0/
total 19
-rw-r--r--   1 radius   radius     20807 Jun 19 19:35 README.rst
drwxr-xr-x   2 radius   radius        36 Jun 19 19:35 certs
-rw-r--r--   1 radius   radius      8323 Jun 19 19:35 clients.conf
-rw-r--r--   1 radius   radius      1440 Jun 19 19:35 dictionary
-rw-r--r--   1 radius   radius      2661 Jun 19 19:35 experimental.conf
lrwxrwxrwx   1 radius   radius        30 Jun 19 19:35 hints -> ./mods-config/preprocess/hints
lrwxrwxrwx   1 radius   radius        35 Jun 19 19:35 huntgroups -> ./mods-config/preprocess/huntgroups
drwxr-xr-x   2 radius   radius        73 Jun 19 19:35 mods-available
drwxr-xr-x   9 radius   radius        10 Jun 19 19:35 mods-config
drwxr-xr-x   2 radius   radius        33 Jun 19 19:35 mods-enabled
-rw-r--r--   1 radius   radius        52 Jun 19 19:35 panic.gdb
drwxr-xr-x   2 radius   radius        14 Jun 19 19:35 policy.d
-rw-r--r--   1 radius   radius     28735 Jun 19 19:35 proxy.conf
-rw-r--r--   1 radius   radius     31996 Jun 19 19:35 radiusd.conf
drwxr-xr-x   2 radius   radius        30 Jun 19 19:35 sites-available
drwxr-xr-x   2 radius   radius         4 Jun 19 19:35 sites-enabled
-rw-r--r--   1 radius   radius      3470 Jun 19 19:35 templates.conf
-rw-r--r--   1 radius   radius      8536 Jun 19 19:35 trigger.conf
lrwxrwxrwx   1 radius   radius        29 Jun 19 19:35 users -> ./mods-config/files/authorize
root@build:~# svcs freeradius
STATE          STIME    FMRI
online         19:36:19 svc:/network/radius:freeradius
```