### PR TITLE
postgresql use ISM by default and add DISM support.

### DIFF
--- a/build/citus/build.sh
+++ b/build/citus/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=citus
+PKG=ooce/database/citus-XX
+VER=10.2.4
+SUMMARY="Citus PostgreSQL XX extension"
+DESC="Transforms PostgreSQL XX into a distributed database"
+
+PGVERSIONS="13 14"
+
+DEF_BUILD_DEPENDS_IPS="ooce/library/postgresql-XX"
+DEF_RUN_DEPENDS_IPS="ooce/database/postgresql-XX"
+
+OPREFIX=$PREFIX
+OPATH=$PATH
+
+set_arch 64
+
+SKIP_LICENCES=AGPLv3
+
+init
+download_source $PROG v$VER
+patch_source
+
+for v in $PGVERSIONS; do
+    PREFIX=$OPREFIX/pgsql-$v
+
+    # Make sure the right pg_config is used.
+    export PATH="$PREFIX/bin:$OPATH"
+
+    reset_configure_opts
+    BUILD_DEPENDS_IPS=${DEF_RUN_DEPENDS_IPS/XX/$v} \
+
+    prep_build
+    build
+    PKG=${PKG/XX/$v} \
+        RUN_DEPENDS_IPS=${DEF_RUN_DEPENDS_IPS/XX/$v} \
+        SUMMARY=${SUMMARY/XX/$v} \
+        DESC=${DESC/XX/$v} \
+        make_package
+done
+
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/citus/files/ctf.ignore
+++ b/build/citus/files/ctf.ignore
@@ -1,0 +1,3 @@
+ruleutils_12.c
+ruleutils_13.c
+ruleutils_14.c

--- a/build/citus/local.mog
+++ b/build/citus/local.mog
@@ -10,17 +10,5 @@
 #
 # Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 
-# Drop html documentation
-<transform path=$(PREFIX)/share/doc/html -> drop>
-
-<transform path=$(PREFIX)/lib(?:/amd64)?/pgxs(?:/|$) -> set facet.devel true>
-
-# Drop 32-bit binaries
-<transform path=$(PREFIX)/bin/i386/(?!pg_config) -> drop>
-<transform path=$(OPREFIX)/bin/(i386|amd64) -> drop>
-
-<include mediated-binlink.mog>
-<include mediated-manlink.mog>
-
-license COPYRIGHT license=postgresql
+license LICENSE license=AGPLv3
 

--- a/build/citus/patches/fix-build-in-zone.patch
+++ b/build/citus/patches/fix-build-in-zone.patch
@@ -1,0 +1,21 @@
+diff -wpruN '--exclude=*.orig' a~/src/backend/distributed/Makefile a/src/backend/distributed/Makefile
+--- a~/src/backend/distributed/Makefile	1970-01-01 00:00:00
++++ a/src/backend/distributed/Makefile	1970-01-01 00:00:00
+@@ -18,7 +18,7 @@ generated_downgrade_sql_files += $(patsu
+ DATA_built = $(generated_sql_files)
+ 
+ # directories with source files
+-SUBDIRS = . commands connection ddl deparser executor metadata operations planner progress relay safeclib test transaction utils worker
++SUBDIRS = commands connection ddl deparser executor metadata operations planner progress relay safeclib test transaction utils worker
+ # columnar modules
+ SUBDIRS += ../columnar
+ # enterprise modules
+@@ -33,6 +33,8 @@ ENSURE_SUBDIRS_EXIST := $(shell mkdir -p
+ OBJS += \
+ 	$(patsubst $(citus_abs_srcdir)/%.c,%.o,$(foreach dir,$(SUBDIRS), $(sort $(wildcard $(citus_abs_srcdir)/$(dir)/*.c))))
+ 
++OBJS += shared_library_init.o
++
+ # be explicit about the default target
+ all:
+ 

--- a/build/citus/patches/series
+++ b/build/citus/patches/series
@@ -1,0 +1,2 @@
+sys_stat.patch
+fix-build-in-zone.patch

--- a/build/citus/patches/sys_stat.patch
+++ b/build/citus/patches/sys_stat.patch
@@ -1,0 +1,11 @@
+diff -wpruN '--exclude=*.orig' a~/src/backend/distributed/commands/multi_copy.c a/src/backend/distributed/commands/multi_copy.c
+--- a~/src/backend/distributed/commands/multi_copy.c	1970-01-01 00:00:00
++++ a/src/backend/distributed/commands/multi_copy.c	1970-01-01 00:00:00
+@@ -54,6 +54,7 @@
+ 
+ #include <arpa/inet.h> /* for htons */
+ #include <netinet/in.h> /* for htons */
++#include <sys/stat.h>
+ #include <string.h>
+ 
+ #include "distributed/pg_version_constants.h"

--- a/build/postgresql/build-10.sh
+++ b/build/postgresql/build-10.sh
@@ -59,7 +59,7 @@ CONFIGURE_OPTS="
     --enable-thread-safety
     --with-openssl
     --with-libxml
-    --with-xslt
+    --with-libxslt
     --with-readline
     --without-systemd
     --with-system-tzdata=/usr/share/lib/zoneinfo

--- a/build/postgresql/build-11.sh
+++ b/build/postgresql/build-11.sh
@@ -59,7 +59,7 @@ CONFIGURE_OPTS="
     --enable-thread-safety
     --with-openssl
     --with-libxml
-    --with-xslt
+    --with-libxslt
     --with-readline
     --without-systemd
     --with-system-tzdata=/usr/share/lib/zoneinfo

--- a/build/postgresql/build-12.sh
+++ b/build/postgresql/build-12.sh
@@ -57,7 +57,7 @@ CONFIGURE_OPTS="
     --enable-thread-safety
     --with-openssl
     --with-libxml
-    --with-xslt
+    --with-libxslt
     --with-readline
     --without-systemd
     --with-system-tzdata=/usr/share/lib/zoneinfo

--- a/build/postgresql/build-13.sh
+++ b/build/postgresql/build-13.sh
@@ -57,7 +57,7 @@ CONFIGURE_OPTS="
     --enable-thread-safety
     --with-openssl
     --with-libxml
-    --with-xslt
+    --with-libxslt
     --with-readline
     --without-systemd
     --with-system-tzdata=/usr/share/lib/zoneinfo

--- a/build/postgresql/build-13.sh
+++ b/build/postgresql/build-13.sh
@@ -74,9 +74,11 @@ MAKE_INSTALL_TARGET=install-world
 
 build_manifests() {
     manifest_start $TMPDIR/manifest.client
-    manifest_add_dir $PREFIX/include libpq
+    manifest_add_dir $PREFIX/include '.*'
     manifest_add_dir $PREFIX/lib/pkgconfig
     manifest_add_dir $PREFIX/lib/$ISAPART64/pkgconfig
+    manifest_add_dir $PREFIX/lib/pgxs '.*'
+    manifest_add_dir $PREFIX/lib/$ISAPART64/pgxs '.*'
     manifest_add $PREFIX/lib '.*lib(pq\.|ecpg|pgtypes|pgcommon|pgport).*'
     manifest_add $PREFIX/bin '.*pg_config' psql ecpg
     manifest_add $PREFIX/share/man/man1 pg_config.1 psql.1 ecpg.1

--- a/build/postgresql/build-14.sh
+++ b/build/postgresql/build-14.sh
@@ -57,8 +57,9 @@ CONFIGURE_OPTS="
     --localstatedir=$VARPATH
     --enable-thread-safety
     --with-openssl
+    --with-lz4
     --with-libxml
-    --with-xslt
+    --with-libxslt
     --with-readline
     --without-systemd
     --with-system-tzdata=/usr/share/lib/zoneinfo

--- a/build/postgresql/build-14.sh
+++ b/build/postgresql/build-14.sh
@@ -76,9 +76,11 @@ MAKE_INSTALL_TARGET=install-world
 
 build_manifests() {
     manifest_start $TMPDIR/manifest.client
-    manifest_add_dir $PREFIX/include libpq
+    manifest_add_dir $PREFIX/include '.*'
     manifest_add_dir $PREFIX/lib/pkgconfig
     manifest_add_dir $PREFIX/lib/$ISAPART64/pkgconfig
+    manifest_add_dir $PREFIX/lib/pgxs '.*'
+    manifest_add_dir $PREFIX/lib/$ISAPART64/pgxs '.*'
     manifest_add $PREFIX/lib '.*lib(pq\.|ecpg|pgtypes|pgcommon|pgport).*'
     manifest_add $PREFIX/bin '.*pg_config' psql ecpg
     manifest_add $PREFIX/share/man/man1 pg_config.1 psql.1 ecpg.1

--- a/build/postgresql/patches-12/dism.patch
+++ b/build/postgresql/patches-12/dism.patch
@@ -1,0 +1,94 @@
+On Solaris we want to use DISM or ISM e.g. Dynamic Intimate Shared Memory or Intimate Shared Memory
+which is available via sysv SHM only. This patch changes the default shared memory system to be sysv
+on Solaris based systems e.g. which have SHM_SHARE_MMU (which translates to ISM) and when SHM_PAGEABLE
+is defined in sys/shm.h we set the default PG_SHMAT_FLAGS to SHM_PAGEABLE which will lead to DISM being
+used. The patch to the postgresql.conf.sample is to show that sysv is the default for Solaris and the
+ordering is changed as by default it used to be mmap and posix for the defaults and you could always
+override things using the sysv setting.
+--
+diff -wpruN '--exclude=*.orig' a~/src/backend/utils/misc/postgresql.conf.sample a/src/backend/utils/misc/postgresql.conf.sample
+--- a~/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
++++ a/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
+@@ -132,16 +132,16 @@
+ #maintenance_work_mem = 64MB		# min 1MB
+ #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+ #max_stack_depth = 2MB			# min 100kB
+-#shared_memory_type = mmap		# the default is the first option
++#shared_memory_type = sysv		# the default is the first option
+ 					# supported by the operating system:
+-					#   mmap
+ 					#   sysv
++					#   mmap
+ 					#   windows
+ 					# (change requires restart)
+-#dynamic_shared_memory_type = posix	# the default is the first option
++#dynamic_shared_memory_type = sysv	# the default is the first option
+ 					# supported by the operating system:
+-					#   posix
+ 					#   sysv
++					#   posix
+ 					#   windows
+ 					#   mmap
+ 					# (change requires restart)
+diff -wpruN '--exclude=*.orig' a~/src/include/portability/mem.h a/src/include/portability/mem.h
+--- a~/src/include/portability/mem.h	1970-01-01 00:00:00
++++ a/src/include/portability/mem.h	1970-01-01 00:00:00
+@@ -14,11 +14,15 @@
+ 
+ #define IPCProtection	(0600)	/* access/modify by user only */
+ 
++#ifdef SHM_PAGEABLE			/* use dynamic intimate shared memory on Solaris */
++#define PG_SHMAT_FLAGS			SHM_PAGEABLE
++#else
+ #ifdef SHM_SHARE_MMU			/* use intimate shared memory on Solaris */
+ #define PG_SHMAT_FLAGS			SHM_SHARE_MMU
+ #else
+ #define PG_SHMAT_FLAGS			0
+ #endif
++#endif
+ 
+ /* Linux prefers MAP_ANONYMOUS, but the flag is called MAP_ANON on other systems. */
+ #ifndef MAP_ANONYMOUS
+diff -wpruN '--exclude=*.orig' a~/src/include/storage/dsm_impl.h a/src/include/storage/dsm_impl.h
+--- a~/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
++++ a/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
+@@ -19,6 +19,13 @@
+ #define DSM_IMPL_WINDOWS		3
+ #define DSM_IMPL_MMAP			4
+ 
++#ifdef HAVE_SYS_SHM_H
++/*
++ * For SHM_SHARE_MMU.
++ */
++#include <sys/shm.h>
++#endif
++
+ /*
+  * Determine which dynamic shared memory implementations will be supported
+  * on this platform, and which one will be the default.
+@@ -34,6 +41,11 @@
+ #define USE_DSM_SYSV
+ #ifndef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
+ #define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#else
++#ifdef SHM_SHARE_MMU
++#undef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
++#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#endif
+ #endif
+ #define USE_DSM_MMAP
+ #endif
+diff -wpruN '--exclude=*.orig' a~/src/include/storage/pg_shmem.h a/src/include/storage/pg_shmem.h
+--- a~/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
++++ a/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
+@@ -69,7 +69,9 @@
+ #endif
+ extern void *UsedShmemSegAddr;
+ 
+-#if !defined(WIN32) && !defined(EXEC_BACKEND)
++#if defined(SHM_SHARE_MMU)
++#define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV
++#elif !defined(WIN32) && !defined(EXEC_BACKEND)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_MMAP
+ #elif !defined(WIN32)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV

--- a/build/postgresql/patches-12/series
+++ b/build/postgresql/patches-12/series
@@ -1,0 +1,1 @@
+dism.patch

--- a/build/postgresql/patches-13/dism.patch
+++ b/build/postgresql/patches-13/dism.patch
@@ -1,0 +1,94 @@
+On Solaris we want to use DISM or ISM e.g. Dynamic Intimate Shared Memory or Intimate Shared Memory
+which is available via sysv SHM only. This patch changes the default shared memory system to be sysv
+on Solaris based systems e.g. which have SHM_SHARE_MMU (which translates to ISM) and when SHM_PAGEABLE
+is defined in sys/shm.h we set the default PG_SHMAT_FLAGS to SHM_PAGEABLE which will lead to DISM being
+used. The patch to the postgresql.conf.sample is to show that sysv is the default for Solaris and the
+ordering is changed as by default it used to be mmap and posix for the defaults and you could always
+override things using the sysv setting.
+--
+diff -wpruN '--exclude=*.orig' a~/src/backend/utils/misc/postgresql.conf.sample a/src/backend/utils/misc/postgresql.conf.sample
+--- a~/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
++++ a/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
+@@ -134,16 +134,16 @@
+ #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+ #logical_decoding_work_mem = 64MB	# min 64kB
+ #max_stack_depth = 2MB			# min 100kB
+-#shared_memory_type = mmap		# the default is the first option
++#shared_memory_type = sysv		# the default is the first option
+ 					# supported by the operating system:
+-					#   mmap
+ 					#   sysv
++					#   mmap
+ 					#   windows
+ 					# (change requires restart)
+-#dynamic_shared_memory_type = posix	# the default is the first option
++#dynamic_shared_memory_type = sysv	# the default is the first option
+ 					# supported by the operating system:
+-					#   posix
+ 					#   sysv
++					#   posix
+ 					#   windows
+ 					#   mmap
+ 					# (change requires restart)
+diff -wpruN '--exclude=*.orig' a~/src/include/portability/mem.h a/src/include/portability/mem.h
+--- a~/src/include/portability/mem.h	1970-01-01 00:00:00
++++ a/src/include/portability/mem.h	1970-01-01 00:00:00
+@@ -14,11 +14,15 @@
+ 
+ #define IPCProtection	(0600)	/* access/modify by user only */
+ 
++#ifdef SHM_PAGEABLE			/* use dynamic intimate shared memory on Solaris */
++#define PG_SHMAT_FLAGS			SHM_PAGEABLE
++#else
+ #ifdef SHM_SHARE_MMU			/* use intimate shared memory on Solaris */
+ #define PG_SHMAT_FLAGS			SHM_SHARE_MMU
+ #else
+ #define PG_SHMAT_FLAGS			0
+ #endif
++#endif
+ 
+ /* Linux prefers MAP_ANONYMOUS, but the flag is called MAP_ANON on other systems. */
+ #ifndef MAP_ANONYMOUS
+diff -wpruN '--exclude=*.orig' a~/src/include/storage/dsm_impl.h a/src/include/storage/dsm_impl.h
+--- a~/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
++++ a/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
+@@ -19,6 +19,13 @@
+ #define DSM_IMPL_WINDOWS		3
+ #define DSM_IMPL_MMAP			4
+ 
++#ifdef HAVE_SYS_SHM_H
++/*
++ * For SHM_SHARE_MMU.
++ */
++#include <sys/shm.h>
++#endif
++
+ /*
+  * Determine which dynamic shared memory implementations will be supported
+  * on this platform, and which one will be the default.
+@@ -34,6 +41,11 @@
+ #define USE_DSM_SYSV
+ #ifndef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
+ #define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#else
++#ifdef SHM_SHARE_MMU
++#undef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
++#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#endif
+ #endif
+ #define USE_DSM_MMAP
+ #endif
+diff -wpruN '--exclude=*.orig' a~/src/include/storage/pg_shmem.h a/src/include/storage/pg_shmem.h
+--- a~/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
++++ a/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
+@@ -69,7 +69,9 @@
+ #endif
+ extern void *UsedShmemSegAddr;
+ 
+-#if !defined(WIN32) && !defined(EXEC_BACKEND)
++#if defined(SHM_SHARE_MMU)
++#define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV
++#elif !defined(WIN32) && !defined(EXEC_BACKEND)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_MMAP
+ #elif !defined(WIN32)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV

--- a/build/postgresql/patches-13/series
+++ b/build/postgresql/patches-13/series
@@ -1,0 +1,1 @@
+dism.patch

--- a/build/postgresql/patches-14/dism.patch
+++ b/build/postgresql/patches-14/dism.patch
@@ -1,0 +1,96 @@
+On Solaris we want to use DISM or ISM e.g. Dynamic Intimate Shared Memory or Intimate Shared Memory
+which is available via sysv SHM only. This patch changes the default shared memory system to be sysv
+on Solaris based systems e.g. which have SHM_SHARE_MMU (which translates to ISM) and when SHM_PAGEABLE
+is defined in sys/shm.h we set the default PG_SHMAT_FLAGS to SHM_PAGEABLE which will lead to DISM being
+used. The patch to the postgresql.conf.sample is to show that sysv is the default for Solaris and the
+ordering is changed as by default it used to be mmap and posix for the defaults and you could always
+override things using the sysv setting.
+--
+diff -wpruN '--exclude=*.orig' a~/src/backend/utils/misc/postgresql.conf.sample a/src/backend/utils/misc/postgresql.conf.sample
+--- a~/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
++++ a/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
+@@ -141,16 +141,16 @@
+ #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+ #logical_decoding_work_mem = 64MB	# min 64kB
+ #max_stack_depth = 2MB			# min 100kB
+-#shared_memory_type = mmap		# the default is the first option
++#shared_memory_type = sysv		# the default is the first option
+ 					# supported by the operating system:
+-					#   mmap
+ 					#   sysv
++					#   mmap
+ 					#   windows
+ 					# (change requires restart)
+-#dynamic_shared_memory_type = posix	# the default is the first option
++#dynamic_shared_memory_type = sysv	# the default is the first option
+ 					# supported by the operating system:
+-					#   posix
+ 					#   sysv
++					#   posix
+ 					#   windows
+ 					#   mmap
+ 					# (change requires restart)
+diff -wpruN '--exclude=*.orig' a~/src/include/portability/mem.h a/src/include/portability/mem.h
+--- a~/src/include/portability/mem.h	1970-01-01 00:00:00
++++ a/src/include/portability/mem.h	1970-01-01 00:00:00
+@@ -14,11 +14,15 @@
+ 
+ #define IPCProtection	(0600)	/* access/modify by user only */
+ 
++#ifdef SHM_PAGEABLE			/* use dynamic intimate shared memory on Solaris */
++#define PG_SHMAT_FLAGS			SHM_PAGEABLE
++#else
+ #ifdef SHM_SHARE_MMU			/* use intimate shared memory on Solaris */
+ #define PG_SHMAT_FLAGS			SHM_SHARE_MMU
+ #else
+ #define PG_SHMAT_FLAGS			0
+ #endif
++#endif
+ 
+ /* Linux prefers MAP_ANONYMOUS, but the flag is called MAP_ANON on other systems. */
+ #ifndef MAP_ANONYMOUS
+diff -wpruN '--exclude=*.orig' a~/src/include/storage/dsm_impl.h a/src/include/storage/dsm_impl.h
+--- a~/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
++++ a/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
+@@ -19,7 +19,14 @@
+ #define DSM_IMPL_WINDOWS		3
+ #define DSM_IMPL_MMAP			4
+ 
++#ifdef HAVE_SYS_SHM_H
+ /*
++ * For SHM_SHARE_MMU.
++ */
++#include <sys/shm.h>
++#endif
++
++/*
+  * Determine which dynamic shared memory implementations will be supported
+  * on this platform, and which one will be the default.
+  */
+@@ -34,7 +41,12 @@
+ #define USE_DSM_SYSV
+ #ifndef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
+ #define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#else
++#ifdef SHM_SHARE_MMU
++#undef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
++#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
+ #endif
++#endif
+ #define USE_DSM_MMAP
+ #endif
+ 
+diff -wpruN '--exclude=*.orig' a~/src/include/storage/pg_shmem.h a/src/include/storage/pg_shmem.h
+--- a~/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
++++ a/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
+@@ -70,7 +70,9 @@
+ #endif
+ extern void *UsedShmemSegAddr;
+ 
+-#if !defined(WIN32) && !defined(EXEC_BACKEND)
++#if defined(SHM_SHARE_MMU)
++#define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV
++#elif !defined(WIN32) && !defined(EXEC_BACKEND)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_MMAP
+ #elif !defined(WIN32)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV

--- a/build/postgresql/patches-14/series
+++ b/build/postgresql/patches-14/series
@@ -1,0 +1,1 @@
+dism.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -35,6 +35,8 @@ extra.omnios ooce/compress/pbzip2
 extra.omnios ooce/compress/pigz
 extra.omnios ooce/compress/zstd r
 extra.omnios ooce/database/bdb
+extra.omnios ooce/database/citus-13
+extra.omnios ooce/database/citus-14
 extra.omnios ooce/database/lmdb
 extra.omnios ooce/database/mariadb-104
 extra.omnios ooce/database/mariadb-105

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -30,6 +30,7 @@
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pigz		| 2.7		| https://zlib.net/pigz/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/bdb		| 5.3.28	| http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html | [omniosorg](https://github.com/omniosorg)
+| ooce/database/citus-XX	| 10.2.4	| https://github.com/citusdata/citus/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/database/lmdb		| 0.9.29	| https://github.com/LMDB/lmdb/tags https://symas.com/lmdb/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-104	| 10.4.22	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-105	| 10.5.13	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)

--- a/tools/audit
+++ b/tools/audit
@@ -130,6 +130,14 @@ add_target()
                 done
                 pkg=
                 ;;
+            */citus-XX:*)
+                pver=`grep '^PGVERSIONS=' $build | cut -d= -f2 \
+                    | cut -d '"' -f2`
+                for p in $pver; do
+                    targets[${pkg/XX/${p//./}}]=$ver
+                done
+                pkg=
+                ;;
             *:github-latest*)
                 ver=`github_latest $pkg $ver`
                 ;;


### PR DESCRIPTION
This adds support for using Intimate Shared Memory using the sysv SHM
methods and Dynamic Intimate Shared Memory when available by checking
for the SHM_PAGEABLE flag in <sys/shm.h>. This makes it possible to have
ISM/DISM without needing to set the shared_memory_type and
dynamic_shared_memory_type to sysv in postgresql.conf. The setting of
shared_memory_type is something that seems to origin from Joyent for
Manta and is available in upstream versions 12 and later so we only
patch those versions for now. Dropped --with-xslt configure options
as all versions issue an unrecognized option for that configure option.