### PR TITLE
ripgrep: fix man page generation

### DIFF
--- a/build/ripgrep/build.sh
+++ b/build/ripgrep/build.sh
@@ -35,6 +35,8 @@ set_arch 64
 
 SKIP_LICENCES=UNLICENSE
 
+export XML_CATALOG_FILES=$PREFIX/docbook-xsl/catalog.xml
+
 init
 download_source $PROG $VER
 patch_source


### PR DESCRIPTION
```diff
--- Comparing old package with new

+dir  path=opt/ooce/share owner=root group=bin mode=0755
+dir  path=opt/ooce/share/man owner=root group=bin mode=0755 facet.doc.man=true
+dir  path=opt/ooce/share/man/man1 owner=root group=bin mode=0755 facet.doc.man=true
+file path=opt/ooce/share/man/man1/rg.1 owner=root group=bin mode=0644 restart_fmri=svc:/system/update-man-index:default facet.doc.man=true
```