### PR TITLE
terminal handling fixes for Neovim 0.10

### DIFF
--- a/build/neovim/patches/illumos-support.patch
+++ b/build/neovim/patches/illumos-support.patch
@@ -264,8 +264,8 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/src/nvim/os_illumos.c a/src/n
 +		 * The line discipline is not present, so push the appropriate
 +		 * STREAMS modules for the subordinate device:
 +		 */
-+		if (ioctl(s, I_PUSH, "ptem") < 0 ||
-+		    ioctl(s, I_PUSH, "ldterm") < 0) {
++		if (ioctl(s, __I_PUSH_NOCTTY, "ptem") < 0 ||
++		    ioctl(s, __I_PUSH_NOCTTY, "ldterm") < 0) {
 +			return (openpty_failure(c, s, errno));
 +		}
 +	}

--- a/build/neovim/patches/series
+++ b/build/neovim/patches/series
@@ -1,3 +1,4 @@
 libuv.patch
 link-gcc_s.patch
 illumos-support.patch
+use-system-default-tty-modes.patch

--- a/build/neovim/patches/use-system-default-tty-modes.patch
+++ b/build/neovim/patches/use-system-default-tty-modes.patch
@@ -1,0 +1,99 @@
+From cbc39cb75b67eb77386337dad47e239346638ff7 Mon Sep 17 00:00:00 2001
+From: "Joshua M. Clulow" <jmc@oxide.computer>
+Date: Fri, 31 May 2024 20:49:32 -0700
+Subject: [PATCH 2/2] XXX use system default tty modes
+
+
+diff --git a/src/nvim/os/pty_process_unix.c b/src/nvim/os/pty_process_unix.c
+index 866a1d2d5..4a37456bd 100644
+--- a/src/nvim/os/pty_process_unix.c
++++ b/src/nvim/os/pty_process_unix.c
+@@ -46,12 +46,6 @@
+ int pty_process_spawn(PtyProcess *ptyproc)
+   FUNC_ATTR_NONNULL_ALL
+ {
+-  // termios initialized at first use
+-  static struct termios termios_default;
+-  if (!termios_default.c_cflag) {
+-    init_termios(&termios_default);
+-  }
+-
+   int status = 0;  // zero or negative error code (libuv convention)
+   Process *proc = (Process *)ptyproc;
+   assert(proc->err.closed);
+@@ -59,7 +53,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
+   ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
+   uv_disable_stdio_inheritance();
+   int master;
+-  int pid = forkpty(&master, NULL, &termios_default, &ptyproc->winsize);
++  int pid = forkpty(&master, NULL, NULL, &ptyproc->winsize);
+ 
+   if (pid < 0) {
+     status = -errno;
+@@ -178,63 +172,6 @@ static void init_child(PtyProcess *ptyproc)
+   _exit(122);  // 122 is EXEC_FAILED in the Vim source.
+ }
+ 
+-static void init_termios(struct termios *termios) FUNC_ATTR_NONNULL_ALL
+-{
+-  // Taken from pangoterm
+-  termios->c_iflag = ICRNL|IXON;
+-  termios->c_oflag = OPOST|ONLCR;
+-#ifdef TAB0
+-  termios->c_oflag |= TAB0;
+-#endif
+-  termios->c_cflag = CS8|CREAD;
+-  termios->c_lflag = ISIG|ICANON|IEXTEN|ECHO|ECHOE|ECHOK;
+-
+-  // not using cfsetspeed, not available on all platforms
+-  cfsetispeed(termios, 38400);
+-  cfsetospeed(termios, 38400);
+-
+-#ifdef IUTF8
+-  termios->c_iflag |= IUTF8;
+-#endif
+-#ifdef NL0
+-  termios->c_oflag |= NL0;
+-#endif
+-#ifdef CR0
+-  termios->c_oflag |= CR0;
+-#endif
+-#ifdef BS0
+-  termios->c_oflag |= BS0;
+-#endif
+-#ifdef VT0
+-  termios->c_oflag |= VT0;
+-#endif
+-#ifdef FF0
+-  termios->c_oflag |= FF0;
+-#endif
+-#ifdef ECHOCTL
+-  termios->c_lflag |= ECHOCTL;
+-#endif
+-#ifdef ECHOKE
+-  termios->c_lflag |= ECHOKE;
+-#endif
+-
+-  termios->c_cc[VINTR] = 0x1f & 'C';
+-  termios->c_cc[VQUIT] = 0x1f & '\\';
+-  termios->c_cc[VERASE] = 0x7f;
+-  termios->c_cc[VKILL] = 0x1f & 'U';
+-  termios->c_cc[VEOF] = 0x1f & 'D';
+-  termios->c_cc[VEOL] = _POSIX_VDISABLE;
+-  termios->c_cc[VEOL2] = _POSIX_VDISABLE;
+-  termios->c_cc[VSTART] = 0x1f & 'Q';
+-  termios->c_cc[VSTOP] = 0x1f & 'S';
+-  termios->c_cc[VSUSP] = 0x1f & 'Z';
+-  termios->c_cc[VREPRINT] = 0x1f & 'R';
+-  termios->c_cc[VWERASE] = 0x1f & 'W';
+-  termios->c_cc[VLNEXT] = 0x1f & 'V';
+-  termios->c_cc[VMIN] = 1;
+-  termios->c_cc[VTIME] = 0;
+-}
+-
+ static int set_duplicating_descriptor(int fd, uv_pipe_t *pipe)
+   FUNC_ATTR_NONNULL_ALL
+ {
+-- 
+2.40.1
+


### PR DESCRIPTION
A few fixes for `:terminal` support in Neovim 0.10:

* The **openpty(3C)** compatibility shim is not quite right in one critical respect: pushing a STREAMS module onto a tty device can have the side effect of making that device the process's controlling terminal.  Using `__I_PUSH_NOCTTY` avoids that side effect.  This was causing the **nvim --embed** child process to exit unexpectedly when `:terminal` was used.
* Neovim presently does some partially incorrect and wholly ill-advised construction of a **struct termios** object from whole cloth when starting an interactive child process.  This likely has a subtle impact even on Linux (I verified that it is not _quite_ producing a default object there either, though the differences are less severe).  The delta between _our_ system default **termios** object and the one Neovim produces is:

  ```diff
  -===== DEFAULT:
  +===== FROM NEOVIM:
  
   input flags (c_iflag):
  -       BRKINT   Signal interrupt on break
           ICRNL   Map CR to NL on input
            IXON   Enable start/stop output control
  -      IMAXBEL   Echo BEL on input line too long
  
   output flags (c_oflag):
           OPOST   Post-process output
           ONLCR   Map NL to CR-NL on output
           NLDLY:  Select newline delays
                     NL0
           CRDLY:  Select carriage-return delays
                     CR0
          TABDLY:  Select horizontal tab delays or tab expansion
  -                  TAB3
  -                  XTABS
  +                  TAB0
           BSDLY:  Select backspace delays
                     BS0
           VTDLY:  Select vertical tab delays
                     VT0
           FFDLY:  Select form feed delays
                     FF0
  
   control flags (c_cflag):
           CREAD   Enable receiver
  -      CRTSCTS   Enable outbound hardware flow control
        CBAUDEXT   Bit to indicate output speed > B38400
  +    CIBAUDEXT   Bit to indicate input speed > B38400
           CBAUD:  Baud rate (with CEXTBAUD)
  -                  B115200
  +                  B57600
           CSIZE:  Character size
                     CS8
  
   local flags (c_lflag):
  -       ICANON   Canonical input (erase/kill proc.)
          TOSTOP   Send SIGTTOU for background output
         ECHOPRT   Echo erase char as char erased
  -       FLUSHO   Output is being flushed
  
   control characters (c_cc):
       for canonical mode:
              VINTR     0x03 (  3)  ^C
              VQUIT     0x1c ( 28)
             VERASE     0x7f (127)
              VKILL     0x15 ( 21)  ^U
  -            VEOF     0x04 (  4)  ^D
  +            VEOF     0x01 (  1)  ^A
               VEOL     0x00 (  0)
              VEOL2     0x00 (  0)
             VSWTCH     0x00 (  0)
             VSTART     0x11 ( 17)  ^Q
              VSTOP     0x13 ( 19)  ^S
              VSUSP     0x1a ( 26)  ^Z
  -          VDSUSP     0x19 ( 25)  ^Y
  +          VDSUSP     0x00 (  0)
           VREPRINT     0x12 ( 18)  ^R
  -        VDISCARD     0x0f ( 15)  ^O
  +        VDISCARD     0x00 (  0)
            VWERASE     0x17 ( 23)  ^W
             VLNEXT     0x16 ( 22)  ^V
  -         VSTATUS     0x14 ( 20)  ^T
  -         VERASE2     0x08 (  8)  ^H
  +         VSTATUS     0x00 (  0)
  +         VERASE2     0x00 (  0)
       for raw mode:
  -            VMIN     0x04 (  4)  ^D
  +            VMIN     0x01 (  1)  ^A
              VTIME     0x00 (  0)
  ```

  Of perhaps paramount importance is that the terminal is _in raw mode_, which is generally totally unexpected on a UNIX system, and followed closely behind that is an unusual value for **VEOF**, which happens to share a slot with **VMIN** which has been spuriously overridden.  I have removed the overrides entirely so that we just use the system default settings.  I'll be working up the energy to post that fix in particular upstream, as I do not believe it is ever correct to do what they're doing there.

With these fixes in place, an interactive `:terminal` works under Neovim, as does the **fzf-lua** plugin that is quite popular and which depends on running **fzf** in under a pty.