### PR TITLE
Add --force to caddy refresh method

### DIFF
--- a/build/caddy/files/caddy-template.xml
+++ b/build/caddy/files/caddy-template.xml
@@ -82,7 +82,7 @@
 
             <exec_method type="method"
                          name="refresh"
-                         exec="%{config/exec} reload --config %{config/file}"
+                         exec="%{config/exec} reload --config %{config/file} --force"
                          timeout_seconds="300" />
 
             <property_group name="config"


### PR DESCRIPTION
I noticed on one of my caddy instances that it was running with expired certs even though I had called its SMF refresh method.  It turns out caddy won't reload the config if nothing has changed.

```
--force will cause a reload to happen even if the specified config is the same as what Caddy is already running.
Can be useful to force Caddy to reprovision its modules, which can have side-effects, for example:
reloading manually-loaded TLS certificates.
 ```