### PR TITLE
dnsmasq: add package (ver 2.86)

### DIFF
--- a/build/dnsmasq/build.sh
+++ b/build/dnsmasq/build.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=dnsmasq
+VER=2.86
+PKG=ooce/network/dnsmasq
+SUMMARY="Lightweight, easy to configure DNS forwarder"
+DESC="dnsmasq is a lightweight, easy to configure DNS forwarder, designed to "
+DESC+="provide DNS (and optionally DHCP and TFTP) services to a small-scale network."
+
+set_arch 64
+set_mirror 'https://thekelleys.org.uk/'
+set_checksum sha256 '28d52cfc9e2004ac4f85274f52b32e1647b4dbc9761b82e7de1e41c49907eb08'
+
+BASEDIR=$PREFIX/$PROG
+CONFFILE=/etc$BASEDIR/$PROG.conf
+EXECFILE=$PREFIX/sbin/dnsmasq
+
+copy_sample_config() {
+    local relative_conffile=${CONFFILE#/}
+    local dest_confdir=$DESTDIR/${relative_conffile%/*}
+
+    logmsg "-- copying sample config"
+    logcmd mkdir -p "$dest_confdir" || logerr "mkdir failed"
+    logcmd cp $TMPDIR/$BUILDDIR/$PROG.conf.example $DESTDIR/$relative_conffile \
+        || logerr "copying configs failed"
+}
+
+# No configure
+configure64() { :; }
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DBASEDIR=${BASEDIR#/}
+    -DEXECFILE=$EXECFILE
+    -DCONFFILE=$CONFFILE
+    -DUSER=$PROG
+    -DGROUP=$PROG
+    -DPROG=$PROG
+"
+
+MAKE_ARGS_WS="
+    CC=$CC
+    CFLAGS=\"-DNO_IPSET $CFLAGS $CFLAGS64 $CTF_CFLAGS\"
+    LDFLAGS=\"$LDFLAGS $LDFLAGS64\"
+    PREFIX=$PREFIX
+    MANDIR=$PREFIX/share/man
+    sunos_libs=\"-lnsl -lsocket\"
+"
+
+MAKE_INSTALL_ARGS_WS="
+    PREFIX=$PREFIX
+    MANDIR=$PREFIX/share/man
+"
+
+init
+download_source "$PROG" "$PROG" "$VER"
+patch_source
+prep_build
+build
+copy_sample_config
+xform files/$PROG.xml > $TMPDIR/$PROG.xml
+install_smf network $PROG.xml
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/dnsmasq/build.sh
+++ b/build/dnsmasq/build.sh
@@ -24,8 +24,6 @@ DESC="dnsmasq is a lightweight, easy to configure DNS forwarder, designed to "
 DESC+="provide DNS (and optionally DHCP and TFTP) services to a small-scale network."
 
 set_arch 64
-set_mirror 'https://thekelleys.org.uk/'
-set_checksum sha256 '28d52cfc9e2004ac4f85274f52b32e1647b4dbc9761b82e7de1e41c49907eb08'
 
 BASEDIR=$PREFIX/$PROG
 CONFFILE=/etc$BASEDIR/$PROG.conf
@@ -41,8 +39,21 @@ copy_sample_config() {
         || logerr "copying configs failed"
 }
 
-# No configure
-configure64() { :; }
+configure64() {
+    MAKE_ARGS_WS="
+        CC=$CC
+        CFLAGS=\"-DNO_IPSET $CFLAGS $CFLAGS64\"
+        LDFLAGS=\"$LDFLAGS $LDFLAGS64\"
+        PREFIX=$PREFIX
+        MANDIR=$PREFIX/share/man
+        sunos_libs=\"-lnsl -lsocket\"
+    "
+
+    MAKE_INSTALL_ARGS_WS="
+        PREFIX=$PREFIX
+        MANDIR=$PREFIX/share/man
+    "
+}
 
 XFORM_ARGS="
     -DPREFIX=${PREFIX#/}
@@ -54,20 +65,6 @@ XFORM_ARGS="
     -DPROG=$PROG
 "
 
-MAKE_ARGS_WS="
-    CC=$CC
-    CFLAGS=\"-DNO_IPSET $CFLAGS $CFLAGS64 $CTF_CFLAGS\"
-    LDFLAGS=\"$LDFLAGS $LDFLAGS64\"
-    PREFIX=$PREFIX
-    MANDIR=$PREFIX/share/man
-    sunos_libs=\"-lnsl -lsocket\"
-"
-
-MAKE_INSTALL_ARGS_WS="
-    PREFIX=$PREFIX
-    MANDIR=$PREFIX/share/man
-"
-
 init
 download_source "$PROG" "$PROG" "$VER"
 patch_source
@@ -75,7 +72,7 @@ prep_build
 build
 copy_sample_config
 xform files/$PROG.xml > $TMPDIR/$PROG.xml
-install_smf network $PROG.xml
+install_smf ooce $PROG.xml
 make_package
 clean_up
 

--- a/build/dnsmasq/files/dnsmasq.xml
+++ b/build/dnsmasq/files/dnsmasq.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+ This file and its contents are supplied under the terms of the
+ Common Development and Distribution License ("CDDL"), version 1.0.
+ You may only use this file in accordance with the terms of version
+ 1.0 of the CDDL.
+
+ A full copy of the text of the CDDL should have accompanied this
+ source. A copy of the CDDL is also available via the Internet at
+ http://www.illumos.org/license/CDDL.
+-->
+<!--
+    Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+-->
+<service_bundle type="manifest"
+                name="network:dnsmasq">
+
+    <service name="network/dnsmasq"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <single_instance />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
+        </dependency>
+
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
+
+        <exec_method type="method"
+                     name="start"
+                     exec="$(EXECFILE) -C $(CONFFILE)"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic,net_privaddr" />
+            </method_context>
+        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
+
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":true"
+                     timeout_seconds="60" />
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
+        </property_group>
+
+        <stability value="Evolving" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">dnsmasq - Lightweight, easy to configure DNS forwarder</loctext>
+            </common_name>
+        </template>
+
+    </service>
+
+</service_bundle>

--- a/build/dnsmasq/files/dnsmasq.xml
+++ b/build/dnsmasq/files/dnsmasq.xml
@@ -14,15 +14,13 @@
     Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 -->
 <service_bundle type="manifest"
-                name="network:dnsmasq">
+                name="network:dns:dnsmasq">
 
-    <service name="network/dnsmasq"
+        <service name="network/dns/dnsmasq"
              type="service"
              version="1">
 
         <create_default_instance enabled="false" />
-
-        <single_instance />
 
         <dependency name="network"
                     grouping="require_all"

--- a/build/dnsmasq/local.mog
+++ b/build/dnsmasq/local.mog
@@ -1,0 +1,20 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+dir group=$(GROUP) mode=0770 owner=$(USER) path=var/$(BASEDIR)
+
+group groupname=$(GROUP) gid=99
+user ftpuser=false username=$(USER) uid=99 group=$(GROUP) \
+    gcos-field="dnsmasq - DNS Forwarder" \
+    home-dir=/var/$(BASEDIR) password=NP
+
+license COPYING-v3 license=GPLv3

--- a/build/dnsmasq/local.mog
+++ b/build/dnsmasq/local.mog
@@ -12,9 +12,13 @@
 
 dir group=$(GROUP) mode=0770 owner=$(USER) path=var/$(BASEDIR)
 
-group groupname=$(GROUP) gid=99
-user ftpuser=false username=$(USER) uid=99 group=$(GROUP) \
+group groupname=$(GROUP) gid=56
+user ftpuser=false username=$(USER) uid=56 group=$(GROUP) \
     gcos-field="dnsmasq - DNS Forwarder" \
     home-dir=/var/$(BASEDIR) password=NP
+
+<transform file path=etc/ -> set preserve renamenew>
+<transform file path=$(PREFIX)/sbin -> \
+    set restart_fmri svc:/network/dns/$(PROG):default >
 
 license COPYING-v3 license=GPLv3

--- a/build/dnsmasq/patches/patch-src_bpf.c.patch
+++ b/build/dnsmasq/patches/patch-src_bpf.c.patch
@@ -1,0 +1,13 @@
+diff -wpruN '--exclude=*.orig' a~/src/bpf.c a/src/bpf.c
+--- a~/src/bpf.c.orig	2022-03-07 00:00:00.000000000 +0000
++++ a/src/bpf.c	2022-03-07 00:00:00.000000000 +0000
+@@ -31,7 +31,9 @@
+ #  include <net/if_var.h> 
+ #endif
+ #include <netinet/in_var.h>
++#if defined(HAVE_BSD_NETWORK)
+ #include <netinet6/in6_var.h>
++#endif
+ 
+ #ifndef SA_SIZE
+ #define SA_SIZE(sa)                                             \

--- a/build/dnsmasq/patches/patch-src_dump.c.patch
+++ b/build/dnsmasq/patches/patch-src_dump.c.patch
@@ -1,0 +1,13 @@
+diff -wpruN '--exclude=*.orig' a~/src/dump.c a/src/dump.c
+--- a~/src/dump.c.orig	2022-03-07 00:00:00.000000000 +0000
++++ a/src/dump.c	2022-03-07 00:00:00.000000000 +0000
+@@ -148,6 +148,9 @@ void dump_packet(int mask, void *packet,
+       ip.ip_v = IPVERSION;
+       ip.ip_hl = sizeof(struct ip) / 4;
+       ip.ip_len = htons(sizeof(struct ip) + sizeof(struct udphdr) + len); 
++#ifndef IPDEFTTL
++#define IPDEFTTL	64
++#endif
+       ip.ip_ttl = IPDEFTTL;
+       ip.ip_p = IPPROTO_UDP;
+       

--- a/build/dnsmasq/patches/series
+++ b/build/dnsmasq/patches/series
@@ -1,0 +1,2 @@
+patch-src_bpf.c.patch
+patch-src_dump.c.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -151,6 +151,7 @@ extra.omnios ooce/network/bind-916
 extra.omnios ooce/network/bind-918
 extra.omnios ooce/network/bind-common
 extra.omnios ooce/network/cyrus-imapd
+extra.omnios ooce/network/dnsmasq
 extra.omnios ooce/network/fping
 extra.omnios ooce/network/irssi
 extra.omnios ooce/network/mosh

--- a/doc/idlist.md
+++ b/doc/idlist.md
@@ -28,6 +28,7 @@
 | extra		| 53	| named
 | extra		| 54	| unbound
 | extra		| 55	| nsd
+| extra		| 56	| dnsmasq
 | illumos	| 60	| xvm
 | extra		| 67	| znc
 | extra		| 68	| clamav
@@ -87,6 +88,7 @@
 | extra		| 53	| named
 | extra		| 54	| unbound
 | extra		| 55	| nsd
+| extra		| 56	| dnsmasq
 | illumos	| 60	| xvm
 | illumos	| 65	| netadm
 | extra		| 67	| znc

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -128,6 +128,7 @@
 | ooce/network/bind-916		| 9.16.26	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/bind-918		| 9.18.0	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/cyrus-imapd	| 3.4.3		| https://github.com/cyrusimap/cyrus-imapd/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/network/dnsmasq		| 2.86		| https://thekelleys.org.uk/dnsmasq/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/fping		| 5.1		| https://github.com/schweikert/fping/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/irssi		| 1.2.3		| https://github.com/irssi/irssi/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/mosh		| 1.3.2		| https://github.com/mobile-shell/mosh/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Hello! This PR adds the `dnsmasq` package.

Possible Concerns
-------------------

This is my first PR for omnios-extra so it's possible I got things wrong or incorrect here.  A couple of possible concerns I had are:

### 1. SMF category

I currently have this under the `network` category, but should it be under `ooce`? I'm not sure what the preference here is for that.  FWIW I based my implementation for this service off of the `mosquitto` package which uses the `network` category.

### 2. User ID and Group ID conflicts

I basically arbitrarily picked a UID and GID that didn't seem to be in use (i used a simple `grep` over the `build/` directory) - is there a better way to pick a UID and GID that won't possibly conflict?

Notes
------

The patches were directly copied from Joyent/pkgsrc for SmartOS (https://github.com/joyent/pkgsrc/tree/trunk/net/dnsmasq/patches)

Testing
--------

I installed the package manually and verified the compilation worked as expected by running the binary with `-v` (version):

```
dave - test-zone sunos ~/dev/omnios-extra (git:dnsmasq) $ pkg info dnsmasq
             Name: ooce/network/dnsmasq
          Summary: Lightweight, easy to configure DNS forwarder
      Description: dnsmasq is a lightweight, easy to configure DNS forwarder,
                   designed to provide DNS (and optionally DHCP and TFTP)
                   services to a small-scale network.
            State: Installed (Manually installed)
        Publisher: local.omnios
          Version: 2.86
           Branch: 151040.0
   Packaging Date: March  8, 2022 at 09:49:00 AM
Last Install Time: March  8, 2022 at 09:49:40 AM
             Size: 605.31 kB
             FMRI: pkg://local.omnios/ooce/network/dnsmasq@2.86-151040.0:20220308T094900Z
```

```
dave - test-zone sunos ~/dev/omnios-extra (git:dnsmasq) $ /opt/ooce/sbin/dnsmasq -v
Dnsmasq version   Copyright (c) 2000-2021 Simon Kelley
Compile time options: IPv6 GNU-getopt no-DBus no-UBus no-i18n no-IDN DHCP DHCPv6 no-Lua TFTP no-conntrack no-ipset auth no-cryptohash no-DNSSEC loop-detect no-inotify dumpfile

This software comes with ABSOLUTELY NO WARRANTY.
Dnsmasq is free software, and you are welcome to redistribute it
under the terms of the GNU General Public License, version 2 or 3.
```

I then used a small config file to test that the service works as expected:

```
$ sudo cp dnsmasq.conf /etc/opt/ooce/dnsmasq/dnsmasq.conf
$ sudo svcadm enable dnsmasq
$ dig foo.example.com @localhost +short A
10.0.1.50
$ dig bar.example.com @localhost +short A
10.0.1.51
$ dig google.com @localhost +short A
142.251.40.142
```

```
$ tail /var/svc/log/network-dnsmasq\:default.log
[ Mar  8 10:04:09 Method "start" exited with status 0. ]
Mar  8 10:04:16 dnsmasq[12300]: query[A] foo.example.com from 127.0.0.1
Mar  8 10:04:16 dnsmasq[12300]: config foo.example.com is 10.0.1.50
Mar  8 10:04:17 dnsmasq[12300]: query[A] bar.example.com from 127.0.0.1
Mar  8 10:04:17 dnsmasq[12300]: config bar.example.com is 10.0.1.51
Mar  8 10:04:18 dnsmasq[12300]: query[A] google.com from 127.0.0.1
Mar  8 10:04:18 dnsmasq[12300]: forwarded google.com to 1.1.1.1
Mar  8 10:04:19 dnsmasq[12300]: reply google.com is 142.250.65.206
```

---

`dnsmasq.conf`

``` ini
port=53
listen-address=0.0.0.0
bind-interfaces

domain-needed
proxy-dnssec
filterwin2k
no-resolv
no-poll
no-hosts
neg-ttl=3600
local-ttl=300

# log queries to stderr
log-queries
log-facility=-

# Custom
domain=example.com
local=/example.com/

# Custom DNS
address=/foo.example.com/10.0.1.50
address=/bar.example.com/10.0.1.51

# PTR records
ptr-record=50.1.0.10.in-addr.arpa,"foo.example.com"
ptr-record=51.1.0.10.in-addr.arpa,"bar.example.com"

# Forward everything else to cloudflare
server=1.1.1.1
```