### PR TITLE
neovim: update to 0.10.3, work around #1539

### DIFF
--- a/build/neovim/build.sh
+++ b/build/neovim/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=neovim
-VER=0.10.2
+VER=0.10.3
 PKG=ooce/editor/neovim
 SUMMARY="Neovim"
 DESC="hyperextensible Vim-based text editor"
@@ -55,7 +55,8 @@ pre_configure() {
             -DUSE_BUNDLED_LIBUV=OFF
         \"
         CMAKE_EXTRA_FLAGS=\"
-            -DCMAKE_EXE_LINKER_FLAGS='-Wl,-R$OPREFIX/${LIBDIRS[$arch]} -lgcc_s'
+            -DCMAKE_EXE_LINKER_FLAGS='-Wl,-R$OPREFIX/${LIBDIRS[$arch]} -lgcc_s
+            -lumem'
         \"
     "
 

--- a/build/neovim/patches/illumos-luajit-umem-workaround.patch
+++ b/build/neovim/patches/illumos-luajit-umem-workaround.patch
@@ -1,0 +1,31 @@
+--- a~/src/nvim/os_illumos.c	Tue Jan 21 16:21:57 2025
++++ a/src/nvim/os_illumos.c	Tue Jan 21 16:39:03 2025
+@@ -174,3 +174,28 @@
+ 
+ 	return (0);
+ }
++
++/*
++ * At present, due to an argument between bespoke generated assembly in LuaJIT
++ * and our linker, we cannot build LuaJIT as a shared library for use by
++ * Neovim. To work around this, we build LuaJIT statically and embed it in the
++ * nvim executable directly.  Unfortunately this means the program text for
++ * LuaJIT is placed before the heap, and LuaJIT does some ill-advised things
++ * with mmap() for memory allocation which means it forcibly tries to put
++ * memory allocations quite close to the heap.  As the brk moves up in the
++ * address space, it eventually collides with one of these low address mappings
++ * and the program crashes with an error like "E41: Out of memory" next time a
++ * malloc(3C) call fails.
++ *
++ * In order to work around this, we'll use libumem(3LIB) as our allocator
++ * instead of the base libc malloc(3C).  The umem allocator has a backend that
++ * can use mmap(2) instead of brk(2) to get memory, which avoids the clash with
++ * LuaJIT.
++ *
++ * See omnios-extra#1539 for more details.
++ */
++const char *
++_umem_options_init(void)
++{
++	return ("backend=mmap");
++}

--- a/build/neovim/patches/series
+++ b/build/neovim/patches/series
@@ -1,5 +1,6 @@
 libuv.patch
 link-gcc_s.patch
 illumos-support.patch
+illumos-luajit-umem-workaround.patch
 use-system-default-tty-modes.patch
 path.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -91,7 +91,7 @@
 | ooce/editor/helix		| 25.01		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 8.2		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
-| ooce/editor/neovim		| 0.10.2	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/editor/neovim		| 0.10.3	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/emulator/qemu		| 9.2.0		| https://www.qemu.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/file/acltool		| 1.16.2	| https://github.com/ptrrkssn/acltool/releases | [Peter Eriksson](https://github.com/ptrrkssn)
 | ooce/file/lsof		| 4.99.3	| https://github.com/lsof-org/lsof/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This change updates Neovim to 0.10.3, which includes a relatively crucial LSP bug fix around server cancellation.  It also adds a temporary workaround for #1539, until we can find time to fix the real issues there.

I have built and tested this on an OmniOS r151046 LTS system, and it appears to work.  I ran ":checkhealth" and also the plugin checks for the Lazy plugin system, and there were no weird new problems.  I also edited a text file and made use of the RPC socket.
