### PR TITLE
Add VictoriaMetrics package, a time series database.

### DIFF
--- a/build/victoriametrics/build.sh
+++ b/build/victoriametrics/build.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2024 Guo-Rong Koh
+
+. ../../lib/build.sh
+
+PROG=victoriametrics
+VER=1.102.2
+PKG=ooce/database/victoriametrics
+SUMMARY="VictoriaMetrics"
+DESC="Fast, cost-effective monitoring solution and time series database."
+
+DATA=var/${PREFIX#/}/$PROG
+
+set_arch 64
+set_gover
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DUSER=$PROG
+    -DGROUP=$PROG
+    -DDATA=$DATA
+    -DVERSION=$VER
+    -DVM=victoria-metrics
+    -DVMAGENT=vmagent
+"
+
+build() {
+    pushd $TMPDIR/$BUILDDIR > /dev/null
+
+    logmsg "Building $PROG"
+    export CGO_ENABLED=0
+    export GOOS=illumos
+
+    logcmd $MAKE victoria-metrics-pure \
+        || logerr "Unable to build victoria-metrics-pure"
+    logcmd $MAKE vmutils-pure \
+        || logerr "Unable to build vmutils-pure"
+
+    popd >/dev/null
+}
+
+# make it so
+init
+clone_go_source VictoriaMetrics VictoriaMetrics v$VER
+prep_build
+build
+install_go bin/victoria-metrics-pure victoria-metrics
+install_go bin/vmagent-pure vmagent
+install_go bin/vmbackup-pure vmbackup
+install_go bin/vmctl-pure vmctl
+install_go bin/vmrestore-pure vmrestore
+xform files/$PROG-template.xml > $TMPDIR/$PROG.xml
+install_smf application $PROG.xml
+xform files/victoria-metrics-profile-template.xml \
+    > $TMPDIR/victoria-metrics-profile.xml
+add_notes README.install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/victoriametrics/files/README.install
+++ b/build/victoriametrics/files/README.install
@@ -1,0 +1,17 @@
+-----------------------------------------
+VictoriaMetrics and vmagent Configuration
+-----------------------------------------
+
+VictoriaMetrics and vmagent are not configured by configuration files.
+Configuration is achieved via command-line arguments or equivalent environment variables.
+
+For SMF service integration, service profiles with appropriate environment variables can be used.
+Example profiles are provided in `<prefix>/share/victoriametrics`.
+
+These can edited and applied with:
+```
+svcadm apply victoria-metrics-profile.xml
+svcadm apply vmagent-profile.xml
+```
+
+vmagent _requires_ at least the envvar `VM_remoteWrite_url`, an example is provided that can be applied.

--- a/build/victoriametrics/files/victoria-metrics-profile-template.xml
+++ b/build/victoriametrics/files/victoria-metrics-profile-template.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="profile"
+                name="victoriametrics">
+
+    <service name="ooce/application/victoriametrics"
+             type="service"
+             version="1">
+
+        <instance name="victoria-metrics">
+            <method_context>
+                <method_environment>
+                    <envvar name="VM_storageDataPath"
+                            value="/$(DATA)" />
+                    <envvar name="VM_retentionPeriod"
+                            value="90d" />
+                    <envvar name="VM_selfScrapeInterval"
+                            value="60s" />
+                </method_environment>
+            </method_context>
+
+        </instance>
+
+    </service>
+
+</service_bundle>

--- a/build/victoriametrics/files/victoriametrics-template.xml
+++ b/build/victoriametrics/files/victoriametrics-template.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="manifest"
+                name="victoriametrics">
+
+    <service name="ooce/application/victoriametrics"
+             type="service"
+             version="1">
+
+        <instance name="victoria-metrics"
+                  enabled="false">
+
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
+
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
+
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
+            <method_context>
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic" />
+                <method_environment>
+                    <envvar name="VM_storageDataPath"
+                            value="/$(DATA)" />
+                </method_environment>
+            </method_context>
+
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/exec} -envflag.enable -envflag.prefix=VM_"
+                         timeout_seconds="60"></exec_method>
+
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="300" />
+
+            <property_group name="config"
+                            type="application">
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/bin/$(VM)" />
+            </property_group>
+
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="child" />
+                <propval name="ignore_error"
+                         type="astring"
+                         value="core,signal" />
+            </property_group>
+
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">VictoriaMetrics server
+                    $(VERSION)</loctext>
+                </common_name>
+            </template>
+
+        </instance>
+
+        <instance name="vmagent"
+                  enabled="false">
+
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
+
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
+
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
+            <method_context>
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic" />
+            </method_context>
+
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/exec} -envflag.enable -envflag.prefix=VM_"
+                         timeout_seconds="60"></exec_method>
+
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="300" />
+
+            <property_group name="config"
+                            type="application">
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/bin/$(VMAGENT)" />
+            </property_group>
+
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="child" />
+                <propval name="ignore_error"
+                         type="astring"
+                         value="core,signal" />
+            </property_group>
+
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">VictoriaMetrics agent
+                    $(VERSION)</loctext>
+                </common_name>
+            </template>
+
+        </instance>
+
+        <stability value="External" />
+
+    </service>
+
+</service_bundle>

--- a/build/victoriametrics/files/vmagent-profile.xml
+++ b/build/victoriametrics/files/vmagent-profile.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="profile"
+                name="victoriametrics">
+
+    <service name="application/victoriametrics"
+             type="service"
+             version="1">
+
+        <instance name="vmagent">
+            <method_context>
+                <method_environment>
+                    <envvar name="VM_remoteWrite_url"
+                            value="http://localhost:8428/api/v1/write" />
+                </method_environment>
+            </method_context>
+
+        </instance>
+
+    </service>
+
+</service_bundle>

--- a/build/victoriametrics/local.mog
+++ b/build/victoriametrics/local.mog
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2024 Guo-Rong Koh
+
+license LICENSE license=Apache2
+
+dir path=$(DATA) owner=$(USER) group=$(GROUP) mode=0700
+
+group groupname=$(GROUP) gid=93
+user ftpuser=false username=$(USER) uid=93 group=$(GROUP) \
+    gcos-field="VictoriaMetrics user" \
+    home-dir=/$(DATA) password=NP
+
+file ./tmp/victoria-metrics-profile.xml \
+    path=$(PREFIX)/share/$(PROG)/victoria-metrics-profile.xml \
+    owner=$(USER) group=$(GROUP) mode=0444
+file files/vmagent-profile.xml \
+    path=$(PREFIX)/share/$(PROG)/vmagent-profile.xml \
+    owner=$(USER) group=$(GROUP) mode=0444
+
+<transform file path=$(PREFIX)/bin/victoria-metrics -> \
+    set restart_fmri svc:/application/$(PROG):victoria-metrics>
+<transform file path=$(PREFIX)/bin/vmagent -> \
+    set restart_fmri svc:/application/$(PROG):vmagent>

--- a/doc/baseline
+++ b/doc/baseline
@@ -63,6 +63,7 @@ extra.omnios ooce/database/postgresql-16/mysql_fdw
 extra.omnios ooce/database/postgresql-16/pg_repack
 extra.omnios ooce/database/postgresql-common
 extra.omnios ooce/database/rrdtool
+extra.omnios ooce/database/victoriametrics
 extra.omnios ooce/developer/aarch64-gcc10
 extra.omnios ooce/developer/aarch64-gnu-binutils
 extra.omnios ooce/developer/aarch64-linker

--- a/doc/idlist.md
+++ b/doc/idlist.md
@@ -58,6 +58,7 @@
 | extra		| 90	| postgres
 | extra		| 91	| subversion
 | omnios	| 92	| sshd
+| extra		| 93	| victoriametrics
 | illumos	| 95	| svctag
 | illumos	| 96	| unknown
 | pkg5		| 97	| pkg5srv
@@ -122,6 +123,7 @@
 | extra		| 90	| postgres
 | extra		| 91	| subversion
 | omnios	| 92	| sshd
+| extra		| 93	| victoriametrics
 | illumos	| 95	| slocate
 | illumos	| 96	| unknown
 | pkg5		| 97	| pkg5srv

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -47,6 +47,7 @@
 | ooce/database/postgresql-XX/mysql_fdw	| 2.9.1	| https://github.com/EnterpriseDB/mysql_fdw/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-XX/pg_repack	| 1.5.0	| https://github.com/reorg/pg_repack/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/database/rrdtool		| 1.9.0		| https://github.com/oetiker/rrdtool-1.x/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/database/victoriametrics	| 1.102.2	| https://github.com/VictoriaMetrics/VictoriaMetrics | [gkoh](https://github.com/gkoh)
 | ooce/developer/autoconf-archive | 2023.02.20	| https://ftp.gnu.org/gnu/autoconf-archive/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/autogen	| 5.18.16	| https://ftp.gnu.org/gnu/autogen/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/bazel		| 6.3.2		| https://github.com/bazelbuild/bazel/releases | [omniosorg](https://github.com/omniosorg)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -219,7 +219,7 @@ logerr() {
     # Print an error message and ask the user if they wish to continue
     logmsg -e "$@" >> /dev/stderr
     if [ -z "$BATCH" ]; then
-        ask_to_continue "An Error occured in the build. "
+        ask_to_continue "An Error occurred in the build. "
     else
         exit 1
     fi


### PR DESCRIPTION
Package multiple pieces of the Prometheus compatible VictoriaMetrics suite:
- victoria-metrics
- vmagent
- vmbackup
- vmrestore
- vmctl

Whilst here, correct a minor spelling error in functions.sh.