### PR TITLE
Update to VictoriaMetrics 1.102.8.

### DIFF
--- a/build/victoriametrics/build.sh
+++ b/build/victoriametrics/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=victoriametrics
-VER=1.102.2
+VER=1.102.8
 PKG=ooce/database/victoriametrics
 SUMMARY="VictoriaMetrics"
 DESC="Fast, cost-effective monitoring solution and time series database."

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -48,7 +48,7 @@
 | ooce/database/postgresql-XX/mysql_fdw	| 2.9.1	| https://github.com/EnterpriseDB/mysql_fdw/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/database/postgresql-XX/pg_repack	| 1.5.0	| https://github.com/reorg/pg_repack/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/database/rrdtool		| 1.9.0		| https://github.com/oetiker/rrdtool-1.x/releases | [omniosorg](https://github.com/omniosorg)
-| ooce/database/victoriametrics	| 1.102.2	| https://github.com/VictoriaMetrics/VictoriaMetrics | [gkoh](https://github.com/gkoh)
+| ooce/database/victoriametrics	| 1.102.8	| https://github.com/VictoriaMetrics/VictoriaMetrics | [gkoh](https://github.com/gkoh)
 | ooce/developer/autoconf-archive | 2023.02.20	| https://ftp.gnu.org/gnu/autoconf-archive/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/autogen	| 5.18.16	| https://ftp.gnu.org/gnu/autogen/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/bazel		| 6.3.2		| https://github.com/bazelbuild/bazel/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Update VictoriaMetrics to recent 1.102.8 LTS.