### PR TITLE
Actually have mosquitto use the config file

### DIFF
--- a/build/mosquitto/build.sh
+++ b/build/mosquitto/build.sh
@@ -65,7 +65,8 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build cmake
 build
-install_smf network mosquitto.xml
+xform files/mosquitto.xml > $TMPDIR/$PROG.xml
+install_smf network $PROG.xml
 make_package
 clean_up
 

--- a/build/mosquitto/files/mosquitto.xml
+++ b/build/mosquitto/files/mosquitto.xml
@@ -40,11 +40,11 @@
 
         <exec_method type="method"
                      name="start"
-                     exec="/opt/ooce/mosquitto/sbin/mosquitto -d"
+                     exec="/$(PREFIX)/sbin/mosquitto -d -c /etc/$(PREFIX)/mosquitto.conf"
                      timeout_seconds="60">
             <method_context security_flags="aslr">
-                <method_credential user="mosquitto"
-                                   group="mosquitto"
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
                                    privileges="basic,!proc_info,!proc_session" />
             </method_context>
         </exec_method>


### PR DESCRIPTION
mosquitto.xml now uses variables to not have hardcoded things like USER/GROUP and actually specifies the config path again, I'm pretty sure I had it in there originally but I guess not.

This slipped through the testing I did as the only change i had was toggle persistence in my config. Which wasn't picked up as I didn't do my testing cross mosquitto restarts.