### PR TITLE
Cleanup double / in default radiusd.conf

### DIFF
--- a/build/freeradius/build.sh
+++ b/build/freeradius/build.sh
@@ -74,8 +74,8 @@ note -n "Building $PROG"
 CONFIGURE_OPTS="
     --prefix=$PREFIX
     --sysconfdir=/etc$PREFIX
-    --with-logdir=/var/log/$PREFIX
-    --localstatedir=/var/$PREFIX
+    --with-logdir=/var/log$PREFIX
+    --localstatedir=/var$PREFIX
     --with-raddbdir=/etc$PREFIX
     --libdir=$PREFIX/lib/$ISAPART64
     --with-talloc-include-dir=$DESTDIR$PREFIX/include


### PR DESCRIPTION
On a new install I noticed the default radiusd.conf has `//` in 2 places, not a big deal. 
But we can easily fix this by bringing `--with-logdir=` and `--localstatedir=` inline with how they are setup for `--sysconfdir=`. 

This results in the following change in radiusd.conf

```diff
--- a/freeradius/etc/radiusd.conf
+++ b/freeradius/etc/radiusd.conf
@@ -1,9 +1,9 @@
 prefix = /opt/ooce/freeradius
 exec_prefix = ${prefix}
 sysconfdir = /etc/opt/ooce/freeradius
-localstatedir = /var//opt/ooce/freeradius
+localstatedir = /var/opt/ooce/freeradius
 sbindir = /opt/ooce/freeradius/sbin
-logdir = /var/log//opt/ooce/freeradius
+logdir = /var/log/opt/ooce/freeradius
 raddbdir = /etc/opt/ooce/freeradius
 radacctdir = ${logdir}/radacct
```