### PR TITLE
Add missing patch_source calls

### DIFF
--- a/build/rlwrap/build.sh
+++ b/build/rlwrap/build.sh
@@ -28,6 +28,7 @@ set_arch 64
 
 init
 download_source $PROG $PROG $VER
+patch_source
 prep_build
 build
 make_package

--- a/build/tailscale/build.sh
+++ b/build/tailscale/build.sh
@@ -56,6 +56,7 @@ install() {
 init
 # Use nshalman fork until it is fully upstreamed
 clone_go_source $PROG nshalman "v$VER-sunos"
+patch_source
 prep_build
 build
 install

--- a/build/tig/build.sh
+++ b/build/tig/build.sh
@@ -40,9 +40,9 @@ XFORM_ARGS="
 
 MAKE_INSTALL_TARGET+=" install-doc-man"
 
-# create package functions
 init
 download_source $PROG $PROG $VER
+patch_source
 prep_build
 build
 strip_install

--- a/build/wireguard-go/build.sh
+++ b/build/wireguard-go/build.sh
@@ -42,6 +42,7 @@ build_and_install() {
 init
 # Use nshalman fork until it is fully upstreamed
 clone_go_source $PROG nshalman $HASH
+patch_source
 prep_build
 build_and_install
 make_package


### PR DESCRIPTION
This change adds a few missing `patch_source` calls to packages that
are needed so that they don't build when run with `-x` (extract source
only). Even if there are currently no patches, all packages should
call this function.
