### PR TITLE
Add postgresql 16

### DIFF
--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -62,6 +62,7 @@ depend fmri=ooce/library/postgresql-12 type=require
 depend fmri=ooce/library/postgresql-13 type=require
 depend fmri=ooce/library/postgresql-14 type=require
 depend fmri=ooce/library/postgresql-15 type=require
+depend fmri=ooce/library/postgresql-16 type=require
 depend fmri=ooce/library/security/libsasl2 type=require
 depend fmri=ooce/library/serf type=require
 depend fmri=ooce/library/slang type=require

--- a/build/pg_extension/common.sh
+++ b/build/pg_extension/common.sh
@@ -10,9 +10,9 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
 
-PGVERSIONS="13 14 15"
+PGVERSIONS="13 14 15 16"
 
 for v in $PGVERSIONS; do
     BUILD_DEPENDS_IPS+=" ooce/library/postgresql-$v"

--- a/build/postgresql/build-16.sh
+++ b/build/postgresql/build-16.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=postgresql
+PKG=ooce/database/postgresql-16
+VER=16.0
+SUMMARY="PostgreSQL 16"
+DESC="The World's Most Advanced Open Source Relational Database"
+
+SKIP_LICENCES=postgresql
+
+# We want to populate the clang-related environment variables
+# and set PATH to point to the correct llvm/clang version for
+# the postgres JIT code, but we want to build with gcc.
+set_clangver
+BASEPATH=$PATH set_gccver $DEFAULT_GCC_VER
+
+MAJVER=${VER%.*}            # M.m
+sMAJVER=${MAJVER//./}       # Mm
+set_patchdir patches-$sMAJVER
+
+OPREFIX=$PREFIX
+PREFIX+=/pgsql-$MAJVER
+CONFPATH=/etc$PREFIX
+LOGPATH=/var/log$PREFIX
+VARPATH=/var$PREFIX
+RUNPATH=$VARPATH/run
+
+reset_configure_opts
+
+SKIP_RTIME_CHECK=1
+SKIP_SSP_CHECK=1
+NO_SONAME_EXPECTED=1
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=pgsql-$MAJVER
+    -DMEDIATOR=$PROG -DMEDIATOR_VERSION=$MAJVER
+    -DVERSION=$MAJVER
+    -DsVERSION=$sMAJVER
+"
+
+CFLAGS+=" -O3"
+CFLAGS[aarch64]+=" -mno-outline-atomics"
+CPPFLAGS+=" -DWAIT_USE_POLL"
+# postgresql has large enumerations
+CTF_FLAGS+=" -s"
+
+CONFIGURE_OPTS="
+    --prefix=$PREFIX
+    --sysconfdir=$CONFPATH
+    --localstatedir=$VARPATH
+    --enable-thread-safety
+    --with-pam
+    --with-ssl=openssl
+    --with-lz4
+    --with-zstd
+    --with-libxml
+    --with-libxslt
+    --with-readline
+    --without-systemd
+    --with-system-tzdata=/usr/share/lib/zoneinfo
+"
+
+CONFIGURE_OPTS[amd64_WS]+="
+    --bindir=$PREFIX/bin
+    --with-llvm LLVM_CONFIG=\"$CLANGPATH/bin/llvm-config --link-static\"
+    --enable-dtrace DTRACEFLAGS=-64
+"
+CONFIGURE_OPTS[aarch64]+="
+    --disable-dtrace
+"
+
+# need to build world to get e.g. man pages in
+MAKE_TARGET=world
+MAKE_INSTALL_TARGET=install-world
+
+pre_configure() {
+    typeset arch=$1
+
+    LDFLAGS[$arch]+=" -Wl,-R$OPREFIX/${LIBDIRS[$arch]}"
+}
+
+post_install() {
+    typeset arch=$1
+
+    [ $arch = i386 ] && return
+
+    # Make ISA binaries for pg_config, to allow software to find the
+    # right settings for 32/64-bit when pkg-config is not used.
+    if [ $arch = amd64 ]; then
+        pushd $DESTDIR$PREFIX/bin >/dev/null
+        logcmd mkdir -p amd64
+        logcmd mv pg_config amd64/ || logerr "mv pg_config"
+        make_isaexec_stub_arch amd64 $PREFIX/bin
+        popd >/dev/null
+    fi
+
+    xform $SRCDIR/files/postgres.xml > $TMPDIR/$PROG-$sMAJVER.xml
+    install_smf ooce $PROG-$sMAJVER.xml
+
+    manifest_start $TMPDIR/manifest.client
+    manifest_add_dir $PREFIX/include '.*'
+    manifest_add_dir $PREFIX/lib/pkgconfig
+    manifest_add_dir $PREFIX/lib/amd64/pkgconfig
+    manifest_add_dir $PREFIX/lib/pgxs '.*'
+    manifest_add_dir $PREFIX/lib/amd64/pgxs '.*'
+    manifest_add $PREFIX/lib '.*lib(pq\.|ecpg|pgtypes|pgcommon|pgport).*'
+    manifest_add $PREFIX/bin '.*pg_config' psql ecpg
+    manifest_add $PREFIX/share/man/man1 pg_config.1 psql.1 ecpg.1
+    manifest_add $PREFIX/share psqlrc.sample
+    manifest_finalise $TMPDIR/manifest.client $OPREFIX
+
+    manifest_uniq $TMPDIR/manifest.{server,client}
+    manifest_finalise $TMPDIR/manifest.server $OPREFIX etc
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+#run_testsuite check-world
+PKG=${PKG/database/library} SUMMARY+=" client and libraries" \
+    make_package -seed $TMPDIR/manifest.client
+[ "$FLAVOR" != libsandheaders ] \
+    && RUN_DEPENDS_IPS="ooce/database/postgresql-common" \
+        make_package -seed $TMPDIR/manifest.server server.mog
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/postgresql/files/ctf.ignore
+++ b/build/postgresql/files/ctf.ignore
@@ -1,3 +1,6 @@
+blake3_dispatch.c
+blake3_portable.c
+blake3.c
 dynloader.c
 regcomp.c
 regerror.c

--- a/build/postgresql/patches-16/dism.patch
+++ b/build/postgresql/patches-16/dism.patch
@@ -1,0 +1,93 @@
+On Solaris we want to use DISM or ISM e.g. Dynamic Intimate Shared Memory or Intimate Shared Memory
+which is available via sysv SHM only. This patch changes the default shared memory system to be sysv
+on Solaris based systems e.g. which have SHM_SHARE_MMU (which translates to ISM) and when SHM_PAGEABLE
+is defined in sys/shm.h we set the default PG_SHMAT_FLAGS to SHM_PAGEABLE which will lead to DISM being
+used. The patch to the postgresql.conf.sample is to show that sysv is the default for Solaris and the
+ordering is changed as by default it used to be mmap and posix for the defaults and you could always
+override things using the sysv setting.
+--
+diff -wpruN --no-dereference '--exclude=*.orig' a~/src/backend/utils/misc/postgresql.conf.sample a/src/backend/utils/misc/postgresql.conf.sample
+--- a~/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
++++ a/src/backend/utils/misc/postgresql.conf.sample	1970-01-01 00:00:00
+@@ -144,16 +144,15 @@
+ #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+ #logical_decoding_work_mem = 64MB	# min 64kB
+ #max_stack_depth = 2MB			# min 100kB
+-#shared_memory_type = mmap		# the default is the first option
++#shared_memory_type = sysv		# the default is the first option
+ 					# supported by the operating system:
+-					#   mmap
+ 					#   sysv
+ 					#   windows
+ 					# (change requires restart)
+-#dynamic_shared_memory_type = posix	# the default is usually the first option
++#dynamic_shared_memory_type = sysv	# the default is usually the first option
+ 					# supported by the operating system:
+-					#   posix
+ 					#   sysv
++					#   posix
+ 					#   windows
+ 					#   mmap
+ 					# (change requires restart)
+diff -wpruN --no-dereference '--exclude=*.orig' a~/src/include/portability/mem.h a/src/include/portability/mem.h
+--- a~/src/include/portability/mem.h	1970-01-01 00:00:00
++++ a/src/include/portability/mem.h	1970-01-01 00:00:00
+@@ -14,11 +14,15 @@
+ 
+ #define IPCProtection	(0600)	/* access/modify by user only */
+ 
++#ifdef SHM_PAGEABLE			/* use dynamic intimate shared memory on Solaris */
++#define PG_SHMAT_FLAGS			SHM_PAGEABLE
++#else
+ #ifdef SHM_SHARE_MMU			/* use intimate shared memory on Solaris */
+ #define PG_SHMAT_FLAGS			SHM_SHARE_MMU
+ #else
+ #define PG_SHMAT_FLAGS			0
+ #endif
++#endif
+ 
+ /* Linux prefers MAP_ANONYMOUS, but the flag is called MAP_ANON on other systems. */
+ #ifndef MAP_ANONYMOUS
+diff -wpruN --no-dereference '--exclude=*.orig' a~/src/include/storage/dsm_impl.h a/src/include/storage/dsm_impl.h
+--- a~/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
++++ a/src/include/storage/dsm_impl.h	1970-01-01 00:00:00
+@@ -19,6 +19,13 @@
+ #define DSM_IMPL_WINDOWS		3
+ #define DSM_IMPL_MMAP			4
+ 
++#ifdef HAVE_SYS_SHM_H
++/*
++ * For SHM_SHARE_MMU.
++ */
++#include <sys/shm.h>
++#endif
++
+ /*
+  * Determine which dynamic shared memory implementations will be supported
+  * on this platform, and which one will be the default.
+@@ -34,6 +41,11 @@
+ #define USE_DSM_SYSV
+ #ifndef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
+ #define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#else
++#ifdef SHM_SHARE_MMU
++#undef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
++#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
++#endif
+ #endif
+ #define USE_DSM_MMAP
+ #endif
+diff -wpruN --no-dereference '--exclude=*.orig' a~/src/include/storage/pg_shmem.h a/src/include/storage/pg_shmem.h
+--- a~/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
++++ a/src/include/storage/pg_shmem.h	1970-01-01 00:00:00
+@@ -70,7 +70,9 @@ extern PGDLLIMPORT void *ShmemProtective
+ #endif
+ extern PGDLLIMPORT void *UsedShmemSegAddr;
+ 
+-#if !defined(WIN32) && !defined(EXEC_BACKEND)
++#if defined(SHM_SHARE_MMU)
++#define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV
++#elif !defined(WIN32) && !defined(EXEC_BACKEND)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_MMAP
+ #elif !defined(WIN32)
+ #define DEFAULT_SHARED_MEMORY_TYPE SHMEM_TYPE_SYSV

--- a/build/postgresql/patches-16/pam_conv.patch
+++ b/build/postgresql/patches-16/pam_conv.patch
@@ -1,0 +1,24 @@
+see: https://www.illumos.org/issues/15657
+struct pam_message in struct pam_conv is not const in illumos
+
+diff -wpruN --no-dereference '--exclude=*.orig' a~/src/backend/libpq/auth.c a/src/backend/libpq/auth.c
+--- a~/src/backend/libpq/auth.c	1970-01-01 00:00:00
++++ a/src/backend/libpq/auth.c	1970-01-01 00:00:00
+@@ -96,7 +96,7 @@ static int	auth_peer(hbaPort *port);
+ #define PGSQL_PAM_SERVICE "postgresql"	/* Service name passed to PAM */
+ 
+ static int	CheckPAMAuth(Port *port, const char *user, const char *password);
+-static int	pam_passwd_conv_proc(int num_msg, const struct pam_message **msg,
++static int	pam_passwd_conv_proc(int num_msg, struct pam_message **msg,
+ 								 struct pam_response **resp, void *appdata_ptr);
+ 
+ static struct pam_conv pam_passw_conv = {
+@@ -1912,7 +1912,7 @@ auth_peer(hbaPort *port)
+  */
+ 
+ static int
+-pam_passwd_conv_proc(int num_msg, const struct pam_message **msg,
++pam_passwd_conv_proc(int num_msg, struct pam_message **msg,
+ 					 struct pam_response **resp, void *appdata_ptr)
+ {
+ 	const char *passwd;

--- a/build/postgresql/patches-16/series
+++ b/build/postgresql/patches-16/series
@@ -1,0 +1,2 @@
+dism.patch
+pam_conv.patch

--- a/doc/baseline
+++ b/doc/baseline
@@ -58,6 +58,10 @@ extra.omnios ooce/database/postgresql-15
 extra.omnios ooce/database/postgresql-15/citus
 extra.omnios ooce/database/postgresql-15/mysql_fdw
 extra.omnios ooce/database/postgresql-15/pg_repack
+extra.omnios ooce/database/postgresql-16
+extra.omnios ooce/database/postgresql-16/citus
+extra.omnios ooce/database/postgresql-16/mysql_fdw
+extra.omnios ooce/database/postgresql-16/pg_repack
 extra.omnios ooce/database/postgresql-common
 extra.omnios ooce/database/rrdtool
 extra.omnios ooce/developer/aarch64-gcc10
@@ -158,6 +162,7 @@ extra.omnios ooce/library/postgresql-12
 extra.omnios ooce/library/postgresql-13
 extra.omnios ooce/library/postgresql-14
 extra.omnios ooce/library/postgresql-15
+extra.omnios ooce/library/postgresql-16
 extra.omnios ooce/library/protobuf o
 extra.omnios ooce/library/security/libsasl2
 extra.omnios ooce/library/serf

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -42,6 +42,7 @@
 | ooce/database/postgresql-13	| 13.12		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-14	| 14.9		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-15	| 15.4		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/postgresql-16	| 16.0		| https://www.postgresql.org/ftp/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-XX/citus	| 11.2.0	| https://github.com/citusdata/citus/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-XX/mysql_fdw	| 2.9.0	| https://github.com/EnterpriseDB/mysql_fdw/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-XX/pg_repack	| 1.4.8	| https://github.com/reorg/pg_repack/tags | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This mostly works I only have one problem and that is that the RPATH is missing /opt/ooce/lib/amd64 and as such is not finding the icu shared libs. If I fix the RPATH and add the path I can run initdb and start a database. I also added the extensions but
have not build them yet and citus might not have support for pgsql16 given it was released yesterday. I can drop the extensions
build for now and we can add that the next time some extension gets updated.