### PR TITLE
Add micro text editor

### DIFF
--- a/build/micro/build.sh
+++ b/build/micro/build.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=micro
+PROGNAME=micro
+# The latest release is broken on illumos, but we can use a later git hash
+# until a new release is cut.
+VER=2.0.14
+HASH=115e560ee24b37893c0bbc51dcfaf5f79e0d64e8
+PKG=ooce/editor/micro
+SUMMARY="$PROG - modern and intuitive terminal-based text editor"
+DESC=`cat <<'EOM'
+Micro is a terminal-based text editor that aims to be easy to use and
+intuitive, while also taking advantage of the full capabilities of modern
+terminals. As the name indicates, micro aims to be somewhat of a successor to
+the nano editor by being easy to install and use in a pinch, but micro also
+aims to be enjoyable to use full time, whether you work in the terminal because
+you prefer it, or because you need to.
+EOM
+`
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+
+set_arch 64
+set_gover
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+"
+
+SKIP_LICENCES=Various
+
+pre_configure() {
+    # No configure
+    false
+}
+
+pre_install() {
+    install_go $PROG
+    false
+}
+
+init
+clone_github_source $PROG "$GITHUB/zyedidia/$PROG" $HASH "" -1
+append_builddir $PROG
+patch_source
+# Use the last commit date as the dash revision
+DASHREV=`$GIT -C $TMPDIR/$BUILDDIR log -1 --date=format:%Y%m%d --format=%cd`
+#export BUILD_NUMBER=$VER
+prep_build
+build -noctf
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/micro/local.mog
+++ b/build/micro/local.mog
@@ -1,0 +1,17 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT
+license LICENSE-THIRD-PARTY license=Various
+
+<include binlink.mog>
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -128,6 +128,7 @@ extra.omnios ooce/driver/fuse
 extra.omnios ooce/editor/emacs
 extra.omnios ooce/editor/helix
 extra.omnios ooce/editor/joe
+extra.omnios ooce/editor/micro
 extra.omnios ooce/editor/nano
 extra.omnios ooce/editor/neovim
 extra.omnios ooce/emulator/qemu

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -97,6 +97,7 @@
 | ooce/editor/emacs		| 30.2		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/helix		| 25.07.1	| https://github.com/helix-editor/helix/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
+| ooce/editor/micro		| 2.0.14	| https://github.com/zyedidia/micro/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 8.6		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/neovim		| 0.10.4	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/emulator/qemu		| 10.1.0	| https://www.qemu.org/download/ | [omniosorg](https://github.com/omniosorg)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1606,7 +1606,8 @@ clone_github_source() {
         logcmd $RSYNC -ar --delete $local/ $prog/ || logerr "rsync failed."
         fresh=1
     elif [ ! -d $prog ]; then
-        logcmd $GIT clone --no-single-branch --depth $depth $src $prog \
+        [ "$depth" = "-1" ] && depth= || depth="--depth $depth"
+        logcmd $GIT clone --no-single-branch $depth $src $prog \
             || logerr "clone failed"
         fresh=1
     else


### PR DESCRIPTION
micro is a GO based terminal editor. The latest release is broken on Illumos, but the git master builds and works just fine. I'd like to get more experience with creating IPS packages, therefore I try to make an own recipe. 

The resipe is updated to point to a specific git commit instead of master. This makes the recipe reproducible.

Thanks to andyf for the help!