### PR TITLE
oath-toolkit: ship 32-bit too, drop static libraries

### DIFF
--- a/build/oath-toolkit/build.sh
+++ b/build/oath-toolkit/build.sh
@@ -25,7 +25,7 @@ DESC="One-time password components"
 # does not yet build with gcc 14
 ((GCCVER > 13)) && set_gccver 13
 
-set_arch 64
+forgo_isaexec
 # For the standard getpwnam_r
 set_standard XPG6
 
@@ -35,6 +35,8 @@ CPPFLAGS+=" -D__STDC_WANT_LIB_EXT1__"
 XFORM_ARGS="
     -DPREFIX=${PREFIX#/}
 "
+
+CONFIGURE_OPTS="--disable-static"
 
 pre_configure() {
     typeset arch=$1

--- a/lib/mog/global-transforms.mog
+++ b/lib/mog/global-transforms.mog
@@ -73,6 +73,8 @@
 # lib/64 -> lib/amd64 link
 <transform dir path=opt/ooce(|/.+)/lib/amd64$ -> emit \
     link path=opt/ooce%<1>/lib/64 target=amd64 >
+<transform dir path=opt/ooce(|/.+)/lib/security/amd64$ -> emit \
+    link path=opt/ooce%<1>/lib/security/64 target=amd64 >
 
 #
 # Drops


### PR DESCRIPTION
```diff
-file path=opt/ooce/lib/amd64/liboath.a owner=root group=bin mode=0644 facet.devel=true
-file path=opt/ooce/lib/amd64/libpskc.a owner=root group=bin mode=0644 facet.devel=true
+link path=opt/ooce/lib/liboath.so target=liboath.so.0.1.3
+link path=opt/ooce/lib/liboath.so.0 target=liboath.so.0.1.3
+file path=opt/ooce/lib/liboath.so.0.1.3 owner=root group=bin mode=0755 elfarch=i386 elfbits=32
+link path=opt/ooce/lib/libpskc.so target=libpskc.so.0.0.1
+link path=opt/ooce/lib/libpskc.so.0 target=libpskc.so.0.0.1
+file path=opt/ooce/lib/libpskc.so.0.0.1 owner=root group=bin mode=0755 elfarch=i386 elfbits=32
+dir  path=opt/ooce/lib/pkgconfig owner=root group=other mode=0755 facet.devel=true
+file path=opt/ooce/lib/pkgconfig/liboath.pc owner=root group=bin mode=0644 facet.devel=true
+file path=opt/ooce/lib/pkgconfig/libpskc.pc owner=root group=bin mode=0644 facet.devel=true
+link path=opt/ooce/lib/security/64 target=amd64
+file path=opt/ooce/lib/security/pam_oath.so owner=root group=bin mode=0755 elfarch=i386 elfbits=32
```