### PR TITLE
Bump helix to version 25.01

### DIFF
--- a/build/helix/build.sh
+++ b/build/helix/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=helix
-VER=24.07
+VER=25.01
 PKG=ooce/editor/helix
 SUMMARY="A post-modern modal text editor."
 DESC="A kakoune / neovim inspired editor, written in Rust."

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -88,7 +88,7 @@
 | ooce/developer/zig-013	| 0.13.0	| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/driver/fuse		| 1.6		| https://github.com/jurikm/illumos-fusefs/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/emacs		| 29.4		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
-| ooce/editor/helix		| 24.07		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
+| ooce/editor/helix		| 25.01		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 8.2		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/neovim		| 0.10.2	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
There's a new version of helix with a bunch of nice features.

Builds successfully:
```
Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
-- Cleaning up
--- Removing temporary install directory /tmp/build_omnios/helix-25.01/ooce_editor_helix_pkg
--- Cleaning up temporary manifest and transform files
Done.
Time: ooce/editor/helix - 0h4m40s
```

Note I pulled the source tar.xz and used site.sh to point the build system at it since I can't modify the omnios mirror web server.