### PR TITLE
bwm-ng: add package (ver 0.6.3)

### DIFF
--- a/build/bwm-ng/build.sh
+++ b/build/bwm-ng/build.sh
@@ -18,16 +18,15 @@
 
 PROG=bwm-ng
 VER=0.6.3
-PKG=ooce/network/$PROG
+PKG=ooce/network/bwm-ng
 SUMMARY="CLI network and disk io monitor"
 DESC="small and simple console-based live network and disk io bandwidth monitor"
 
 set_arch 64
-set_mirror "$GITHUB/vgropp/$PROG/archive"
-set_checksum "none"
 
 init
-download_source v$VER $PROG $VER
+download_source $PROG v$VER
+patch_source
 prep_build
 run_inbuild "./autogen.sh"
 build

--- a/build/bwm-ng/build.sh
+++ b/build/bwm-ng/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=bwm-ng
+VER=0.6.3
+PKG=ooce/network/$PROG
+SUMMARY="CLI network and disk io monitor"
+DESC="small and simple console-based live network and disk io bandwidth monitor"
+
+set_arch 64
+set_mirror "$GITHUB/vgropp/$PROG/archive"
+set_checksum "none"
+
+init
+download_source v$VER $PROG $VER
+prep_build
+run_inbuild "./autogen.sh"
+build
+make_package
+clean_up
+
+# Vim hints
+## vim:ts=4:sw=4:et:fdm=marker

--- a/build/bwm-ng/local.mog
+++ b/build/bwm-ng/local.mog
@@ -1,0 +1,13 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=GPLv2

--- a/doc/baseline
+++ b/doc/baseline
@@ -150,6 +150,7 @@ extra.omnios ooce/network/bind-911
 extra.omnios ooce/network/bind-916
 extra.omnios ooce/network/bind-918
 extra.omnios ooce/network/bind-common
+extra.omnios ooce/network/bwm-ng
 extra.omnios ooce/network/cyrus-imapd
 extra.omnios ooce/network/fping
 extra.omnios ooce/network/irssi

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -127,6 +127,7 @@
 | ooce/network/bind-911		| 9.11.36	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/bind-916		| 9.16.26	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/bind-918		| 9.18.0	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
+| ooce/network/bwm-ng		| 0.6.3		| https://github.com/vgropp/bwm-ng/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/cyrus-imapd	| 3.4.3		| https://github.com/cyrusimap/cyrus-imapd/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/fping		| 5.1		| https://github.com/schweikert/fping/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/irssi		| 1.2.3		| https://github.com/irssi/irssi/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
a fairly straight forward package add, i've been using `bwm-ng` for about 15 years and it's pretty much muscle-memory for me at this point.  source https://github.com/vgropp/bwm-ng

Concerns
----------

I chose what i thought was the best name for this (`ooce/network/bwm-ng`) but if it better fits under another category i'm fine with changing it.

Testing
-------

```
$ sudo pkg install bwm-ng
$ bwm-ng -h
Bandwidth Monitor NG (bwm-ng) v0.6.3USAGE: bwm-ng [OPTION] ... [CONFIGFILE]
displays current ethernet interfaces stats
...
```