### PR TITLE
Switch omnios-extra to Python 3.12

### DIFF
--- a/build/x11/libxcb/build.sh
+++ b/build/x11/libxcb/build.sh
@@ -44,7 +44,7 @@ addpath PKG_CONFIG_PATH[amd64] $DEPROOT$PREFIX/lib/amd64/pkgconfig
 
 ######################################################################
 
-PYTHONPATH+=":$PREFIX/lib/python$PYTHONVER/vendor-packages"
+PYTHONPATH+=":$PYTHONVENDOR"
 export PYTHONPATH
 
 download_source x11/$PROG $PROG $VER

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -379,7 +379,8 @@ case $RELVER in
     15103[7-9])         PYTHON3VER=3.9 ;;
     151040)             PYTHON3VER=3.9 ;;
     15104[1-4])         PYTHON3VER=3.10 ;;
-    15104[5-9])         PYTHON3VER=3.11 ;;
+    15104[5-8])         PYTHON3VER=3.11 ;;
+    151049|15105[0-9])  PYTHON3VER=3.12 ;;
     *)                  PYTHON3VER=3.5 ;;
 esac
 # Specify default Python version for building packages


### PR DESCRIPTION
I successfully ran a full omnios-extra build on the latest bloody with this change.