### PR TITLE
Bump atuin to v18.8.0

### DIFF
--- a/build/atuin/build.sh
+++ b/build/atuin/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=atuin
-VER=18.6.1
+VER=18.8.0
 PKG=ooce/util/atuin
 SUMMARY="Magical shell history"
 DESC="Replaces your existing shell history with a SQLite database and "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -239,7 +239,7 @@
 | ooce/text/tree-sitter-langs	| 0.12.268	| https://github.com/emacs-tree-sitter/tree-sitter-langs/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/text/xsv			| 0.13.0	| https://github.com/BurntSushi/xsv/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/acmefetch		| 0.8.1		| https://github.com/oetiker/AcmeFetch/releases | [omniosorg](https://github.com/omniosorg)
-| ooce/util/atuin		| 18.6.1	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/util/atuin		| 18.8.0	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/bat			| 0.25.0	| https://github.com/sharkdp/bat/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/diffr		| 0.1.5		| https://github.com/mookid/diffr/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/util/direnv		| 2.35.0	| https://github.com/direnv/direnv/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This bumps atuin from 18.6.1 to 18.8.0

```
--- Publishing package to file:///ws/omnios-extra/tmp.repo/
Intentional pause: Last chance to sanity-check before publication!
Do you wish to continue anyway? (y/n) Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
--- Published ooce/util/atuin@18.8.0,5.11-151054.0
--- Comparing old package with new

-set name=info.source-url value=https://mirrors.omnios.org/atuin/v18.6.1.tar.gz
+set name=info.source-url value=https://mirrors.omnios.org/atuin/v18.8.0.tar.gz

***
*** Differences found between old and new packages
***
Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
-- Cleaning up
--- Removing temporary install directory /tmp/build_omnios/atuin-18.8.0/ooce_util_atuin_pkg
--- Cleaning up temporary manifest and transform files
Done.
```