### PR TITLE
pg_repack fix typo in build script.

### DIFF
--- a/build/pg_repack/build.sh
+++ b/build/pg_repack/build.sh
@@ -67,7 +67,7 @@ for v in $PGVERSIONS; do
             -DMEDIATOR=postgresql -DMEDIATOR_VERSION=$v
             -DVERSION=$v
             -DsVERSION=$v
-        "
+        " \
         make_package
     clean_up
 done


### PR DESCRIPTION
This fixes published both pg13 and pg14 version under the same pkg name. The is a missing \ in the cmdline before make_package which I missed by last moment change.