### PR TITLE
clang 18 should be able to cross compile for aarch64

### DIFF
--- a/build/aarch64/gcc10/local.mog
+++ b/build/aarch64/gcc10/local.mog
@@ -27,4 +27,5 @@ license COPYING3.LIB license=LGPLv3
     set pkg.depend.bypass-generate .*libm\.so\.0$>
 
 link path=$(PREFIX)/lib/gcc/$(TRIPLET64)/$(MAJOR) target=$(GCCVER)
+link path=$(PREFIX)/$(TRIPLET64)/include/c++/$(MAJOR) target=$(GCCVER)
 

--- a/build/clang/local.mog
+++ b/build/clang/local.mog
@@ -9,7 +9,7 @@
 # http://www.illumos.org/license/CDDL.
 #
 
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 # Skip dependency resolution for python components
 <transform file path=$(PREFIX)/share/$(PROG)/.*\.py$ \
@@ -30,6 +30,9 @@ link path=$(OPREFIX)/bin/$(PROG)++-$(VERSION) target=../$(PKGROOT)/bin/$(PROG)++
 # don't mediate version specific binaries
 <transform path=.*/s?bin/[^/]+-$(VERSION)$ -> delete mediator .>
 <transform path=.*/s?bin/[^/]+-$(VERSION)$ -> delete mediator-version .>
+
+# drop config symlinks
+<transform link path=$(OPREFIX)/bin/.+\.cfg$ -> drop>
 
 license LICENSE.TXT license=Apache2
 

--- a/build/llvm/patches-18/aarch64-eh_frame-ro.patch
+++ b/build/llvm/patches-18/aarch64-eh_frame-ro.patch
@@ -1,0 +1,17 @@
+Ensure .eh_frame is consistently read-only for aarch64
+
+diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/MC/MCObjectFileInfo.cpp a/lib/MC/MCObjectFileInfo.cpp
+--- a~/lib/MC/MCObjectFileInfo.cpp	1970-01-01 00:00:00
++++ a/lib/MC/MCObjectFileInfo.cpp	1970-01-01 00:00:00
+@@ -381,8 +381,10 @@ void MCObjectFileInfo::initELFMCObjectFi
+   // Solaris requires different flags for .eh_frame to seemingly every other
+   // platform.
+   unsigned EHSectionFlags = ELF::SHF_ALLOC;
+-  if (T.isOSSolaris() && T.getArch() != Triple::x86_64)
++  if (T.isOSSolaris() && T.getArch() != Triple::x86_64 &&
++      T.getArch() != Triple::aarch64) {
+     EHSectionFlags |= ELF::SHF_WRITE;
++  }
+ 
+   // ELF
+   BSSSection = Ctx->getELFSection(".bss", ELF::SHT_NOBITS,

--- a/build/llvm/patches-18/series
+++ b/build/llvm/patches-18/series
@@ -1,0 +1,1 @@
+aarch64-eh_frame-ro.patch


### PR DESCRIPTION
When I was doing first test builds of clang 19, I realised that the configure option `GCC_INSTALL_PREFIX` is deprecated. Apparently it also interferes with the `--sysroot` command line option.

Instead, we are now shipping default configurations for all supported triplets on OmniOS so clang will find the runtime objects and libstdc++ headers from gcc it uses (users can still easily override them but we provide working defaults). This also makes cross compiling for aarch64 with clang 18 work.

This is the deprecation warning:
```
  GCC_INSTALL_PREFIX is deprecated and will be removed.  Use configuration
  files (https://clang.llvm.org/docs/UsersManual.html#configuration-files)to
  specify the default --gcc-install-dir= or --gcc-triple=.  --gcc-toolchain=
  is discouraged.  See https://github.com/llvm/llvm-project/pull/77537 for
  detail.
  ```
  
  Using `--gcc-install-dir` seems to be the way forward.

requires https://github.com/omniosorg/omnios-build/pull/3658

cc @richlowe