### PR TITLE
Retrieve CTF data from genunix instead of sockfs

### DIFF
--- a/build/lsof/build.sh
+++ b/build/lsof/build.sh
@@ -19,6 +19,7 @@
 PROG=lsof
 PKG=ooce/file/lsof
 VER=4.95.0
+DASHREV=1
 SUMMARY="List open files"
 DESC="Report a list of all open files and the processes that opened them"
 

--- a/build/lsof/patches/genunix.patch
+++ b/build/lsof/patches/genunix.patch
@@ -1,0 +1,21 @@
+
+As of "14768: retire nca", the sockfs module no longer contains CTF data for
+the types that lsof needs. However, these are present in genunix and apparently
+always have been (at least back to r151038) so we can safely patch lsof to read
+those instead.
+
+The patch doesn't adjust the 32-bit kernel line since it would be changing
+one non-existent path (/kernel/fs/sockfs) to another.
+
+diff -wpruN '--exclude=*.orig' a~/dialects/sun/dnode.c a/dialects/sun/dnode.c
+--- a~/dialects/sun/dnode.c	1970-01-01 00:00:00
++++ a/dialects/sun/dnode.c	1970-01-01 00:00:00
+@@ -88,7 +88,7 @@ static	int	Sockfs_ctfs = 0;	/* CTF initi
+ 					 * sockfs */
+ 
+ #  if	defined(_LP64)
+-#define	SOCKFS_MOD_FORMAT "/kernel/fs/%s/sockfs"
++#define	SOCKFS_MOD_FORMAT "/kernel/%s/genunix"
+ #  else	/* !defined(_LP64) */
+ #define	SOCKFS_MOD_FORMAT "/kernel/fs/sockfs"
+ # endif	/* defined(_LP64) */

--- a/build/lsof/patches/include_limits.patch
+++ b/build/lsof/patches/include_limits.patch
@@ -1,6 +1,6 @@
 diff -wpruN '--exclude=*.orig' a~/arg.c a/arg.c
---- a~/arg.c	2020-11-10 19:00:21.000000000 +0000
-+++ a/arg.c	2020-11-19 21:40:18.819000177 +0000
+--- a~/arg.c	1970-01-01 00:00:00
++++ a/arg.c	1970-01-01 00:00:00
 @@ -29,6 +29,8 @@
   * 4. This notice may not be removed or altered.
   */

--- a/build/lsof/patches/series
+++ b/build/lsof/patches/series
@@ -1,1 +1,2 @@
 include_limits.patch
+genunix.patch


### PR DESCRIPTION
As of `14768: retire nca`, the `sockfs` module no longer contains CTF data for the types that `lsof` needs. However, these are present in `genunix` and apparently always have been (at least back to r151038) so we can safely patch `lsof` to read those. 

```
r151038% ctfdump -c /kernel/amd64/genunix| grep sotpi
typedef struct sotpi_info sotpi_info_t;
struct sotpi_info { /* 0x140 bytes */

r151038% ctfdump -c /kernel/amd64/genunix| grep soaddr
struct soaddr { /* 0x10 bytes */
```
