### PR TITLE
dont-package-helix-grammar-sources

### DIFF
--- a/build/helix/local.mog
+++ b/build/helix/local.mog
@@ -17,6 +17,7 @@
 <transform file elfhash path=$(PREFIX)/bin/hx -> edit path bin/hx bin/hx.bin>
 file files/hx path=X/$(PREFIX)/bin/hx mode=0555
 <transform file path=X/ -> edit path X/ "">
+<transform path=$(PREFIX)/share/runtime/grammars/sources -> drop>  
 
 license LICENSE license=MPLv2
 


### PR DESCRIPTION
Omit the grammar sources from the Helix package. This removes the better part of 20,000 small files from the package, none of which are not required to run Helix. 

[Homebrew already do this](https://github.com/helix-editor/helix/issues/3437) and it is [recommended by the Helix devs](https://github.com/helix-editor/helix/issues/6187#issuecomment-1769860105).