### PR TITLE
bump Helix to 24.07

### DIFF
--- a/build/helix/build.sh
+++ b/build/helix/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=helix
-VER=24.03
+VER=24.07
 PKG=ooce/editor/helix
 SUMMARY="A post-modern modal text editor."
 DESC="A kakoune / neovim inspired editor, written in Rust."

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -89,7 +89,7 @@
 | ooce/developer/zig-013	| 0.13.0	| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/driver/fuse		| 1.5		| https://github.com/jurikm/illumos-fusefs/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/emacs		| 29.4		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
-| ooce/editor/helix		| 24.03		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
+| ooce/editor/helix		| 24.07		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 8.0		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/neovim		| 0.10.0	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
I built this version for myself and I've been using it for a couple of days with no issues. The version is year-month, so it's [a more significant upgrade than the numbers might suggest](https://github.com/helix-editor/helix/blob/master/CHANGELOG.md#2407-2024-07-14).