### PR TITLE
Want atuin

### DIFF
--- a/build/atuin/build.sh
+++ b/build/atuin/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=atuin
+VER=16.0.0
+PKG=ooce/util/atuin
+SUMMARY="Magical shell history"
+DESC="Replaces your existing shell history with a SQLite database and "
+DESC+="records additional context for your commands. Additionally, "
+DESC+="it provides optional and fully encrypted synchronisation of "
+DESC+="your history between machines, via an Atuin server."
+
+BMI_EXPECTED=1
+
+BUILD_DEPENDS_IPS="
+    ooce/developer/rust
+"
+
+set_arch 64
+
+init
+download_source $PROG v$VER
+patch_source
+prep_build
+build_rust
+install_rust
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/atuin/local.mog
+++ b/build/atuin/local.mog
@@ -1,0 +1,15 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -249,6 +249,7 @@ extra.omnios ooce/text/ripgrep
 extra.omnios ooce/text/texinfo
 extra.omnios ooce/text/xsv
 extra.omnios ooce/util/acmefetch
+extra.omnios ooce/util/atuin
 extra.omnios ooce/util/bat
 extra.omnios ooce/util/diffr
 extra.omnios ooce/util/dtc

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -211,6 +211,7 @@
 | ooce/text/texinfo		| 7.0.3		| https://ftp.gnu.org/gnu/texinfo/ https://www.gnu.org/software/texinfo/ | [omniosorg](https://github.com/omniosorg)
 | ooce/text/xsv			| 0.13.0	| https://github.com/BurntSushi/xsv/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/acmefetch		| 0.8.1		| https://github.com/oetiker/AcmeFetch/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/util/atuin		| 16.0.0	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/bat			| 0.23.0	| https://github.com/sharkdp/bat/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/diffr		| 0.1.5		| https://github.com/mookid/diffr/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/util/dtc			| 1.7.0		| https://git.kernel.org/pub/scm/utils/dtc/dtc.git/refs/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This provides [atuin](https://atuin.sh) so that I can stop manually running `cargo install --locked atuin` everywhere.
Once this is in, I plan to update their [install script](https://github.com/atuinsh/atuin/blob/main/install.sh#L105) to use `pkg install atuin`.

I built this locally on r46.
Note that I locally use `MIRROR=https://foo..` in `lib/site.sh` providing the downloaded GitHub release tar and checksum digest on my fileserver.

I am not sure how to gate this on a particular Rust version as building with the rust in r40 was too old prompting me to update my development VM. It seems there is at least some cargo workspace feature being used that is not supported in older Rust releases.

Let me know if there's anything else I can do to help move this PR along.