### PR TITLE
dnscrypt-proxy: add package (ver 2.1.1)

### DIFF
--- a/build/dnscrypt-proxy/build.sh
+++ b/build/dnscrypt-proxy/build.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=dnscrypt-proxy
+PKG=ooce/network/dnscrypt-proxy
+VER=2.1.1
+SUMMARY="DNS proxy with support for encrypted DNS protocols"
+DESC="A flexible DNS proxy, with support for modern encrypted DNS protocols"
+DESC+=" such as DNSCrypt v2 and DNS-over-HTTP/2."
+
+set_arch 64
+set_gover 1.17
+
+BASEDIR=$PREFIX/$PROG
+CONFFILE=/etc$BASEDIR/$PROG.conf
+EXECFILE=$PREFIX/bin/$PROG
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DBASEDIR=${BASEDIR#/}
+    -DEXECFILE=$EXECFILE
+    -DCONFFILE=$CONFFILE
+    -DUSER=dnscrypt
+    -DGROUP=dnscrypt
+    -DPROG=$PROG
+"
+
+GOOS=illumos
+GOARCH=amd64
+export GOOS GOARCH
+
+build() {
+    pushd $TMPDIR/$BUILDDIR/$PROG > /dev/null
+
+    logmsg "Building 64-bit"
+    logcmd go build || logerr "Build failed"
+    logcmd ./dnscrypt-proxy -version || logerr "$PROG failed"
+
+    popd >/dev/null
+}
+
+copy_sample_config() {
+    local relative_conffile=${CONFFILE#/}
+    local dest_confdir=$DESTDIR/${relative_conffile%/*}
+
+    logmsg "-- copying sample config"
+    logcmd mkdir -p "$dest_confdir" || logerr "mkdir failed"
+    logcmd cp $TMPDIR/$BUILDDIR/$PROG/example-$PROG.toml \
+        $DESTDIR/$relative_conffile || logerr "copying configs failed"
+}
+
+init
+clone_go_source $PROG DNSCrypt $VER
+patch_source
+prep_build
+build
+copy_sample_config
+install_go $PROG/$PROG $PROG
+xform files/$PROG.xml > $TMPDIR/$PROG.xml
+install_smf ooce $PROG.xml
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/dnscrypt-proxy/files/dnscrypt-proxy.xml
+++ b/build/dnscrypt-proxy/files/dnscrypt-proxy.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+ This file and its contents are supplied under the terms of the
+ Common Development and Distribution License ("CDDL"), version 1.0.
+ You may only use this file in accordance with the terms of version
+ 1.0 of the CDDL.
+
+ A full copy of the text of the CDDL should have accompanied this
+ source. A copy of the CDDL is also available via the Internet at
+ http://www.illumos.org/license/CDDL.
+-->
+<!--
+    Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+-->
+<service_bundle type="manifest"
+                name="network:dns:dnscrypt-proxy">
+
+        <service name="network/dns/dnscrypt-proxy"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
+        </dependency>
+
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
+
+        <exec_method type="method"
+                     name="start"
+                     exec="$(EXECFILE) -config $(CONFFILE) &amp;"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic,net_privaddr" />
+            </method_context>
+        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
+
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":true"
+                     timeout_seconds="60" />
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
+        </property_group>
+
+        <stability value="Evolving" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">dnscrypt-proxy - Flexible DNS Proxy</loctext>
+            </common_name>
+        </template>
+
+    </service>
+
+</service_bundle>

--- a/build/dnscrypt-proxy/local.mog
+++ b/build/dnscrypt-proxy/local.mog
@@ -8,8 +8,7 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
-
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 
 group groupname=$(GROUP) gid=57
 user ftpuser=false username=$(USER) uid=57 group=$(GROUP) \
@@ -19,7 +18,7 @@ user ftpuser=false username=$(USER) uid=57 group=$(GROUP) \
 dir group=$(GROUP) mode=0770 owner=$(USER) path=var/$(BASEDIR)
 
 <transform file path=etc/ -> set preserve renamenew>
-<transform file path=$(PREFIX)/sbin -> \
+<transform file path=$(PREFIX)/bin -> \
     set restart_fmri svc:/network/dns/$(PROG):default >
 
 license LICENSE license=ISC

--- a/build/dnscrypt-proxy/local.mog
+++ b/build/dnscrypt-proxy/local.mog
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+
+group groupname=$(GROUP) gid=57
+user ftpuser=false username=$(USER) uid=57 group=$(GROUP) \
+    gcos-field="dnscrypt - Flexible DNS Proxy" \
+    home-dir=/var/$(BASEDIR) password=NP
+
+dir group=$(GROUP) mode=0770 owner=$(USER) path=var/$(BASEDIR)
+
+<transform file path=etc/ -> set preserve renamenew>
+<transform file path=$(PREFIX)/sbin -> \
+    set restart_fmri svc:/network/dns/$(PROG):default >
+
+license LICENSE license=ISC

--- a/doc/baseline
+++ b/doc/baseline
@@ -152,6 +152,7 @@ extra.omnios ooce/network/bind-918
 extra.omnios ooce/network/bind-common
 extra.omnios ooce/network/bwm-ng
 extra.omnios ooce/network/cyrus-imapd
+extra.omnios ooce/network/dnscrypt-proxy
 extra.omnios ooce/network/dnsmasq
 extra.omnios ooce/network/fping
 extra.omnios ooce/network/irssi

--- a/doc/idlist.md
+++ b/doc/idlist.md
@@ -29,6 +29,7 @@
 | extra		| 54	| unbound
 | extra		| 55	| nsd
 | extra		| 56	| dnsmasq
+| extra		| 57	| dnscrypt
 | illumos	| 60	| xvm
 | extra		| 67	| znc
 | extra		| 68	| clamav
@@ -89,6 +90,7 @@
 | extra		| 54	| unbound
 | extra		| 55	| nsd
 | extra		| 56	| dnsmasq
+| extra		| 57	| dnscrypt
 | illumos	| 60	| xvm
 | illumos	| 65	| netadm
 | extra		| 67	| znc

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -129,6 +129,7 @@
 | ooce/network/bind-918		| 9.18.0	| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/bwm-ng		| 0.6.3		| https://github.com/vgropp/bwm-ng/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/cyrus-imapd	| 3.4.3		| https://github.com/cyrusimap/cyrus-imapd/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/network/dnscrypt-proxy	| 2.1.1		| https://github.com/DNSCrypt/dnscrypt-proxy/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/dnsmasq		| 2.86		| https://thekelleys.org.uk/dnsmasq/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/fping		| 5.1		| https://github.com/schweikert/fping/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/network/irssi		| 1.2.3		| https://github.com/irssi/irssi/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Add [dnscrypt-proxy](https://github.com/DNSCrypt/dnscrypt-proxy) at the latest version.

**NOTE:** This package works on my test setup but has 2 errors it encounters that I currently skip.

Errors
------

### 1. Found object(s) without SSP

```
opt/ooce/bin/dnscrypt-proxy does not include stack smashing protection
```

This is a go binary built simply with `go build` - I personally am not very familiar with building go binaries so i'm not sure how to get this protection when compiling the binary.  Any insights on this would be appreciated.

### 2. Unknown licence type 'ISC'

This software is released under the [ISC License](https://en.wikipedia.org/wiki/ISC_license) which doesn't seem to be recognized in `doc/licences`.  It appears this license is similar to the BSD or MIT license, so I would imagine it wouldn't be a conflict to allow it in omnios-extra?

---

Besides these errors the software builds without issue and works as expected.

Concerns
----------

To build the software I do:

    logcmd go build || logerr "Build failed"
    logcmd ./dnscrypt-proxy -version || logerr "$PROG failed"

The second command is sort of a sanity-check (`./dnscrypt-proxy -version`) to make sure the program compiled and can be executed.  I added it there during testing and thought it may make sense to leave in there, but I didn't know if this was something that packages should do.  I can imagine a scenario such as cross-compiling for a different architecture where this might fail.  Should this be removed?

Testing
-------

Using a known-good simple config I start the service and run some lookups against it to make sure it all works:

```
$ sudo cp dnscrypt-proxy.conf /etc/opt/ooce/dnscrypt-proxy/dnscrypt-proxy.conf
$ sudo svcadm enable dnscrypt-proxy
$ dig google.com @localhost +short A
142.251.40.174
$ dig daveeddy.com @localhost +short A
147.182.177.15
$ sudo svcadm disable dnscrypt-proxy
```

```
$ tail -f "$(svcs -L dnscrypt-proxy)"
[ Mar 10 13:56:45 Method "start" exited with status 0. ]
[2022-03-10 13:56:45] [NOTICE] dnscrypt-proxy 2.1.1
[2022-03-10 13:56:45] [NOTICE] Network connectivity detected
[2022-03-10 13:56:45] [NOTICE] Now listening to 127.0.0.1:53 [UDP]
[2022-03-10 13:56:45] [NOTICE] Now listening to 127.0.0.1:53 [TCP]
[2022-03-10 13:56:45] [NOTICE] Source [public-resolvers] loaded
[2022-03-10 13:56:45] [NOTICE] Firefox workaround initialized
[2022-03-10 13:56:46] [NOTICE] [cloudflare] OK (DoH) - rtt: 29ms
[2022-03-10 13:56:46] [NOTICE] Server with the lowest initial latency: cloudflare (rtt: 29ms)
[2022-03-10 13:56:46] [NOTICE] dnscrypt-proxy is ready - live servers: 1
[2022-03-10 13:57:19]   127.0.0.1       google.com      A       PASS    87ms    cloudflare
[2022-03-10 13:57:23]   127.0.0.1       daveeddy.com    A       PASS    29ms    cloudflare
[ Mar 10 13:57:38 Stopping because service disabled. ]
[ Mar 10 13:57:38 Executing stop method (:kill). ]
[2022-03-10 13:57:38] [NOTICE] Stopped.
```

---

`dnscrypt-proxy.toml`

``` toml
listen_addresses = ['127.0.0.1:53']
ipv4_servers = true
dnscrypt_servers = true
doh_servers = true
require_dnssec = true
require_nolog = true
require_nofilter = true
timeout = 2000
keepalive = 30
cert_refresh_delay = 240
ignore_system_dns = true

cache = true
cache_size = 512
cache_min_ttl = 600
cache_max_ttl = 86400
cache_neg_min_ttl = 60
cache_neg_max_ttl = 600

server_names = ['cloudflare']

[sources]
    [sources.'public-resolvers']
        urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
        cache_file = '/tmp/public-resolvers.md'
        minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
        refresh_delay = 72
        prefix = ''

# log queries (XXX ONLY FOR TESTING)
[query_log]
    format = 'tsv'
    file = '/dev/stdout'
```