### PR TITLE
caddy: add version 2.7.6 to extra.omnios

### DIFF
--- a/build/apache/build-24.sh
+++ b/build/apache/build-24.sh
@@ -12,7 +12,7 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
@@ -28,6 +28,8 @@ set_arch 64
 set_builddir httpd-$VER
 
 set_patchdir patches-$sMAJVER
+
+RUN_DEPENDS_IPS="ooce/server/webservd-common"
 
 OPREFIX=$PREFIX
 PREFIX+=/$PROG-$MAJVER

--- a/build/apache/local.mog
+++ b/build/apache/local.mog
@@ -10,11 +10,6 @@
 #
 # Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
-$(GATE_SYSUSER)group gid=80 groupname=$(GROUP)
-$(GATE_SYSUSER)user ftpuser=false gcos-field="Apache user" \
-    group=$(GROUP) uid=80 password=NP username=$(USER) \
-    home-dir=/var/$(PREFIX)
-
 # Mediated binaries
 <transform file \
     path=$(PREFIX)/bin/((?:ht|ab|apachectl|apxs).*) -> emit \

--- a/build/caddy/build.sh
+++ b/build/caddy/build.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2024 Guo-Rong Koh
+
+. ../../lib/build.sh
+
+PROG=caddy
+VER=2.7.6
+PKG=ooce/server/caddy
+SUMMARY="Caddy web server"
+DESC="Fast and extensible multi-platform HTTP/1-2-3 web server with automatic \
+HTTPS"
+
+CONFIG=etc/${PREFIX#/}/$PROG
+DATA=var/${PREFIX#/}/$PROG
+
+RUN_DEPENDS_IPS="ooce/server/webservd-common"
+
+set_arch amd64
+set_gover
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DVERSION=$VER
+    -DUSER=webservd -DGROUP=webservd
+    -DCONFIG=$CONFIG
+    -DDATA=$DATA
+    -DXDG_CONFIG=${CONFIG%/$PROG}
+    -DXDG_DATA=${DATA%/$PROG}
+"
+
+build() {
+    pushd $TMPDIR/$BUILDDIR > /dev/null
+
+    logmsg "Building $PROG"
+    export CGO_ENABLED=0
+    export GOOS=illumos
+
+    logcmd go build -o caddy cmd/caddy/main.go || logerr "Unable to build $PROG"
+
+    popd >/dev/null
+}
+
+# create package functions
+init
+clone_go_source $PROG caddyserver v$VER
+patch_source
+prep_build
+build
+install_go $PROG
+xform files/$PROG-template.xml > $TMPDIR/$PROG.xml
+install_smf network $PROG.xml
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/caddy/files/caddy-template.xml
+++ b/build/caddy/files/caddy-template.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="manifest"
+                name="http:caddy">
+
+    <service name="network/http"
+             type="service"
+             version="1">
+
+        <instance name="caddy"
+                  enabled="false">
+
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
+
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
+
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
+
+            <dependent name="caddy_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
+            <method_context security_flags="aslr">
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   limit_privileges="basic,net_privaddr,!proc_info,!file_link_any" />
+                <method_environment>
+                    <envvar name="HOME"
+                            value="/$(DATA)" />
+                    <envvar name="XDG_CONFIG_HOME"
+                            value="/$(XDG_CONFIG)" />
+                    <envvar name="XDG_DATA_HOME"
+                            value="/$(XDG_DATA)" />
+                </method_environment>
+            </method_context>
+
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/exec} %m --config %{config/file}"
+                         timeout_seconds="60">
+                <method_context security_flags="aslr">
+                    <method_credential user="$(USER)"
+                                       group="$(GROUP)"
+                                       privileges="basic,net_privaddr,!proc_info,!proc_session,!file_link_any" />
+                </method_context>
+            </exec_method>
+
+            <exec_method type="method"
+                         name="stop"
+                         exec="%{config/exec} %m --config %{config/file}"
+                         timeout_seconds="300" />
+
+            <exec_method type="method"
+                         name="refresh"
+                         exec="%{config/exec} reload --config %{config/file}"
+                         timeout_seconds="300" />
+
+            <property_group name="config"
+                            type="application">
+                <propval name="file"
+                         type="astring"
+                         value="/$(CONFIG)/Caddyfile" />
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/bin/$(PROG)" />
+            </property_group>
+
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">caddy $(VERSION)</loctext>
+                </common_name>
+            </template>
+
+        </instance>
+
+        <stability value="External" />
+
+    </service>
+
+</service_bundle>

--- a/build/caddy/local.mog
+++ b/build/caddy/local.mog
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2024 Guo-Rong Koh
+
+license LICENSE license=Apache2
+
+dir path=$(CONFIG) owner=$(USER) group=$(GROUP) mode=0700
+dir path=$(DATA) owner=$(USER) group=$(GROUP) mode=0700
+dir path=var/log/$(PREFIX)/$(PROG) owner=$(USER) group=$(GROUP) mode=0755
+
+<transform file path=$(CONFIG)/ -> set preserve true>
+
+<transform file path=$(PREFIX)/bin/$(PROG) -> \
+    set restart_fmri svc:/network/http:$(PROG)>

--- a/build/caddy/patches/0001-Switch-Solaris-derivatives-away-from-listen_unix.patch
+++ b/build/caddy/patches/0001-Switch-Solaris-derivatives-away-from-listen_unix.patch
@@ -1,0 +1,36 @@
+diff --git a/listen.go b/listen.go
+index 0cd3fabb..34812b54 100644
+--- a/listen.go
++++ b/listen.go
+@@ -12,7 +12,7 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+ 
+-//go:build !unix
++//go:build !unix || solaris
+ 
+ package caddy
+ 
+diff --git a/listen_unix.go b/listen_unix.go
+index 34cd76c5..9ec65c39 100644
+--- a/listen_unix.go
++++ b/listen_unix.go
+@@ -15,7 +15,7 @@
+ // Even though the filename ends in _unix.go, we still have to specify the
+ // build constraint here, because the filename convention only works for
+ // literal GOOS values, and "unix" is a shortcut unique to build tags.
+-//go:build unix
++//go:build unix && !solaris
+ 
+ package caddy
+ 
+diff --git a/listen_unix_setopt.go b/listen_unix_setopt.go
+index c9675f92..13ee7b83 100644
+--- a/listen_unix_setopt.go
++++ b/listen_unix_setopt.go
+@@ -1,4 +1,4 @@
+-//go:build unix && !freebsd
++//go:build unix && !freebsd && !solaris
+ 
+ package caddy
+ 

--- a/build/caddy/patches/series
+++ b/build/caddy/patches/series
@@ -1,0 +1,1 @@
+0001-Switch-Solaris-derivatives-away-from-listen_unix.patch

--- a/build/webservd/webservd.p5m
+++ b/build/webservd/webservd.p5m
@@ -1,0 +1,14 @@
+set name=pkg.fmri value=ooce/server/webservd-common@1.0.0-$(PVER)
+set name=variant.arch value=i386
+set name=variant.opensolaris.zone value=global value=nonglobal
+set name=description value="Common webservd package"
+set name=pkg.description value="Common webservd package"
+set name=pkg.summary value="Common webservd package"
+
+dir group=bin mode=0755 owner=root  path=var/opt/ooce
+dir group=webservd mode=0755 owner=webservd path=var/opt/ooce/webservd
+
+$(GATE_SYSUSER)group gid=80 groupname=webservd
+$(GATE_SYSUSER)user ftpuser=false gcos-field="webservd user" \
+    group=webservd uid=80 password=NP username=webservd \
+    home-dir=/var/opt/ooce/webservd

--- a/doc/baseline
+++ b/doc/baseline
@@ -232,11 +232,13 @@ extra.omnios ooce/server/apache-24
 extra.omnios ooce/server/apache-24/modules/fcgid
 extra.omnios ooce/server/apache-24/modules/subversion
 extra.omnios ooce/server/apache-24/modules/wsgi
+extra.omnios ooce/server/caddy
 extra.omnios ooce/server/freeradius
 extra.omnios ooce/server/haproxy
 extra.omnios ooce/server/nginx
 extra.omnios ooce/server/nginx-124
 extra.omnios ooce/server/nginx-common
+extra.omnios ooce/server/webservd-common
 extra.omnios ooce/storage/minio
 extra.omnios ooce/storage/minio-mc
 extra.omnios ooce/system/clamav

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -191,6 +191,7 @@
 | ooce/server/apache-24		| 2.4.58	| https://downloads.apache.org/httpd/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/apache-24/modules/fcgid | 2.3.9	| https://downloads.apache.org/httpd/mod_fcgid/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/apache-24/modules/wsgi | 5.0.0    | https://github.com/GrahamDumpleton/mod_wsgi/tags/ | [cgrzemba](https://github.com/cgrzemba)
+| ooce/server/caddy         | 2.7.6     | https://github.com/caddyserver/caddy/releases | [gkoh](https://github.com/gkoh)
 | ooce/server/freeradius	| 3.2.3		| https://github.com/FreeRADIUS/freeradius-server/releases https://freeradius.org/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/server/haproxy		| 2.8.5		| https://www.haproxy.org/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx		| 1.25.4	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Add v2.7.6 of the Caddy web server.

Add patch to fix Solaris-derivative build.
Comes from caddy master:76611fa15079b755ddf3c859ae2ea0ad2123223f and this PR 6021: https://github.com/caddyserver/caddy/pull/6021