### PR TITLE
alpine: switch to libuuid for uuid generation

### DIFF
--- a/build/alpine/build.sh
+++ b/build/alpine/build.sh
@@ -48,6 +48,8 @@ CONFIGURE_OPTS="
     --with-ldap-lib-dir=$OPREFIX/lib/$ISAPART64
 "
 
+export LIBS=-luuid
+
 init
 download_source $PROG $PROG $VER
 prep_build autoconf -autoreconf

--- a/build/alpine/patches/series
+++ b/build/alpine/patches/series
@@ -1,1 +1,2 @@
 lib.patch
+uuid.patch

--- a/build/alpine/patches/uuid.patch
+++ b/build/alpine/patches/uuid.patch
@@ -1,0 +1,49 @@
+
+In https://repo.or.cz/alpine.git?a=commit;h=4d77713f495bc1e797393cb05e88f17f7
+alpine switch to generating message IDs using the built in oauth2 random
+UUID generator. Unfortunately this is not very robust as it uses a sequence
+of calls to random(), which is seeded.
+
+Duplicate message IDs have been seen in the wild, use libuuid instead.
+
+diff --git a/imap/src/c-client/oauth2_aux.c b/imap/src/c-client/oauth2_aux.c
+index d2ad6ce..ca0fadb 100644
+--- a/imap/src/c-client/oauth2_aux.c
++++ b/imap/src/c-client/oauth2_aux.c
+@@ -24,30 +24,20 @@
+ #include "json.h"
+ #include "oauth2_aux.h"
+ 
++#include <uuid/uuid.h>
++
+ /* we generate something like a guid, but not care about
+  * anything, but that it is really random.
+  */
+ char *oauth2_generate_state(void)
+ {
+-  char rv[37];
++  char rv[UUID_PRINTABLE_STRING_LENGTH];
++  uuid_t uu;
+   int i;
+ 
+   rv[0] = '\0';
+-  for(i = 0; i < 4; i++)
+-     sprintf(rv + strlen(rv), "%x", (unsigned int) (random() % 256));
+-  sprintf(rv + strlen(rv), "%c", '-');
+-  for(i = 0; i < 2; i++)
+-     sprintf(rv + strlen(rv), "%x", (unsigned int) (random() % 256));
+-  sprintf(rv + strlen(rv), "%c", '-');
+-  for(i = 0; i < 2; i++)
+-     sprintf(rv + strlen(rv), "%x", (unsigned int) (random() % 256));
+-  sprintf(rv + strlen(rv), "%c", '-');
+-  for(i = 0; i < 2; i++)
+-     sprintf(rv + strlen(rv), "%x", (unsigned int) (random() % 256));
+-  sprintf(rv + strlen(rv), "%c", '-');
+-  for(i = 0; i < 6; i++)
+-     sprintf(rv + strlen(rv), "%x", (unsigned int) (random() % 256));
+-  rv[36] = '\0';
++  uuid_generate(uu);
++  uuid_unparse_lower(uu, rv);
+   return cpystr(rv);
+ }
+ 


### PR DESCRIPTION
The current algorithm is flawed, using only the bottom bits of `random()`. From the man page:

> Different srandom() seeds often produce, within an offset, the same sequence of low order bits from random().
