### PR TITLE
Fixed user input bug by switching to read

### DIFF
--- a/build/byobu/build.sh
+++ b/build/byobu/build.sh
@@ -53,6 +53,7 @@ fix_shebang() {
 
 init
 download_source $PROG ${PROG}_$VER.orig
+patch_source
 fix_shebang
 prep_build
 build

--- a/build/byobu/patches/read_ctrl-a.in.patch
+++ b/build/byobu/patches/read_ctrl-a.in.patch
@@ -1,0 +1,19 @@
+diff -wpruN '--exclude=*.orig' a~/usr/bin/byobu-ctrl-a.in a/usr/bin/byobu-ctrl-a.in
+--- a~/usr/bin/byobu-ctrl-a.in	2017-09-25 11:25:23.000000000 +0000
++++ a/usr/bin/byobu-ctrl-a.in	2021-10-08 05:36:20.226004935 +0000
+@@ -85,12 +85,11 @@ while [ -z "$bind_to" ]; do
+ 	echo "  - You can press F9 and choose your escape character"
+ 	echo "  - You can run 'byobu-ctrl-a' at any time to change your selection"
+ 	echo
+-	printf "Select [1 or 2]: "
+-	s=$(head -n1)
++	read -p "Select [1 or 2]: " s
+ 	echo
+ 	case "$s" in
+-		1) bind_to="screen"; break;;
+-		2) bind_to="emacs"; break;;
++      1*) bind_to="screen"; break;;
++      2*) bind_to="emacs"; break;;
+ 	esac
+ done
+ 

--- a/build/byobu/patches/series
+++ b/build/byobu/patches/series
@@ -1,0 +1,1 @@
+read_ctrl-a.in.patch


### PR DESCRIPTION
I was having trouble were the interactive usage of byobu-ctrl-a would fail. Switched from head to read -p to resolve the issue.