### PR TITLE
tig: add package (ver 2.5.5)

### DIFF
--- a/build/tig/build.sh
+++ b/build/tig/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2022 Martin Samuelsson
+
+. ../../lib/build.sh
+
+PROG=tig
+VER=2.5.5
+PKG=ooce/application/tig
+SUMMARY="Tig: text-mode interface for Git"
+DESC="Tig is an ncurses-based text-mode interface for git. \
+    It functions mainly as a Git repository browser, but can \
+    also assist in staging changes for commit at chunk level \
+    and act as a pager for output from various Git commands."
+
+OPREFIX=$PREFIX
+PREFIX+=/$PROG
+
+set_arch 64
+
+XFORM_ARGS="
+    -DOPREFIX=${OPREFIX#/}
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+"
+
+MAKE_INSTALL_TARGET+=" install-doc-man"
+
+# create package functions
+init
+download_source $PROG $PROG $VER
+prep_build
+build
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/tig/local.mog
+++ b/build/tig/local.mog
@@ -1,0 +1,17 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2022 Martin Samuelsson
+
+license COPYING license=GPLv2
+
+<include binlink.mog>
+<include manlink.mog>
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -26,6 +26,7 @@ extra.omnios ooce/application/php-81/imagick
 extra.omnios ooce/application/php-common
 extra.omnios ooce/application/texlive
 extra.omnios ooce/application/tidy
+extra.omnios ooce/application/tig
 extra.omnios ooce/application/vagrant
 extra.omnios ooce/application/vaultwarden
 extra.omnios ooce/application/zabbix-agent

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -24,6 +24,7 @@
 | ooce/application/php-XX/imagick	| 3.7.0	| https://github.com/Imagick/imagick/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/application/texlive	| 20220321	| ftp://tug.org/historic/systems/texlive/2022/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tidy		| 5.8.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/application/tig 		| 2.5.5		| https://github.com/jonas/tig/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vagrant	| 2.2.19	| https://github.com/hashicorp/vagrant/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vaultwarden	| 1.25.0	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.0.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Running `build.sh` results in an `--- Comparing old package with new` error. Maybe I've done some mistake with adding to `doc/baseline`? I attempted to follow the instructions and mimicked earlier commits in the history (such as e.g. 1e8d76da).

There are also a bunch of these warnings when building on an up-to-date bloody:

>   .../omnios-extra/lib/functions.sh: line 193: /opt/onbld/bin/find_elf: No such file or directory

I'm posting as a draft PR for now. If anyone would be able to provide some insight in what I've missed, that would be most appreciated.