### PR TITLE
First pass at helix pkg

### DIFF
--- a/build/helix/build.sh
+++ b/build/helix/build.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=helix
+VER=22.12
+PKG=ooce/editor/helix
+SUMMARY="A post-modern modal text editor."
+DESC="A kakoune / neovim inspired editor, written in Rust."
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+
+set_arch 64
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+"
+
+SKIP_SSP_CHECK=1
+NO_SONAME_EXPECTED=1 # files in runtime dir
+
+install_helix_runtime() {
+    pushd $DESTDIR/$PREFIX >/dev/null || logerr "chdir $DESTDIR/$PREFIX"
+
+    logcmd $MKDIR -p "share/runtime" || logerr "Failed to create runtime dir"
+
+    logcmd $RSYNC -a $TMPDIR/$BUILDDIR/runtime/ share/runtime/ \
+        || logerr "rsync runtime failed"
+
+    # We have no control over the symlinks in this directory, so lets remove
+    # the dangling ones now.
+    find share/runtime -type l | while read link; do
+        $READLINK -e "$link" >/dev/null || logcmd $RM "$link"
+    done
+
+    popd >/dev/null
+}
+
+init
+prep_build
+download_source -nodir $PROG $PROG $VER-source
+patch_source
+build_rust
+install_rust hx
+install_helix_runtime
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/helix/files/hx
+++ b/build/helix/files/hx
@@ -1,0 +1,4 @@
+#!/usr/bin/ksh
+
+HELIX_RUNTIME=/opt/ooce/helix/share/runtime exec $0.bin "$@"
+

--- a/build/helix/local.mog
+++ b/build/helix/local.mog
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+# The runtime path needs to be set via an environment variable. To achieve
+# that, move the real binary aside and replace it with a wrapper script that
+# modifies the environment.
+<transform file elfhash path=$(PREFIX)/bin/hx -> edit path bin/hx bin/hx.bin>
+file files/hx path=X/$(PREFIX)/bin/hx mode=0555
+<transform file path=X/ -> edit path X/ "">
+
+license LICENSE license=MPLv2
+
+<include binlink.mog>
+<include manlink.mog>
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -98,6 +98,7 @@ extra.omnios ooce/developer/yasm
 extra.omnios ooce/developer/zig
 extra.omnios ooce/driver/fuse
 extra.omnios ooce/editor/emacs
+extra.omnios ooce/editor/helix
 extra.omnios ooce/editor/joe
 extra.omnios ooce/editor/nano
 extra.omnios ooce/editor/neovim

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -77,6 +77,7 @@
 | ooce/developer/zig		| 0.9.1		| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/driver/fuse		| 1.4		| https://github.com/jurikm/illumos-fusefs/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/emacs		| 28.2		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
+| ooce/editor/helix		| 22.12		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 7.1		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/neovim		| 0.8.2		| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1142,10 +1142,17 @@ download_source() {
     [ -n "$SKIP_DOWNLOAD" ] && return
 
     typeset -i record_arc=1
-    [ "$1" = "-norecord" ] && { record_arc=0; shift; }
-
     typeset -i dependency=0
-    [ "$1" = "-dependency" ] && { dependency=1; shift; }
+    typeset -i nodir=0
+    while [[ $1 = -* ]]; do
+        case $1 in
+            -norecord)      record_arc=0 ;;
+            -dependency)    dependency=1 ;;
+            -nodir)         nodir=1 ;;
+            *)              logerr "Unknown download_source option, $1" ;;
+        esac
+        shift
+    done
 
     local DLDIR="$1"; shift
     local PROG="$1"; shift
@@ -1196,8 +1203,15 @@ download_source() {
 
     # Extract the archive
     logmsg "Extracting archive: $FILENAME"
-    logcmd extract_archive $FILENAME $EXTRACTARGS \
+    if ((nodir)); then
+        mkdir $BUILDDIR || logerr "Failed to mkdir $BUILDDIR"
+        pushd $BUILDDIR
+    else
+        pushd $TARGETDIR >/dev/null
+    fi
+    logcmd extract_archive $TARGETDIR/$FILENAME $EXTRACTARGS \
         || logerr "--- Unable to extract archive."
+    popd >/dev/null
 
     # Make sure the archive actually extracted some source where we expect
     if [ ! -d "$BUILDDIR" ]; then

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -2145,19 +2145,21 @@ install_go() {
 #############################################################################
 
 install_rust() {
-    logmsg "Installing $PROG"
+    typeset prog=${1:-$PROG}
+
+    logmsg "Installing $prog"
 
     logcmd $MKDIR -p "$DESTDIR/$PREFIX/bin" \
         || logerr "Failed to create install dir"
-    logcmd $CP $TMPDIR/$BUILDDIR/target/release/$PROG \
-        $DESTDIR/$PREFIX/bin/$PROG || logerr "Failed to install binary"
+    logcmd $CP $TMPDIR/$BUILDDIR/target/release/$prog \
+        $DESTDIR/$PREFIX/bin/$prog || logerr "Failed to install binary"
 
-    for f in `$FD "^$PROG\.1\$" $TMPDIR/$BUILDDIR`; do
+    for f in `$FD "^$prog\.1\$" $TMPDIR/$BUILDDIR`; do
         logmsg "Found man page at $f"
 
         logcmd $MKDIR -p "$DESTDIR/$PREFIX/share/man/man1" \
             || logerr "Failed to create man install dir"
-        logcmd $CP $f $DESTDIR/$PREFIX/share/man/man1/$PROG.1 \
+        logcmd $CP $f $DESTDIR/$PREFIX/share/man/man1/$prog.1 \
             || logerr "Failed to install man page"
         break
     done


### PR DESCRIPTION
@hadfl / @citrus-it  this is what I pinged about over chat.

Some open issues here:
- I don't think I have `files/hx` setup properly to land in `/opt/ooce/bin/hx`
- The so files in the runtime dir shipped by helix get stripped (not sure if this matters?)
- I have an issue somewhere that's reporting "Manifest contains unresolved variables"

The idea though is that this binary should land in `/opt/ooce/helix/bin/hx` and the runtime lands in `/var/opt/occe/helix/runtime` and the wrapper script exports the proper variable to tell helix where the runtime lives.

This is what linux distros do.  An example of one such case is:
https://github.com/archlinux/svntogit-community/blob/packages/helix/trunk/helix.sh