### PR TITLE
Fixes to fully support extract mode (-x/-xx)

### DIFF
--- a/build/acltool/build.sh
+++ b/build/acltool/build.sh
@@ -31,6 +31,7 @@ set_checksum sha256 \
 
 init
 download_source v$VER $PROG $VER
+patch_source
 prep_build
 build
 strip_install

--- a/build/buildctl
+++ b/build/buildctl
@@ -505,6 +505,8 @@ count_expensive() {
 set_batch_build_flags() {
     build_flags="-b -t -l"
     [ -n "$USE_CCACHE" ] && build_flags+=" -c"
+    ((EXTRACT_MODE == 1)) && build_flags+=" -x"
+    ((EXTRACT_MODE == 2)) && build_flags+=" -xx"
     export BATCH=1  # So logerr() exits without prompting
     export SKIP_PKG_DIFF=1
     export SKIP_PKGLINT=1
@@ -718,6 +720,8 @@ shift $((OPTIND - 1))
 [ -n "$SKIP_PKGLINT" ] && build_flags+="-l "
 [ -n "$SKIP_TESTSUITE" ] && build_flags+="-t "
 [ -n "$SKIP_HARDLINK" ] && build_flags+="-L "
+((EXTRACT_MODE == 1)) && build_flags+="-x "
+((EXTRACT_MODE == 2)) && build_flags+="-xx "
 
 case "$1" in
     config)

--- a/build/ffmpeg/build.sh
+++ b/build/ffmpeg/build.sh
@@ -87,7 +87,7 @@ for pver in $PVERS; do
     set_builddir $PROG-$pver
     save_variable CONFIGURE_OPTS
     CONFIGURE_OPTS+=" --disable-programs --disable-doc"
-    download_source $PROG $PROG $pver
+    download_source -dependency $PROG $PROG $pver
     patch_source patches-`echo $pver | cut -d. -f1-2`
     build
     restore_variable CONFIGURE_OPTS

--- a/build/flamegraph/build.sh
+++ b/build/flamegraph/build.sh
@@ -47,6 +47,7 @@ make_install() {
 
 init
 download_source $PROG $PROG $VER
+patch_source
 prep_build
 make_install
 make_package

--- a/build/mattermost/build.sh
+++ b/build/mattermost/build.sh
@@ -107,9 +107,12 @@ prep_build
 gitenv
 # use clone_github_source instead of clone_go_source
 # since mattermost bundles its dependencies
-clone_github_source "mmctl" "$GITHUB/$PROG/mmctl" v$MMCTLVER
-clone_github_source "$PROG-server" "$GITHUB/$PROG/$PROG-server" v$VER
-clone_github_source "$PROG-webapp" "$GITHUB/$PROG/$PROG-webapp" v$VER
+clone_github_source -dependency "mmctl" "$GITHUB/$PROG/mmctl" v$MMCTLVER
+clone_github_source -dependency "$PROG-server" \
+    "$GITHUB/$PROG/$PROG-server" v$VER
+clone_github_source -dependency "$PROG-webapp" \
+    "$GITHUB/$PROG/$PROG-webapp" v$VER
+((EXTRACT_MODE)) && exit
 build mmctl "ADVANCED_VET=FALSE"
 
 if [ $RELVER -lt 151033 ]; then

--- a/build/ncdu/build.sh
+++ b/build/ncdu/build.sh
@@ -30,6 +30,7 @@ CPPFLAGS+=' -I/usr/include/ncurses '
 
 init
 download_source "$PROG" "$PROG" "$VER"
+patch_source
 prep_build
 build -ctf
 make_package

--- a/build/omni/build.sh
+++ b/build/omni/build.sh
@@ -35,6 +35,7 @@ build() {
 init
 set_builddir $PROG-v$VER
 download_source v$VER $PROG v$VER
+patch_source
 prep_build
 build
 make_package

--- a/build/pango/build.sh
+++ b/build/pango/build.sh
@@ -83,10 +83,12 @@ export CPPFLAGS+=" -I$DEPROOT/$PREFIX/include/fribidi"
 
 ######################################################################
 
-logcmd find $DEPROOT -name \*.la -exec rm {} +
-logcmd mv $DEPROOT/$PREFIX/bin/$ISAPART64/* $DEPROOT/$PREFIX/bin/ \
-    || logerr "relocate dependency binaries"
-logcmd rm -rf $DEPROOT/$PREFIX/bin/{$ISAPART,$ISAPART64}
+if ((EXTRACT_MODE == 0)); then
+    logcmd find $DEPROOT -name \*.la -exec rm {} +
+    logcmd mv $DEPROOT/$PREFIX/bin/$ISAPART64/* $DEPROOT/$PREFIX/bin/ \
+        || logerr "relocate dependency binaries"
+    logcmd rm -rf $DEPROOT/$PREFIX/bin/{$ISAPART,$ISAPART64}
+fi
 
 LDFLAGS32+=" -L$DEPROOT/$PREFIX/lib"
 LDFLAGS64+=" -L$DEPROOT/$PREFIX/lib/$ISAPART64"

--- a/build/tcpdump/build.sh
+++ b/build/tcpdump/build.sh
@@ -30,6 +30,7 @@ BUILD_DEPENDS_IPS="
 
 init
 download_source $PROG $PROG $VER
+patch_source
 prep_build
 build
 run_testsuite check


### PR DESCRIPTION
This makes every package respond correctly to `./build.sh -x` and `./build.sh -xx`, and allow download and extraction of the whole source via `cd build; ./buildctl -xx build parallel 10` or similar.