### PR TITLE
clang: relax check whether to add the RPATH for libstdc++

### DIFF
--- a/build/clang/patches-13/add-rpath-for-libstdcxx.patch
+++ b/build/clang/patches-13/add-rpath-for-libstdcxx.patch
@@ -1,7 +1,20 @@
 diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.cpp a/lib/Driver/ToolChains/Solaris.cpp
 --- a~/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
 +++ a/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
-@@ -279,3 +279,16 @@ void Solaris::addLibStdCxxIncludePaths(
+@@ -125,9 +125,10 @@
+   bool NeedsSanitizerDeps = addSanitizerRuntimes(getToolChain(), Args, CmdArgs);
+   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
+
++  if (getToolChain().ShouldLinkCXXStdlib(Args) && !Args.hasArg(options::OPT_r))
++    getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
++
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
+-    if (getToolChain().ShouldLinkCXXStdlib(Args))
+-      getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
+     if (D.CCCIsCXX())
+       CmdArgs.push_back("-lgcc_s");
+     CmdArgs.push_back("-lc");
+@@ -302,3 +302,16 @@ void Solaris::addLibStdCxxIncludePaths(
                             TripleStr, Multilib.includeSuffix(), DriverArgs,
                             CC1Args);
  }
@@ -31,3 +44,17 @@ diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.h a/lib/Driver/T
    SanitizerMask getSupportedSanitizers() const override;
    unsigned GetDefaultDwarfVersion() const override { return 2; }
  
+diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChain.cpp a/lib/Driver/ToolChain.cpp
+--- a~/lib/Driver/ToolChain.cpp  1970-01-01 00:00:00
++++ a/lib/Driver/ToolChain.cpp   1970-01-01 00:00:00
+@@ -999,9 +999,7 @@
+ }
+
+ bool ToolChain::ShouldLinkCXXStdlib(const llvm::opt::ArgList &Args) const {
+-  return getDriver().CCCIsCXX() &&
+-         !Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+-                      options::OPT_nostdlibxx);
++  return getDriver().CCCIsCXX() && !Args.hasArg(options::OPT_nostdlibxx);
+ }
+
+ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,

--- a/build/clang/patches-14/add-rpath-for-libstdcxx.patch
+++ b/build/clang/patches-14/add-rpath-for-libstdcxx.patch
@@ -1,7 +1,21 @@
 diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.cpp a/lib/Driver/ToolChains/Solaris.cpp
 --- a~/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
 +++ a/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
-@@ -286,3 +286,16 @@ void Solaris::addLibStdCxxIncludePaths(
+@@ -125,10 +125,11 @@
+   bool NeedsSanitizerDeps = addSanitizerRuntimes(getToolChain(), Args, CmdArgs);
+   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
+
++  if (getToolChain().ShouldLinkCXXStdlib(Args) && !Args.hasArg(options::OPT_r))
++    getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
++
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+                    options::OPT_r)) {
+-    if (getToolChain().ShouldLinkCXXStdlib(Args))
+-      getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
+     // LLVM support for atomics on 32-bit SPARC V8+ is incomplete, so
+     // forcibly link with libatomic as a workaround.
+     if (getToolChain().getTriple().getArch() == llvm::Triple::sparc) {
+@@ -302,3 +302,16 @@ void Solaris::addLibStdCxxIncludePaths(
                             TripleStr, Multilib.includeSuffix(), DriverArgs,
                             CC1Args);
  }
@@ -31,3 +45,17 @@ diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.h a/lib/Driver/T
    SanitizerMask getSupportedSanitizers() const override;
    unsigned GetDefaultDwarfVersion() const override { return 2; }
  
+diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChain.cpp a/lib/Driver/ToolChain.cpp
+--- a~/lib/Driver/ToolChain.cpp  1970-01-01 00:00:00
++++ a/lib/Driver/ToolChain.cpp   1970-01-01 00:00:00
+@@ -999,9 +999,7 @@
+ }
+
+ bool ToolChain::ShouldLinkCXXStdlib(const llvm::opt::ArgList &Args) const {
+-  return getDriver().CCCIsCXX() &&
+-         !Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+-                      options::OPT_nostdlibxx);
++  return getDriver().CCCIsCXX() && !Args.hasArg(options::OPT_nostdlibxx);
+ }
+
+ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,

--- a/build/clang/patches-15/add-rpath-for-libstdcxx.patch
+++ b/build/clang/patches-15/add-rpath-for-libstdcxx.patch
@@ -1,6 +1,20 @@
 diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.cpp a/lib/Driver/ToolChains/Solaris.cpp
 --- a~/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
 +++ a/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
+@@ -125,10 +125,11 @@
+   bool NeedsSanitizerDeps = addSanitizerRuntimes(getToolChain(), Args, CmdArgs);
+   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
+
++  if (getToolChain().ShouldLinkCXXStdlib(Args) && !Args.hasArg(options::OPT_r))
++    getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
++
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+                    options::OPT_r)) {
+-    if (getToolChain().ShouldLinkCXXStdlib(Args))
+-      getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
+     // LLVM support for atomics on 32-bit SPARC V8+ is incomplete, so
+     // forcibly link with libatomic as a workaround.
+     if (getToolChain().getTriple().getArch() == llvm::Triple::sparc) {
 @@ -302,3 +302,16 @@ void Solaris::addLibStdCxxIncludePaths(
                             TripleStr, Multilib.includeSuffix(), DriverArgs,
                             CC1Args);
@@ -31,3 +45,17 @@ diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.h a/lib/Driver/T
    SanitizerMask getSupportedSanitizers() const override;
    unsigned GetDefaultDwarfVersion() const override { return 2; }
  
+diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChain.cpp a/lib/Driver/ToolChain.cpp
+--- a~/lib/Driver/ToolChain.cpp  1970-01-01 00:00:00
++++ a/lib/Driver/ToolChain.cpp   1970-01-01 00:00:00
+@@ -999,9 +999,7 @@
+ }
+
+ bool ToolChain::ShouldLinkCXXStdlib(const llvm::opt::ArgList &Args) const {
+-  return getDriver().CCCIsCXX() &&
+-         !Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+-                      options::OPT_nostdlibxx);
++  return getDriver().CCCIsCXX() && !Args.hasArg(options::OPT_nostdlibxx);
+ }
+
+ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,

--- a/build/clang/patches-16/add-rpath-for-libstdcxx.patch
+++ b/build/clang/patches-16/add-rpath-for-libstdcxx.patch
@@ -1,6 +1,20 @@
 diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.cpp a/lib/Driver/ToolChains/Solaris.cpp
 --- a~/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
 +++ a/lib/Driver/ToolChains/Solaris.cpp	1970-01-01 00:00:00
+@@ -125,10 +125,11 @@
+   bool NeedsSanitizerDeps = addSanitizerRuntimes(getToolChain(), Args, CmdArgs);
+   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
+
++  if (getToolChain().ShouldLinkCXXStdlib(Args) && !Args.hasArg(options::OPT_r))
++    getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
++
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+                    options::OPT_r)) {
+-    if (getToolChain().ShouldLinkCXXStdlib(Args))
+-      getToolChain().AddCXXStdlibLibArgs(Args, CmdArgs);
+     // LLVM support for atomics on 32-bit SPARC V8+ is incomplete, so
+     // forcibly link with libatomic as a workaround.
+     if (getToolChain().getTriple().getArch() == llvm::Triple::sparc) {
 @@ -302,3 +302,16 @@ void Solaris::addLibStdCxxIncludePaths(
                             TripleStr, Multilib.includeSuffix(), DriverArgs,
                             CC1Args);
@@ -31,3 +45,17 @@ diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChains/Solaris.h a/lib/Driver/T
    SanitizerMask getSupportedSanitizers() const override;
    unsigned GetDefaultDwarfVersion() const override { return 2; }
  
+diff -wpruN '--exclude=*.orig' a~/lib/Driver/ToolChain.cpp a/lib/Driver/ToolChain.cpp
+--- a~/lib/Driver/ToolChain.cpp  1970-01-01 00:00:00
++++ a/lib/Driver/ToolChain.cpp   1970-01-01 00:00:00
+@@ -999,9 +999,7 @@
+ }
+
+ bool ToolChain::ShouldLinkCXXStdlib(const llvm::opt::ArgList &Args) const {
+-  return getDriver().CCCIsCXX() &&
+-         !Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
+-                      options::OPT_nostdlibxx);
++  return getDriver().CCCIsCXX() && !Args.hasArg(options::OPT_nostdlibxx);
+ }
+
+ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,

--- a/build/hunspell/build.sh
+++ b/build/hunspell/build.sh
@@ -52,11 +52,6 @@ CONFIGURE_OPTS[amd64]="
 
 CPPFLAGS+=" -I/usr/include/ncurses"
 
-# libtool adds '-nostdlib' which prevents clang from adding the proper RPATH
-# for libstdc++
-LDFLAGS[i386]+=" -Wl,-R/usr/gcc/$DEFAULT_GCC_VER/lib"
-LDFLAGS[amd64]+=" -Wl,-R/usr/gcc/$DEFAULT_GCC_VER/lib/amd64"
-
 post_install() {
     [ $1 = i386 ] && return
 

--- a/tools/audit
+++ b/tools/audit
@@ -275,8 +275,9 @@ audit()
                         # qemu and tailscale are not published until r151044
                         */qemu:|*/tailscale:)
                             [ $r -lt 151044 ] || ok=0 ;;
-                        # helix and mariadb-1011 are not published until r151042
-                        */helix:|*/mariadb-1011:)
+                        # helix, mariadb-1011 and hunspell
+                        # are not published until r151042
+                        */helix:|*/mariadb-1011:|*/hunspell:)
                             [ $r -lt 151042 ] || ok=0 ;;
                         # X11 headers/libraries are not published until r151035
                         */x11/*:) [ $r -lt 151035 ] || ok=0 ;;


### PR DESCRIPTION
when i did a test-build of `hunspell`  recently, @richlowe discovered, that the shared libraries are using the default libstdc++ library and not the ones we build against. investigating this revealed that libtool is adding `-nostdlib` which prevents setting the correct `RPATH` for libstdc++.

This change should make clang behave like our gcc does and therefore lead to least surprise to the user.