### PR TITLE
Add -M build flag to temporarily override mirror for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,20 +739,26 @@ packages. In the early stages of a build, this source tarball will not be
 available on the OmniOS mirror, and will be need to be made available for the
 build process.
 
-This can be done by using the `set_mirror` directive in `build.sh`. For example
-the source tarball for "Apache httpd 2.4.43" is available at the mirror:
-<https://downloads.apache.org/>. Therefore the `set_mirror` directive should be
-as follows:
+The easiest way to do this is to use `build.sh`'s `-M` option to temporarily
+point at either the original distribution site, or to a temporary directory.
 
-```none
-set_mirror "https://downloads.apache.org/"
-```
-Further in the `build.sh` file, the `download_source` directive should be as
-follows:
+For example the source tarball for "Apache httpd 2.4.43" is available at the
+mirror: <https://downloads.apache.org/>. Therefore `build.sh` can be run as:
 
-```none
-download_source $PROG $PROG $VER
+```bash
+$ ./build.sh -M https://downloads.apache.org/
 ```
+
+or, if you download `httpd-2.4.43.tar.bz2` and place it in `/tmp/apache`:
+
+```bash
+$ ./build.sh -M /tmp
+```
+
+If the download fails, look at `build.log` to determine the pathnames that
+were tried, and adjust accordingly.
+
+The mirror can also be changed permanently in `lib/site.sh`.
 
 #### Checksums:
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -59,7 +59,7 @@ process_opts() {
     SKIP_CHECKSUM=
     EXTRACT_MODE=0
     MOG_TEST=
-    while getopts "bcimPpstf:ha:d:Llr:x" opt; do
+    while getopts "bcimM:Ppstf:ha:d:Llr:x" opt; do
         case $opt in
             a)
                 set_arch "$OPTARG"
@@ -95,6 +95,11 @@ process_opts() {
                 ;;
             m)
                 MOG_TEST=1
+                ;;
+            M)
+                logmsg -n "-- Will retrieve files from $OPTARG"
+                set_mirror "$OPTARG"
+                set_checksum none
                 ;;
             P)
                 REBASE_PATCHES=1
@@ -139,6 +144,8 @@ show_usage() {
   -l        : skip pkglint check
   -L        : skip hardlink target check
   -m        : re-generate final mog from local.mog (mog test mode)
+  -M URL    : retrieve files from URL instead of OmniOS mirror
+  -M /PATH  : retrieve files from (absolute) PATH instead of OmniOS mirror
   -p        : output all commands to the screen as well as log file
   -P        : re-base patches on latest source
   -r REPO   : specify the IPS repo to use


### PR DESCRIPTION
Although those working on package updates are able to change the download mirror in `lib/site.sh` or via `set_mirror` directives in the build script, it would be useful if they could do this transiently via a new flag to `build.sh` and not have to make changes that then need to be reverted.

This adds a new `-M` option to `build.sh` that does this, and updates the documentation accordingly.