### PR TITLE
Update Virtualbox to support illumos 13915

### DIFF
--- a/build/virtualbox/patches/build-in-zone.patch
+++ b/build/virtualbox/patches/build-in-zone.patch
@@ -3,7 +3,7 @@ Patch originally taken from OpenIndiana, author is Alexander Pyhalov
 diff -wpruN '--exclude=*.orig' a~/Config.kmk a/Config.kmk
 --- a~/Config.kmk	1970-01-01 00:00:00
 +++ a/Config.kmk	1970-01-01 00:00:00
-@@ -2749,8 +2749,6 @@ $(PATH_OUT)/DynamicConfig.kmk: \
+@@ -2752,8 +2752,6 @@ $(PATH_OUT)/DynamicConfig.kmk: \
  		$(VBOX_GCC32_PATH_CC) \
  		$(VBOX_GCC32_PATH_CXX) \
  		$(VBOX_GCC32_LIBGCC) \

--- a/build/virtualbox/patches/ctf.patch
+++ b/build/virtualbox/patches/ctf.patch
@@ -68,7 +68,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  else # !KBUILD_USE_KOBJCACHE
-@@ -132,6 +156,9 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
+@@ -132,6 +158,9 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
  		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
  		-o $(obj)\
  		$(abspath $(source))
@@ -78,7 +78,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  endif # !KBUILD_USE_KOBJCACHE
-@@ -166,6 +191,9 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
+@@ -166,6 +195,9 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
  		$(flags) -fpreprocessed -x c++\
  		-o $(obj)\
  		-
@@ -88,7 +88,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  else # !KBUILD_USE_KOBJCACHE
-@@ -176,6 +202,9 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
+@@ -176,6 +208,9 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
  		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
  		-o $(obj)\
  		$(abspath $(source))
@@ -98,7 +98,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  endif # !KBUILD_USE_KOBJCACHE
-@@ -257,6 +284,10 @@ define TOOL_GCC3PLAIN_LINK_PROGRAM_CMDS
+@@ -257,6 +292,10 @@ define TOOL_GCC3PLAIN_LINK_PROGRAM_CMDS
  		$(filter %.def, $(othersrc))\
  		$(foreach p,$(libpath), -L$(p))\
  		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
@@ -109,7 +109,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3
  endef
  
  
-@@ -285,6 +314,10 @@ define TOOL_GCC3PLAIN_LINK_DLL_CMDS
+@@ -285,6 +324,10 @@ define TOOL_GCC3PLAIN_LINK_DLL_CMDS
  		$(filter %.def, $(othersrc))\
  		$(foreach p,$(libpath), -L$(p))\
  		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
@@ -120,7 +120,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GCC3PLAIN.kmk a/kBuild/tools/GCC3
  endef
  
  
-@@ -316,5 +347,9 @@ define TOOL_GCC3PLAIN_LINK_SYSMOD_CMDS
+@@ -316,5 +359,9 @@ define TOOL_GCC3PLAIN_LINK_SYSMOD_CMDS
  		$(filter %.def, $(othersrc))\
  		$(foreach p,$(libpath), -L$(p))\
  		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
@@ -194,7 +194,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GXX3PLAIN.kmk a/kBuild/tools/GXX3
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  
-@@ -231,6 +254,10 @@ define TOOL_GXX3PLAIN_COMPILE_AS_CMDS
+@@ -231,6 +256,10 @@ define TOOL_GXX3PLAIN_COMPILE_AS_CMDS
  		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
  		-o $(obj)\
  		$(abspath $(source))
@@ -205,7 +205,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GXX3PLAIN.kmk a/kBuild/tools/GXX3
  	$(QUIET)$(APPEND) -n "$(dep)" "" "$(source):" ""
  endef
  
-@@ -285,6 +310,10 @@ define TOOL_GXX3PLAIN_LINK_PROGRAM_CMDS
+@@ -285,6 +314,10 @@ define TOOL_GXX3PLAIN_LINK_PROGRAM_CMDS
  		$(filter %.def, $(othersrc))\
  		$(foreach p,$(libpath), -L$(p))\
  		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
@@ -216,7 +216,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GXX3PLAIN.kmk a/kBuild/tools/GXX3
  endef
  
  
-@@ -313,6 +340,10 @@ define TOOL_GXX3PLAIN_LINK_DLL_CMDS
+@@ -313,6 +346,10 @@ define TOOL_GXX3PLAIN_LINK_DLL_CMDS
  		$(filter %.def, $(othersrc))\
  		$(foreach p,$(libpath), -L$(p))\
  		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
@@ -227,7 +227,7 @@ diff -wpruN '--exclude=*.orig' a~/kBuild/tools/GXX3PLAIN.kmk a/kBuild/tools/GXX3
  endef
  
  
-@@ -344,5 +373,9 @@ define TOOL_GXX3PLAIN_LINK_SYSMOD_CMDS
+@@ -344,5 +381,9 @@ define TOOL_GXX3PLAIN_LINK_SYSMOD_CMDS
  		$(filter %.def, $(othersrc))\
  		$(foreach p,$(libpath), -L$(p))\
  		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))

--- a/build/virtualbox/patches/installctx.diff
+++ b/build/virtualbox/patches/installctx.diff
@@ -1,0 +1,130 @@
+
+The fix for
+
+    installctx() blocking allocate causes problems
+    https://www.illumos.org/issues/13915
+
+changed the signature of installctx() to take an additional argument which
+needs to be set to NULL for previous behaviour.
+
+diff -wpruN '--exclude=*.orig' a~/src/VBox/Runtime/r0drv/solaris/initterm-r0drv-solaris.c a/src/VBox/Runtime/r0drv/solaris/initterm-r0drv-solaris.c
+--- a~/src/VBox/Runtime/r0drv/solaris/initterm-r0drv-solaris.c	1970-01-01 00:00:00
++++ a/src/VBox/Runtime/r0drv/solaris/initterm-r0drv-solaris.c	1970-01-01 00:00:00
+@@ -68,6 +68,7 @@ bool                            g_frtSol
+ RTR0FNSOLXCCALL                 g_rtSolXcCall;
+ /** Whether to use the old-style installctx()/removectx() routines. */
+ bool                            g_frtSolOldThreadCtx = false;
++bool                            g_frtillumosNewThreadCtx = false;
+ /** The thread-context hooks callout table structure. */
+ RTR0FNSOLTHREADCTX              g_rtSolThreadCtx;
+ /** Thread preemption offset in the thread structure. */
+@@ -212,6 +213,15 @@ DECLHIDDEN(int) rtR0InitNative(void)
+         /*
+          * Mandatory: Thread-context hooks.
+          */
++        rc = RTR0DbgKrnlInfoQuerySymbol(g_hKrnlDbgInfo, NULL /* pszModule */, "installctx_preallocate",  NULL /* ppvSymbol */);
++        if (RT_SUCCESS(rc))
++        {
++            g_frtillumosNewThreadCtx = true;
++            g_rtSolThreadCtx.Install.pfnillumos_installctx = (void *)installctx;
++            g_rtSolThreadCtx.Remove.pfnillumos_removectx   = (void *)removectx;
++        }
++        else
++        {
+         rc = RTR0DbgKrnlInfoQuerySymbol(g_hKrnlDbgInfo, NULL /* pszModule */, "exitctx",  NULL /* ppvSymbol */);
+         if (RT_SUCCESS(rc))
+         {
+@@ -224,6 +234,7 @@ DECLHIDDEN(int) rtR0InitNative(void)
+             g_rtSolThreadCtx.Install.pfnSol_installctx_old = (void *)installctx;
+             g_rtSolThreadCtx.Remove.pfnSol_removectx_old   = (void *)removectx;
+         }
++        }
+ 
+         /*
+          * Mandatory: map_addr() hooks.
+diff -wpruN '--exclude=*.orig' a~/src/VBox/Runtime/r0drv/solaris/the-solaris-kernel.h a/src/VBox/Runtime/r0drv/solaris/the-solaris-kernel.h
+--- a~/src/VBox/Runtime/r0drv/solaris/the-solaris-kernel.h	1970-01-01 00:00:00
++++ a/src/VBox/Runtime/r0drv/solaris/the-solaris-kernel.h	1970-01-01 00:00:00
+@@ -163,6 +163,15 @@ typedef struct RTR0FNSOLTHREADCTX
+ {
+     union
+     {
++        void *(*pfnillumos_installctx)    (kthread_t *pThread, void *pvArg,
++                                           void (*pfnSave)(void *pvArg),
++                                           void (*pfnRestore)(void *pvArg),
++                                           void (*pfnFork)(void *pvThread, void *pvThreadFork),
++                                           void (*pfnLwpCreate)(void *pvThread, void *pvThreadCreate),
++                                           void (*pfnExit)(void *pvThread),
++                                           void (*pfnFree)(void *pvArg, int fIsExec),
++                                           void *ctx);
++
+         void *(*pfnSol_installctx)        (kthread_t *pThread, void *pvArg,
+                                            void (*pfnSave)(void *pvArg),
+                                            void (*pfnRestore)(void *pvArg),
+@@ -181,6 +190,14 @@ typedef struct RTR0FNSOLTHREADCTX
+ 
+     union
+     {
++        int (*pfnillumos_removectx)           (kthread_t *pThread, void *pvArg,
++                                           void (*pfnSave)(void *pvArg),
++                                           void (*pfnRestore)(void *pvArg),
++                                           void (*pfnFork)(void *pvThread, void *pvThreadFork),
++                                           void (*pfnLwpCreate)(void *pvThread, void *pvThreadCreate),
++                                           void (*pfnExit)(void *pvThread),
++                                           void (*pfnFree)(void *pvArg, int fIsExec));
++
+         int (*pfnSol_removectx)           (kthread_t *pThread, void *pvArg,
+                                            void (*pfnSave)(void *pvArg),
+                                            void (*pfnRestore)(void *pvArg),
+@@ -201,6 +218,7 @@ typedef RTR0FNSOLTHREADCTX *PRTR0FNSOLTH
+ 
+ extern RTR0FNSOLTHREADCTX       g_rtSolThreadCtx;
+ extern bool                     g_frtSolOldThreadCtx;
++extern bool                     g_frtillumosNewThreadCtx;
+ 
+ /*
+  * Workaround for older Solaris versions which called map_addr()/choose_addr()/
+diff -wpruN '--exclude=*.orig' a~/src/VBox/Runtime/r0drv/solaris/threadctxhooks-r0drv-solaris.c a/src/VBox/Runtime/r0drv/solaris/threadctxhooks-r0drv-solaris.c
+--- a~/src/VBox/Runtime/r0drv/solaris/threadctxhooks-r0drv-solaris.c	1970-01-01 00:00:00
++++ a/src/VBox/Runtime/r0drv/solaris/threadctxhooks-r0drv-solaris.c	1970-01-01 00:00:00
+@@ -182,7 +182,19 @@ RTDECL(int) RTThreadCtxHookCreate(PRTTHR
+      * with preemption disabled. We allocate the context-hooks here and use 'fEnabled' to determine if we can
+      * invoke the consumer's hook or not.
+      */
+-    if (g_frtSolOldThreadCtx)
++    if (g_frtillumosNewThreadCtx)
++    {
++        g_rtSolThreadCtx.Install.pfnillumos_installctx(curthread,
++                                                   pThis,
++                                                   rtThreadCtxHookSolOut,       /* save */
++                                                   rtThreadCtxHookSolIn,        /* restore */
++                                                   NULL,                        /* fork */
++                                                   NULL,                        /* lwp_create */
++                                                   NULL,                        /* exit */
++                                                   rtThreadCtxHookSolFree,
++                                                   NULL);                       /* ctx */
++    }
++    else if (g_frtSolOldThreadCtx)
+     {
+         g_rtSolThreadCtx.Install.pfnSol_installctx_old(curthread,
+                                                        pThis,
+@@ -244,7 +256,18 @@ RTDECL(int) RTThreadCtxHookDestroy(RTTHR
+          * ring-0 thread dies, Solaris will call rtThreadCtxHookSolFree() which will free the hook object.
+          */
+         int rc;
+-        if (g_frtSolOldThreadCtx)
++        if (g_frtillumosNewThreadCtx)
++        {
++            rc = g_rtSolThreadCtx.Remove.pfnillumos_removectx(curthread,
++                                                          pThis,
++                                                          rtThreadCtxHookSolOut,        /* save */
++                                                          rtThreadCtxHookSolIn,         /* restore */
++                                                          NULL,                         /* fork */
++                                                          NULL,                         /* lwp_create */
++                                                          NULL,                         /* exit */
++                                                          rtThreadCtxHookSolFree);
++        }
++        else if (g_frtSolOldThreadCtx)
+         {
+             rc = g_rtSolThreadCtx.Remove.pfnSol_removectx_old(curthread,
+                                                               pThis,

--- a/build/virtualbox/patches/series
+++ b/build/virtualbox/patches/series
@@ -4,3 +4,4 @@ solaris-install.patch
 build-in-zone.patch
 ctf.patch
 hma.patch
+installctx.diff

--- a/build/virtualbox/patches/solaris-install.patch
+++ b/build/virtualbox/patches/solaris-install.patch
@@ -5,7 +5,7 @@ the default layout without building the package file.
 diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/VBox/Installer/solaris/Makefile.kmk
 --- a~/src/VBox/Installer/solaris/Makefile.kmk	1970-01-01 00:00:00
 +++ a/src/VBox/Installer/solaris/Makefile.kmk	1970-01-01 00:00:00
-@@ -553,7 +553,6 @@
+@@ -553,7 +553,6 @@ $(VBOX_PATH_SI_SCRATCH)/dist-copy.ts: \
  		$(VBOX_PATH_SOL_INST_SRC)/vbox.pkginfo \
  		$(VBOX_PATH_SOL_INST_SRC)/vbox-ips.mog \
  		\
@@ -13,7 +13,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  		$(if-expr !defined(VBOX_OSE) && defined(VBOX_WITH_VBOXSDL), $(PATH_DEVTOOLS_TRG)/libsdl/v1.2.13/lib/libSDL-1.2.so.0.11.2,) \
  		\
  		$(if $(VBOX_OSE),,$(foreach arch, x86 amd64, $(foreach lib, libgcc_s.so.1 libstdc++.so.6, \
-@@ -614,8 +613,6 @@
+@@ -614,8 +613,6 @@ $(VBOX_PATH_SI_SCRATCH)/dist-copy.ts: \
  		"$($(var).SRC)/$(file)" "$($(var).DST)/$(file)")))
  
  # VirtualBox: Common files.
@@ -22,7 +22,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  	$(LN_SYMLINK) -f ./pkginstall.sh $(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/ipsinstall.sh
  	$(SED) -e "s/_HARDENED_/$(if $(VBOX_WITH_HARDENED),hardened,)/" \
  		--output $(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/vboxconfig.sh \
-@@ -631,9 +628,6 @@
+@@ -631,9 +628,6 @@ $(VBOX_PATH_SI_SCRATCH)/dist-copy.ts: \
  	$(if-expr defined(VBOX_WITH_QTGUI) \
  	,$(NLTAB)$(LN_SYMLINK) ../rdesktop-vrdp-keymaps/ $(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/$(VBOX_SI_ARCH)/rdesktop-vrdp-keymaps,)
  
@@ -32,7 +32,7 @@ diff -wpruN '--exclude=*.orig' a~/src/VBox/Installer/solaris/Makefile.kmk a/src/
  	$(if-expr !defined(VBOX_OSE) && defined(VBOX_WITH_VBOXSDL) \
  	,$(INSTALL) -s -m 0644 $(PATH_DEVTOOLS_TRG)/libsdl/v1.2.13/lib/libSDL-1.2.so.0.11.2 \
  		$(VBOX_PATH_SI_SCRATCH_PKG)/opt/VirtualBox/$(VBOX_SI_ARCH)/libSDL-1.2.so.0,)
-@@ -700,7 +694,7 @@
+@@ -700,7 +694,7 @@ $(VBOX_PATH_SI_SCRATCH)/dist-copy.ts: \
  # Creates the System V style installer package.
  #
  solaris-package:: $(VBOX_PATH_SI_SCRATCH)/$(PKG_FILENAME).pkg


### PR DESCRIPTION
Tested that this updated virtualbox package works on r151038 both before and after illumos 13915.

```
theeo% uname -a
SunOS theeo 5.11 omnios-r151038-a4c5b5181d i86pc i386 i86pc   <- upcoming r151038k

theeo% vagrant up
Bringing machine 'default' up with 'virtualbox' provider...

theeo% vagrant ssh
Linux debian-10 4.19.0-9-amd64 #1 SMP Debian 4.19.118-2+deb10u1 (2020-06-07) x86_64

Last login: Sat May  1 20:07:19 2021 from 10.0.2.2
vagrant@debian-10:~$
```