### PR TITLE
WireGuard packages (wireguard-go and wireguard-tools)

### DIFF
--- a/build/wireguard-go/build.sh
+++ b/build/wireguard-go/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=wireguard-go
+PKG=ooce/network/wireguard-go
+VER=0.0.20220316
+HASH=c8619d9
+SUMMARY="Go Implementation of WireGuard"
+DESC="This is an implementation of WireGuard in Go."
+
+RUN_DEPENDS_IPS="driver/tuntap"
+
+set_arch 64
+set_gover 119
+
+build_and_install() {
+    pushd $TMPDIR/$BUILDDIR > /dev/null
+    logcmd $MAKE PREFIX=$PREFIX DESTDIR=$DESTDIR install \
+        || logerr "Unable to build wireguard-go"
+    popd >/dev/null
+}
+
+init
+# Use nshalman fork until it is fully upstreamed
+clone_go_source $PROG nshalman $HASH
+prep_build
+build_and_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/wireguard-go/local.mog
+++ b/build/wireguard-go/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT
+

--- a/build/wireguard-tools/build.sh
+++ b/build/wireguard-tools/build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=wireguard-tools
+PKG=ooce/network/wireguard-tools
+VER=1.0.20210914
+HASH=8588ad1
+SUMMARY="Tools for configuring WireGuard"
+DESC="This supplies the main userspace tooling for using and configuring "
+DESC+="WireGuard tunnels, including the wg(8) and wg-quick(8) utilities."
+
+RUN_DEPENDS_IPS="ooce/network/wireguard-go"
+
+XFORM_ARGS+="
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DSERVICE=ooce/network/wg-quick
+"
+
+build_and_install() {
+    pushd $TMPDIR/$BUILDDIR/$PROG/src
+    logcmd $MAKE \
+        SYSCONFDIR=/etc$PREFIX \
+        PREFIX=$PREFIX \
+        DESTDIR=$DESTDIR \
+        WITH_WGQUICK=yes \
+        install \
+        || logerr "unable to build wireguard-tools"
+    popd >/dev/null
+}
+
+init
+prep_build
+# Use nshalman fork until it is fully upstreamed
+clone_github_source $PROG $GITHUB/nshalman/$PROG $HASH
+build_and_install
+xform files/wg-quick.xml > $TMPDIR/network-wg-quick.xml
+install_smf ooce network-wg-quick.xml
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/wireguard-tools/files/wg-quick.xml
+++ b/build/wireguard-tools/files/wg-quick.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest"
+                name="export">
+
+    <service name="$(SERVICE)"
+             type="service"
+             version="0">
+
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
+        </dependency>
+
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
+
+        <exec_method name="start"
+                     type="method"
+                     exec="/$(PREFIX)/bin/wg-quick up %i"
+                     timeout_seconds="180">
+            <method_context>
+                <method_credential group="root"
+                                   user="root" />
+                <method_environment>
+                    <envvar name="WG_QUICK_USERSPACE_IMPLEMENTATION"
+                            value="/$(PREFIX)/bin/wireguard-go" />
+                </method_environment>
+            </method_context>
+        </exec_method>
+
+        <exec_method name="stop"
+                     type="method"
+                     exec="/$(PREFIX)/bin/wg-quick down %i"
+                     timeout_seconds="180">
+            <method_context>
+                <method_credential group="root"
+                                   user="root" />
+                <method_environment>
+                    <envvar name="WG_QUICK_USERSPACE_IMPLEMENTATION"
+                            value="/$(PREFIX)/bin/wireguard-go" />
+                </method_environment>
+            </method_context>
+        </exec_method>
+
+        <property_group name="application"
+                        type="application" />
+
+        <property_group name="startd"
+                        type="framework">
+            <propval name="duration"
+                     type="astring"
+                     value="contract" />
+            <propval name="ignore_error"
+                     type="astring"
+                     value="core,signal" />
+        </property_group>
+
+        <stability value="Evolving" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">WireGuard via wg-quick(8)</loctext>
+            </common_name>
+        </template>
+
+    </service>
+
+</service_bundle>

--- a/build/wireguard-tools/local.mog
+++ b/build/wireguard-tools/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+license wireguard-tools/COPYING license=GPLv2
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -195,6 +195,8 @@ extra.omnios ooce/network/socat r
 extra.omnios ooce/network/tailscale
 extra.omnios ooce/network/tcpdump
 extra.omnios ooce/network/unbound
+extra.omnios ooce/network/wireguard-go
+extra.omnios ooce/network/wireguard-tools
 extra.omnios ooce/network/znc
 extra.omnios ooce/omnios-build-tools
 extra.omnios ooce/ooceapps

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -160,6 +160,8 @@
 | ooce/network/tailscale	| 1.36.0	| https://www.tailscale.com/ | [nshalman](https://github.com/nshalman)
 | ooce/network/tcpdump		| 4.99.1	| https://www.tcpdump.org/release/ | [omniosorg](https://github.com/omniosorg)
 | ooce/network/unbound		| 1.17.1	| https://nlnetlabs.nl/downloads/unbound/ | [omniosorg](https://github.com/omniosorg)
+| ooce/network/wireguard-go	| 0.0.20220316	| https://www.wireguard.com/ | [nshalman](https://github.com/nshalman)
+| ooce/network/wireguard-tools	| 1.0.20210914	| https://www.wireguard.com/ | [nshalman](https://github.com/nshalman)
 | ooce/network/znc		| 1.8.2		| https://github.com/znc/znc/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/ooceapps			| github-latest	| https://github.com/omniosorg/ooceapps/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/print/cups		| 2.4.2		| https://github.com/OpenPrinting/cups/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
I'd love to get these packages out into the illumos community to help get feedback and bug fixes for
WireGuard/wireguard-go#39 and WireGuard/wireguard-tools#17

These packages ship the code as it exists in those PRs today (tied to the specific commits).

Some notes for the original version of the SMF manifest can be found here:
https://github.com/nshalman/wireguard-tools/blob/wg-quick-for-sunos/contrib/smf/README.md