### PR TITLE
gnupg: grant proc_lock_memory

### DIFF
--- a/build/gnupg/build.sh
+++ b/build/gnupg/build.sh
@@ -113,6 +113,7 @@ PATH+=":$DEPROOT$PREFIX/bin"
 download_source $PROG $PROG $VER
 patch_source
 build -ctf
+install_execattr
 run_testsuite check
 make_package
 clean_up

--- a/build/gnupg/files/exec_attr
+++ b/build/gnupg/files/exec_attr
@@ -1,0 +1,1 @@
+Forced Privilege:solaris:cmd:::/$(PREFIX)/bin/gpg:privs=proc_lock_memory

--- a/build/gnupg/local.mog
+++ b/build/gnupg/local.mog
@@ -12,16 +12,25 @@
 
 license COPYING license=GPLv3
 license COPYING.other license=simplified-BSD
-license ../libgpg-error-$(GPGERROR)/COPYING.LIB license=LGPLv2.1
-license ../libgcrypt-$(GCRYPT)/COPYING.LIB license=LGPLv2.1
+license ../libgpg-error-$(GPGERROR)/COPYING.LIB license=LGPLv2.1/libgpgerror
+license ../libgcrypt-$(GCRYPT)/COPYING.LIB license=LGPLv2.1/libgcrypt
 license ../libksba-$(KSBA)/COPYING.LGPLv3 license=LGPLv3
-license ../libassuan-$(ASSUAN)/COPYING.LIB license=LGPLv2.1
-license ../npth-$(NPTH)/COPYING.LIB license=LGPLv2.1
+license ../libassuan-$(ASSUAN)/COPYING.LIB license=LGPLv2.1/libsassuan
+license ../npth-$(NPTH)/COPYING.LIB license=LGPLv2.1/npth
 license ../pinentry-$(PINENTRY)/COPYING license=GPLv2
 
 dir group=bin mode=0755 owner=root path=etc/$(PREFIX)
 
 <transform path=$(PREFIX)/share/(?:doc|info) -> drop>
+
+# gpg needs the proc_lock_memory privilege in order to be able to lock a
+# memory segment. If it can't do that, it utters
+#    gpg: Warning: using insecure memory!
+# Using the illumos forced privileges feature, we afford it the additional
+# privilege by making it setuid root and installing an exec_attr entry
+# to add just the necessary privilege. See files/exec_attr.
+<transform path=$(PREFIX)/bin/gpg$ -> set owner root>
+<transform path=$(PREFIX)/bin/gpg$ -> set mode 04755>
 
 <include binlink.mog>
 <include manlink.mog>


### PR DESCRIPTION
This fixes the `gpg: Warning: using insecure memory!` warning that is shown to non-root users by granting `gpg` the `lock_memory` privilege using illumos' forced privileges feature.

```
build% id
uid=100(af) gid=1(other)
build% gpg
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
gpg: Go ahead and type your message ...
^Z
zsh: suspended  gpg
build% pfexec pcred `pgrep -n gpg`
244:    e/r/suid=100  e/r/sgid=1
build% pfexec ppriv `pgrep -n gpg`
244:    gpg
flags = <none>
        E: basic,proc_lock_memory
        I: basic
        P: basic,proc_lock_memory
 
build% ls -lL =gpg
-rwsr-xr-x   1 root     bin        2.90M Dec 21 21:51 /opt/ooce/bin/gpg*
build% rg gnupg /etc/security/exec_attr
98:Forced Privilege:solaris:cmd:::/opt/ooce/gnupg/bin/gpg:privs=proc_lock_memory
```