### PR TITLE
enable JIT/llvm support for postgresql14.

### DIFF
--- a/build/postgresql/build-14.sh
+++ b/build/postgresql/build-14.sh
@@ -25,6 +25,12 @@ DESC="The World's Most Advanced Open Source Relational Database"
 
 SKIP_LICENCES=postgresql
 
+# We want to populate the clang-related environment variables
+# and set PATH to point to the correct llvm/clang version for
+# the postgres JIT code, but we want to build with gcc.
+set_clangver
+set_gccver $DEFAULT_GCC_VER
+
 MAJVER=${VER%.*}            # M.m
 sMAJVER=${MAJVER//./}       # Mm
 set_patchdir patches-$sMAJVER
@@ -65,8 +71,9 @@ CONFIGURE_OPTS="
     --with-system-tzdata=/usr/share/lib/zoneinfo
 "
 
-CONFIGURE_OPTS_64+="
+CONFIGURE_OPTS_WS_64+="
     --bindir=$PREFIX/bin
+    --with-llvm LLVM_CONFIG=\"$CLANGPATH/bin/llvm-config --link-static\"
     --enable-dtrace DTRACEFLAGS=-64
 "
 

--- a/build/postgresql/files/ctf.ignore
+++ b/build/postgresql/files/ctf.ignore
@@ -1,1 +1,6 @@
 dynloader.c
+regcomp.c
+regerror.c
+regexec.c
+regfree.c
+regstrlcpy.c


### PR DESCRIPTION
This statically links the llvm stuff into /opt/ooce/pgsql-14/lib/amd64/llvmjit.so which leads to
it being around 50 Mb e.g. pkg.csize=18194824 pkg.size=50894672

I first tried dynamic linking but the we need  /opt/ooce/llvm-13/lib/libLLVM-13.so which is 116967096 bytes.

So statically linking saves us about 56% thanks hadfl for the hint.
