### PR TITLE
bump vaultwarden to 1.32.6

### DIFF
--- a/build/vaultwarden/build.sh
+++ b/build/vaultwarden/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=vaultwarden
-VER=1.32.5
+VER=1.32.6
 PKG=ooce/application/vaultwarden
 SUMMARY="Bitwarden compatible server"
 DESC="Unofficial Bitwarden compatible server written in Rust, formerly known "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -28,7 +28,7 @@
 | ooce/application/tidy		| 5.8.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tig 		| 2.5.10	| https://github.com/jonas/tig/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vagrant	| 2.2.19	| https://github.com/hashicorp/vagrant/tags | [omniosorg](https://github.com/omniosorg)
-| ooce/application/vaultwarden	| 1.32.5	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
+| ooce/application/vaultwarden	| 1.32.6	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.2.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.4.3		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Been wondering why push was broken, it's fixed in this update.

https://github.com/dani-garcia/vaultwarden/releases/tag/1.32.6

I'm traveling at the moment so haven't given this a build in a VM yet. But past updates seemed to have went fine without issue.