### PR TITLE
zig: update to 0.15.1

### DIFF
--- a/build/zig/build-0.15.sh
+++ b/build/zig/build-0.15.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=zig
+VER=0.15.1
+MAJVER=${VER%%.*}
+MINVER=${VER%.*}
+MINVER=${MINVER#*.}
+PKG=ooce/developer/zig-015
+SUMMARY="$PROG programming language"
+DESC="$PROG is a general-purpose programming language and toolchain for "
+DESC+="maintaining robust, optimal, and reusable software."
+
+min_rel 151054
+
+#
+# Zig 0.15.x requires LLVM 20.1.8
+#
+set_clangver 20
+set_arch 64
+
+CLANGFVER=`pkg_ver clang build-$CLANGVER.sh`
+
+set_patchdir patches-$MAJVER.$MINVER
+OPREFIX=$PREFIX
+PREFIX+=/$PROG-$MAJVER.$MINVER
+
+XFORM_ARGS="
+    -DOPREFIX=${OPREFIX#/}
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG-$MAJVER.$MINVER
+    -DMEDIATOR=$PROG -DMEDIATOR_VERSION=$MAJVER.$MINVER
+"
+
+#
+# CMAKE_BUILD_TYPE=RelWithDebInfo
+#
+#   Keep debug info so symbols are available to the various
+#   debugging tools.
+#
+# ZIG_STATIC_LLVM=on
+#
+#   Embed the LLVM toolchain in the zig executable. This is
+#   the preferred way to ship zig.
+#
+# ZIG_TARGET_MCPU=baseline
+#
+#   Target the compiler to pentium4-era CPU features so it can
+#   work on the maximum set of hosts. This only effects the
+#   compiler executable, applications built with this compiler
+#   can set their own CPU features.
+#
+CONFIGURE_OPTS[amd64]="
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    -DCMAKE_INSTALL_PREFIX=$PREFIX
+    -DLLVM_INCLUDE_DIRS=$OPREFIX/llvm-$CLANGVER/include
+    -DCLANG_INCLUDE_DIRS=$OPREFIX/llvm-$CLANGVER/include
+    -DLLVM_LIBDIRS=$OPREFIX/llvm-$CLANGVER/lib
+    -DCLANG_LIBDIRS=$OPREFIX/llvm-$CLANGVER/lib
+    -DZIG_STATIC_LLVM=on
+    -DZIG_TARGET_MCPU="baseline"
+"
+
+init
+
+#########################################################################
+# Download and build lld
+
+save_buildenv
+
+set_builddir llvm-project-$CLANGFVER.src/lld
+prep_build cmake+ninja
+
+CONFIGURE_OPTS[amd64]="
+    -DCMAKE_BUILD_TYPE=Release
+    -DLLVM_MAIN_SRC_DIR=$TMPDIR/llvm-project-$CLANGFVER.src/llvm
+"
+
+build_dependency -noctf lld-$CLANGVER llvm-project-$CLANGFVER.src/lld \
+    llvm llvm-project $CLANGFVER.src
+
+restore_buildenv
+
+CONFIGURE_OPTS[amd64]+="
+    -DLLD_INCLUDE_DIRS=$DEPROOT/usr/local/include
+    -DLLD_LIBDIRS=$DEPROOT/usr/local/lib
+"
+
+#########################################################################
+
+note -n "Building $PROG"
+
+set_builddir $PROG-$VER
+
+CXXFLAGS+=" -fPIC"
+
+download_source $PROG $PROG $VER
+patch_source
+prep_build cmake+ninja
+build -noctf    # C++
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/zig/patches-0.15/add-arc4random_buf.patch
+++ b/build/zig/patches-0.15/add-arc4random_buf.patch
@@ -1,0 +1,91 @@
+From f3d196190048fce8609e0dd7257c864e32a3663e Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 24 Sep 2025 08:34:29 -0400
+Subject: [PATCH] add arc4random_buf
+
+Add support for arc4random_buf to avoid relying on zig's internal
+tlcsprng implementation as there seems to be some flakiness with it's
+use of threadlocal when using the build runner to build the zig stage3
+compiler (see error below). This only works when the program is linked
+with libc, as should always be the case on illumos.
+
+[19/19] Building stage3
+FAILED: stage3/bin/zig /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-build/build.amd64/stage3/bin/zig
+
+cd /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0 && /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-b
+uild/build.amd64/zig2 build --prefix /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-build/build.amd64/
+stage3 --zig-lib-dir /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib -Dversion-string=0.14.0 -Dtarg
+et=native -Dcpu=baseline -Denable-llvm -Dconfig_h=/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-build
+/build.amd64/config.h -Dno-langref -Doptimize=ReleaseFast
+Segmentation fault at address 0xfffffc7feeccf448
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/crypto/tlcsprng.zig:59:9: 0x1593a4f in tlsCsprn
+gFill (build)
+    if (wipe_mem.len == 0) {
+        ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Random.zig:58:13: 0x15efbe1 in bytes (build)
+    r.fillFn(r.ptr, buf);
+            ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/fs/AtomicFile.zig:26:32: 0x15e84d5 in init (bui
+ld)
+        std.crypto.random.bytes(rand_buf[0..]);
+                               ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/fs/Dir.zig:2657:31: 0x15e8099 in atomicFile (bu
+ild)
+        return AtomicFile.init(fs.path.basename(dest_path), options.mode, dir, true);
+                              ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/fs/Dir.zig:2541:46: 0x15e8ca0 in updateFile (bu
+ild)
+    var atomic_file = try dest_dir.atomicFile(dest_path, .{ .mode = actual_mode });
+                                             ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Build/Step/InstallDir.zig:111:54: 0x1574176 in
+make (build)
+                const prev_status = fs.Dir.updateFile(
+                                                     ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Build/Step.zig:231:13: 0x15545ff in make (build
+)
+    s.makeFn(s, options) catch |err| switch (err) {
+            ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/compiler/build_runner.zig:1105:31: 0x151ca08 in workerMakeOneStep (build)
+    const make_result = s.make(.{
+                              ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Thread/Pool.zig:119:39: 0x151d3d3 in runFn (build)
+            @call(.auto, func, closure.arguments);
+                                      ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Thread/Pool.zig:295:32: 0x159da4c in worker (build)
+            run_node.data.runFn(&run_node.data, id);
+                               ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Thread.zig:488:13: 0x155323a in callFn__anon_100548 (build)
+            @call(.auto, f, args);
+            ^
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib/std/Thread.zig:757:30: 0x151c29e in entryFn (build)
+                return callFn(f, args_ptr.*);
+                             ^
+???:?:?: 0xfffffc7fef057326 in ??? (libc.so.1)
+Unwind information for `libc.so.1:0xfffffc7fef057326` was not available, trace may be incomplete
+
+???:?:?: 0xfffffc7fef05766f in ??? (libc.so.1)
+???:?:?: 0x0 in ??? (???)
+error: the following build command crashed:
+/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/.zig-cache/o/7d72ec58c6f1742b1ecb4d994da3a6df/build /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-build/build.amd64/zig2 /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/lib /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0 /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0/.zig-cache /export/home/rpz/.cache/zig --seed 0x97ac69e3 -Zb9a9429c1f2e840d --prefix /tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-build/build.amd64/stage3 -Dversion-string=0.14.0 -Dtarget=native -Dcpu=baseline -Denable-llvm -Dconfig_h=/tmp/build_rpz/zig-0.14.0/zig-0.14.0/zig-0.14.0-build/build.amd64/config.h -Dno-langref -Doptimize=ReleaseFast
+ninja: build stopped: subcommand failed.
+--- Make failed
+---
+ lib/std/c.zig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/std/c.zig b/lib/std/c.zig
+index 9d5e5bf9ab..8295a990b3 100644
+--- a/lib/std/c.zig
++++ b/lib/std/c.zig
+@@ -10312,7 +10312,7 @@ pub extern "c" fn setrlimit64(resource: rlimit_resource, rlim: *const rlimit) c_
+ 
+ pub const arc4random_buf = switch (native_os) {
+     .linux => if (builtin.abi.isAndroid()) private.arc4random_buf else {},
+-    .dragonfly, .netbsd, .freebsd, .solaris, .openbsd, .macos, .ios, .tvos, .watchos, .visionos => private.arc4random_buf,
++    .dragonfly, .netbsd, .freebsd, .illumos, .solaris, .openbsd, .macos, .ios, .tvos, .watchos, .visionos => private.arc4random_buf,
+     else => {},
+ };
+ pub const getentropy = switch (native_os) {
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/define-msghdr-flags.patch
+++ b/build/zig/patches-0.15/define-msghdr-flags.patch
@@ -1,0 +1,37 @@
+From baab5ae970709cd8f38071c4f32a1d65313f0af4 Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 3 Sep 2025 18:41:36 -0400
+Subject: [PATCH] define msghdr flags
+
+---
+ lib/std/c.zig | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/lib/std/c.zig b/lib/std/c.zig
+index 9d5e5bf9ab..40f6c6539f 100644
+--- a/lib/std/c.zig
++++ b/lib/std/c.zig
+@@ -5685,6 +5685,20 @@ pub const MSG = switch (native_os) {
+         pub const WAITFORONE = 0x2000;
+         pub const NOTIFICATION = 0x4000;
+     },
++    .illumos => struct {
++        pub const OOB = 0x0001;
++        pub const PEEK = 0x0002;
++        pub const DONTROUTE = 0x0004;
++        pub const EOR = 0x0008;
++        pub const CTRUNC = 0x0010;
++        pub const TRUNC = 0x0020;
++        pub const WAITALL = 0x0040;
++        pub const DONTWAIT = 0x0080;
++        pub const NOTIFICATION = 0x0100;
++        pub const NOSIGNAL = 0x0200;
++        pub const CMSG_CLOEXEC = 0x1000;
++        pub const CMSG_CLOFORK = 0x2000;
++    },
+     else => void,
+ };
+ pub const SOCK = switch (native_os) {
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/define-sigrt-min-and-max.patch
+++ b/build/zig/patches-0.15/define-sigrt-min-and-max.patch
@@ -1,0 +1,41 @@
+From ab1a8c52e8ce2acf27fad1481006735ceb8c838f Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Thu, 4 Sep 2025 10:58:50 -0400
+Subject: [PATCH] define sigrt min and max
+
+---
+ lib/std/c.zig | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/std/c.zig b/lib/std/c.zig
+index 9d5e5bf9ab..4c3cc6f51a 100644
+--- a/lib/std/c.zig
++++ b/lib/std/c.zig
+@@ -2583,6 +2583,8 @@ pub const _SC = if (builtin.abi.isAndroid()) enum(c_int) {
+     .solaris, .illumos => enum(c_int) {
+         PAGESIZE = 11,
+         NPROCESSORS_ONLN = 15,
++        SIGRT_MIN = 40,
++        SIGRT_MAX = 41,
+     },
+     // https://github.com/SerenityOS/serenity/blob/1dfc9e2df39dd23f1de92530677c845aae4345f2/Kernel/API/POSIX/unistd.h#L36-L52
+     .serenity => enum(c_int) {
+@@ -10464,6 +10466,7 @@ pub fn sigrtmin() u8 {
+     return switch (native_os) {
+         .freebsd => 65,
+         .netbsd => 33,
++        .illumos => @intCast(sysconf(@intFromEnum(_SC.SIGRT_MIN))),
+         else => @truncate(@as(c_uint, @bitCast(private.__libc_current_sigrtmin()))),
+     };
+ }
+@@ -10473,6 +10476,7 @@ pub fn sigrtmax() u8 {
+     return switch (native_os) {
+         .freebsd => 126,
+         .netbsd => 63,
++        .illumos => @intCast(sysconf(@intFromEnum(_SC.SIGRT_MAX))),
+         else => @truncate(@as(c_uint, @bitCast(private.__libc_current_sigrtmax()))),
+     };
+ }
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/fix-watch-init.patch
+++ b/build/zig/patches-0.15/fix-watch-init.patch
@@ -1,0 +1,19 @@
+From aa7fc1c9d627957e5c7df8a90e8613d8d4f78069 Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Thu, 13 Mar 2025 19:46:46 -0400
+Subject: [PATCH] fix watch init
+
+I'm not sure how this was ever supposed to compile on platforms that
+don't implement the Watch API.
+diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/std/Build/Watch.zig a/lib/std/Build/Watch.zig
+--- a~/lib/std/Build/Watch.zig	1970-01-01 00:00:00
++++ a/lib/std/Build/Watch.zig	1970-01-01 00:00:00
+@@ -811,7 +811,7 @@ const Os = switch (builtin.os.tag) {
+ };
+ 
+ pub fn init() !Watch {
+-    return Os.init();
++    return if (Os != void) Os.init() else error.Unsupported;
+ }
+ 
+ pub const Match = struct {

--- a/build/zig/patches-0.15/illumos-interp-check.patch
+++ b/build/zig/patches-0.15/illumos-interp-check.patch
@@ -1,0 +1,276 @@
+From 026af0419d22f9714dbbd9c03d8071f37d62735a Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 24 Sep 2025 08:33:02 -0400
+Subject: [PATCH] illumos interp check
+
+Before allowing the builder to run (exec) a command, verify that the binary
+contains a PT_INTERP entry. This avoids an issue with illumos where we drop a
+SIGKILL on the process if there is a PT_PHDR with no PT_INTERP.
+
+Furthermore, verify that the interpreter specified is the native one for
+illumos. Zig tries to execute foreign binaries as part of its test suite; which
+also results in our exec(2) implementation dropping a SIGKILL on the process.
+Let's just avoid attempting to run foreign binaries altogether for the time
+being.
+---
+ lib/std/Build/Step/Run.zig | 237 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 237 insertions(+)
+
+diff --git a/lib/std/Build/Step/Run.zig b/lib/std/Build/Step/Run.zig
+index 78cf08dd43..b4701cd501 100644
+--- a/lib/std/Build/Step/Run.zig
++++ b/lib/std/Build/Step/Run.zig
+@@ -1406,6 +1406,221 @@ fn runCommand(
+     }
+ }
+ 
++// Copied directly from std.system.
++fn preadAtLeast(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usize {
++    var i: usize = 0;
++    while (i < min_read_len) {
++        const len = file.pread(buf[i..], offset + i) catch |err| switch (err) {
++            error.OperationAborted => unreachable, // Windows-only
++            error.WouldBlock => unreachable, // Did not request blocking mode
++            error.Canceled => unreachable, // timerfd is unseekable
++            error.NotOpenForReading => unreachable,
++            error.SystemResources => return error.SystemResources,
++            error.IsDir => return error.UnableToReadElfFile,
++            error.BrokenPipe => return error.UnableToReadElfFile,
++            error.Unseekable => return error.UnableToReadElfFile,
++            error.ConnectionResetByPeer => return error.UnableToReadElfFile,
++            error.ConnectionTimedOut => return error.UnableToReadElfFile,
++            error.SocketNotConnected => return error.UnableToReadElfFile,
++            error.Unexpected => return error.Unexpected,
++            error.InputOutput => return error.FileSystem,
++            error.AccessDenied => return error.Unexpected,
++            error.ProcessNotFound => return error.ProcessNotFound,
++            error.LockViolation => return error.UnableToReadElfFile,
++        };
++        if (len == 0) return error.UnexpectedEndOfFile;
++        i += len;
++    }
++    return i;
++}
++
++// Copied directly from std.system.
++fn elfInt(is_64: bool, need_bswap: bool, int_32: anytype, int_64: anytype) @TypeOf(int_64) {
++    if (is_64) {
++        if (need_bswap) {
++            return @byteSwap(int_64);
++        } else {
++            return int_64;
++        }
++    } else {
++        if (need_bswap) {
++            return @byteSwap(int_32);
++        } else {
++            return int_32;
++        }
++    }
++}
++
++// A modified version of std.system.abiAndDynamicLinkerFromFile().
++//
++// We are checking to see if there is a PT_INTERP section and that it specifies
++// the illumos interpreter.
++fn illumosHasInterp(file: fs.File) !bool {
++    const elf = std.elf;
++
++    var hdr_buf: [@sizeOf(elf.Elf64_Ehdr)]u8 align(@alignOf(elf.Elf64_Ehdr)) = undefined;
++    _ = try preadAtLeast(file, &hdr_buf, 0, hdr_buf.len);
++    const hdr32: *elf.Elf32_Ehdr = @ptrCast(&hdr_buf);
++    const hdr64: *elf.Elf64_Ehdr = @ptrCast(&hdr_buf);
++
++    if (!mem.eql(u8, hdr32.e_ident[0..4], elf.MAGIC)) {
++        return error.InvalidElfMagic;
++    }
++
++    const native_endian = builtin.cpu.arch.endian();
++    const elf_endian: std.builtin.Endian = switch (hdr32.e_ident[elf.EI_DATA]) {
++        elf.ELFDATA2LSB => .little,
++        else => return error.InvalidElfEndian,
++    };
++
++    const need_bswap = elf_endian != native_endian;
++
++    if (need_bswap) {
++        return error.ForeignElf;
++    }
++
++    if (hdr32.e_ident[elf.EI_VERSION] != 1) return error.InvalidElfVersion;
++
++    const is_64 = switch (hdr32.e_ident[elf.EI_CLASS]) {
++        elf.ELFCLASS32 => false,
++        elf.ELFCLASS64 => true,
++        else => return error.InvalidElfClass,
++    };
++
++    var phoff = elfInt(is_64, need_bswap, hdr32.e_phoff, hdr64.e_phoff);
++    const phentsize = elfInt(is_64, need_bswap, hdr32.e_phentsize, hdr64.e_phentsize);
++    const phnum = elfInt(is_64, need_bswap, hdr32.e_phnum, hdr64.e_phnum);
++
++    var ph_buf: [16 * @sizeOf(elf.Elf64_Phdr)]u8 align(@alignOf(elf.Elf64_Phdr)) = undefined;
++    if (phentsize > @sizeOf(elf.Elf64_Phdr)) return error.InvalidElfFile;
++
++    var ph_i: u16 = 0;
++    while (ph_i < phnum) {
++        // Reserve some bytes so that we can deref the 64-bit struct fields
++        // even when the ELF file is 32-bits.
++        const ph_reserve: usize = @sizeOf(elf.Elf64_Phdr) - @sizeOf(elf.Elf32_Phdr);
++        const ph_read_byte_len = try preadAtLeast(file, ph_buf[0 .. ph_buf.len - ph_reserve], phoff, phentsize);
++        var ph_buf_i: usize = 0;
++
++        while (ph_buf_i < ph_read_byte_len and ph_i < phnum) : ({
++            ph_i += 1;
++            phoff += phentsize;
++            ph_buf_i += phentsize;
++        }) {
++            const ph32: *elf.Elf32_Phdr = @ptrCast(@alignCast(&ph_buf[ph_buf_i]));
++            const ph64: *elf.Elf64_Phdr = @ptrCast(@alignCast(&ph_buf[ph_buf_i]));
++            const p_type = elfInt(is_64, need_bswap, ph32.p_type, ph64.p_type);
++            switch (p_type) {
++                elf.PT_INTERP => {
++                    const p_offset = elfInt(is_64, need_bswap, ph32.p_offset, ph64.p_offset);
++                    const p_filesz = elfInt(is_64, need_bswap, ph32.p_filesz, ph64.p_filesz);
++                    var dl_buff: [32]u8 = .{ 0 } ** 32;
++
++                    if (p_filesz > 32) return error.InterpTooLong;
++
++                    const filesz: usize = @intCast(p_filesz);
++                    _ = try preadAtLeast(file, dl_buff[0..filesz], p_offset, filesz);
++                    // Remove NUL char
++                    const ld = dl_buff[0..filesz - 1];
++                    if (std.mem.eql(u8, "/lib/ld.so.1", ld) or
++                        std.mem.eql(u8, "/lib/64/ld.so.1", ld) or
++                        std.mem.eql(u8, "/usr/lib/ld.so.1", ld) or
++                        std.mem.eql(u8, "/usr/lib/64/ld.so.1", ld)) {
++                        return true;
++                    } else {
++                        return false;
++                    }
++                },
++                else => continue,
++            }
++        }
++    }
++
++    // We didn't find a PT_INTERP section.
++    return false;
++}
++
++fn illumosOpenFile(
++    prog: []const u8,
++    child_cwd: ?[]const u8,
++    alloc: std.mem.Allocator,
++) !std.fs.File {
++    if (std.fs.path.isAbsolutePosix(prog)) {
++        return std.fs.openFileAbsolute(prog, .{}) catch |err| {
++            std.log.err(
++                "could not open file ({any}): {s}",
++                .{ err, prog },
++            );
++            return error.InvalidExe;
++        };
++    } else if (child_cwd) |ccwd| {
++        if (std.fs.path.isAbsolutePosix(ccwd)) {
++            var dir = std.fs.openDirAbsolute(ccwd, .{}) catch |e| {
++                std.log.err(
++                    "could not open dir ({any}): {s}",
++                    .{ e, ccwd },
++                );
++                return e;
++            };
++            defer dir.close();
++
++            return dir.openFile(prog, .{ .mode = .read_only }) catch |e| {
++                std.log.err(
++                    "could not open file ({any}): {s} {s}",
++                    .{ e, ccwd, prog },
++                );
++                return e;
++            };
++        } else {
++            var dir = std.fs.cwd().openDir(ccwd, .{}) catch |e| {
++                std.log.err(
++                    "could not open dir ({any}): {s}",
++                    .{ e, ccwd },
++                );
++                return e;
++            };
++            defer dir.close();
++
++            return dir.openFile(prog, .{ .mode = .read_only }) catch |e| {
++                std.log.err(
++                    "could not open file ({any}): {s} {s}",
++                    .{ e, ccwd, prog },
++                );
++                return e;
++            };
++        }
++    } else {
++        const cwd = std.fs.cwd();
++        return cwd.openFile(prog, .{ .mode = .read_only }) catch |e| {
++            const cwd_path = try cwd.realpathAlloc(alloc, ".");
++            std.log.err(
++                "could not open file ({any}) {s} {s}",
++                .{ e, cwd_path, prog },
++            );
++            return e;
++        };
++    }
++}
++
++fn illumosInterpCheck(
++    prog: []const u8,
++    child_cwd: ?[]const u8,
++    alloc: std.mem.Allocator,
++) !bool {
++    // Try to open the executable for inspection. Return these errors as-is
++    // because they indicate a legitimate issue.
++    var file = try illumosOpenFile(prog, child_cwd, alloc);
++    defer file.close();
++
++    // Here we convert any error into InvalidExe because illumos exec(2) is just
++    // going to kill the child process anyways. By converting to InvalidExe here
++    // we better mimic the behavior of other systems which are returning ENOEXEC
++    // without also sending a SIGKILL.
++    return illumosHasInterp(file) catch {
++        return error.InvalidExe;
++    };
++}
++
+ const ChildProcResult = struct {
+     term: std.process.Child.Term,
+     elapsed_ns: u64,
+@@ -1437,6 +1652,28 @@ fn spawnChildAndCollect(
+     child.env_map = env_map;
+     child.request_resource_usage_statistics = true;
+ 
++    // The zig test suite is happy to attempt executing foreing
++    // binaries, both static and dynamic. It relies on exec(2) to
++    // return ENOEXEC as indication that this binary cannot be run on
++    // the native system. However, the static binaries pose a problem.
++    // They contain a PT_PHDR without a PT_INTERP, causing the illumos
++    // exec(2) to return ENOEXEC but also causing the kernel to drop a
++    // SIGKILL on the process. The test suite doesn't expect this and
++    // ends up dead in its tracks. Illumos drops the SIGKILL because
++    // by the time it makes this check it has already modified the
++    // process, and so its only option is to drop a SIGKILL to end the
++    // process. We should modify exec(2) to catch this condition
++    // before modifying the process, but for now we check the binary
++    // ahead of time and return InvalidExe for any file without an
++    // interpreter.
++    if (builtin.os.tag == .illumos) {
++        const has_interp = try illumosInterpCheck(argv[0], child.cwd, arena);
++
++        if (!has_interp) {
++            return error.InvalidExe;
++        }
++    }
++
+     child.stdin_behavior = switch (run.stdio) {
+         .infer_from_args => if (has_side_effects) .Inherit else .Ignore,
+         .inherit => .Inherit,
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/is-valid-memory.patch
+++ b/build/zig/patches-0.15/is-valid-memory.patch
@@ -1,0 +1,36 @@
+From b0261b4b0692b0fe6b6d7a2d61dfc48a2c25c486 Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 24 Sep 2025 08:36:40 -0400
+Subject: [PATCH] use madvise to check for mapped memory
+
+Use madvise instead of msync to avoid creating unnecessary I/O on the
+swap device.
+---
+ lib/std/debug/MemoryAccessor.zig | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/lib/std/debug/MemoryAccessor.zig b/lib/std/debug/MemoryAccessor.zig
+index 7857656554..7de0a01736 100644
+--- a/lib/std/debug/MemoryAccessor.zig
++++ b/lib/std/debug/MemoryAccessor.zig
+@@ -98,6 +98,17 @@ pub fn isValidMemory(address: usize) bool {
+     if (aligned_address == 0) return false;
+     const aligned_memory = @as([*]align(page_size_min) u8, @ptrFromInt(aligned_address))[0..page_size];
+ 
++    if (native_os == .illumos) {
++        posix.madvise(aligned_memory, page_size, posix.MADV.NORMAL) catch |err| {
++            switch (err) {
++                posix.MadviseError.OutOfMemory => return false,
++                else => unreachable,
++            }
++        };
++
++        return true;
++    }
++
+     if (native_os == .windows) {
+         const windows = std.os.windows;
+ 
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/keep-frame-pointers.patch
+++ b/build/zig/patches-0.15/keep-frame-pointers.patch
@@ -1,0 +1,28 @@
+From 08bcbbb75394b80bf84b7f77428a84ef1bac48ed Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 3 Sep 2025 17:11:30 -0400
+Subject: [PATCH] keep frame pointers
+
+---
+ build.zig | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/build.zig b/build.zig
+index 37523e66a3..1115d2f9a3 100644
+--- a/build.zig
++++ b/build.zig
+@@ -203,6 +203,11 @@ pub fn build(b: *std.Build) !void {
+     exe.pie = pie;
+     exe.entitlements = entitlements;
+ 
++    //
++    // We prefer to have the frame pointer in illumos.
++    //
++    exe.root_module.omit_frame_pointer = false;
++
+     const use_llvm = b.option(bool, "use-llvm", "Use the llvm backend");
+     exe.use_llvm = use_llvm;
+     exe.use_lld = use_llvm;
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/series
+++ b/build/zig/patches-0.15/series
@@ -1,0 +1,9 @@
+verbose-link.patch
+keep-frame-pointers.patch
+is-valid-memory.patch
+illumos-interp-check.patch
+fix-watch-init.patch
+add-arc4random_buf.patch
+stack-trace-thread-safety.patch
+define-msghdr-flags.patch
+define-sigrt-min-and-max.patch

--- a/build/zig/patches-0.15/stack-trace-thread-safety.patch
+++ b/build/zig/patches-0.15/stack-trace-thread-safety.patch
@@ -1,0 +1,97 @@
+From 1764647b9474cb86ab62349ff0d80cbc032c71c6 Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 24 Sep 2025 08:39:18 -0400
+Subject: [PATCH] stack trace thread safety
+
+Currently the "thread local storage" test fails (for reasons unknown).
+The nature of this test failing results in multiple threads trying to
+print a stack trace concurrently using shared debug info structures.
+However, these structures are currently not MT-safe and chaos ensues.
+This patch adds a few mutexes to stop the bleeding until upstream
+fixes things.
+
+The wst_lock probably covers everything, but it was the last one I
+added. I left the other two in because they shouldn't hurt anything.
+---
+ lib/std/debug.zig          | 9 +++++++++
+ lib/std/debug/SelfInfo.zig | 7 +++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/lib/std/debug.zig b/lib/std/debug.zig
+index ebbcad627b..20fa5a5599 100644
+--- a/lib/std/debug.zig
++++ b/lib/std/debug.zig
+@@ -233,8 +233,11 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
+ 
+ /// TODO multithreaded awareness
+ var self_debug_info: ?SelfInfo = null;
++var sdi_lock: std.Thread.Mutex = .{};
+ 
+ pub fn getSelfDebugInfo() !*SelfInfo {
++    sdi_lock.lock();
++    defer sdi_lock.unlock();
+     if (self_debug_info) |*info| {
+         return info;
+     } else {
+@@ -736,6 +739,9 @@ fn waitForOtherThreadToFinishPanicking() void {
+     }
+ }
+ 
++// This locking could be finer, but I just want to get things working.
++var wst_lock: std.Thread.Mutex = .{};
++
+ pub fn writeStackTrace(
+     stack_trace: std.builtin.StackTrace,
+     writer: *Writer,
+@@ -746,6 +752,8 @@ pub fn writeStackTrace(
+     var frame_index: usize = 0;
+     var frames_left: usize = @min(stack_trace.index, stack_trace.instruction_addresses.len);
+ 
++    wst_lock.lock();
++    errdefer wst_lock.unlock();
+     while (frames_left != 0) : ({
+         frames_left -= 1;
+         frame_index = (frame_index + 1) % stack_trace.instruction_addresses.len;
+@@ -753,6 +761,7 @@ pub fn writeStackTrace(
+         const return_address = stack_trace.instruction_addresses[frame_index];
+         try printSourceAtAddress(debug_info, writer, return_address - 1, tty_config);
+     }
++    wst_lock.unlock();
+ 
+     if (stack_trace.index > stack_trace.instruction_addresses.len) {
+         const dropped_frames = stack_trace.index - stack_trace.instruction_addresses.len;
+diff --git a/lib/std/debug/SelfInfo.zig b/lib/std/debug/SelfInfo.zig
+index 3f1514a957..fccf141a30 100644
+--- a/lib/std/debug/SelfInfo.zig
++++ b/lib/std/debug/SelfInfo.zig
+@@ -30,6 +30,8 @@ const SelfInfo = @This();
+ 
+ const root = @import("root");
+ 
++// The si_lock must be held when accessing the allocator or address map.
++si_lock: std.Thread.Mutex,
+ allocator: Allocator,
+ address_map: std.AutoHashMap(usize, *Module),
+ modules: if (native_os == .windows) std.ArrayListUnmanaged(WindowsModule) else void,
+@@ -61,6 +63,7 @@ pub fn open(allocator: Allocator) OpenError!SelfInfo {
+ 
+ pub fn init(allocator: Allocator) !SelfInfo {
+     var debug_info: SelfInfo = .{
++        .si_lock = .{},
+         .allocator = allocator,
+         .address_map = std.AutoHashMap(usize, *Module).init(allocator),
+         .modules = if (native_os == .windows) .{} else {},
+@@ -458,6 +461,10 @@ fn lookupModuleDl(self: *SelfInfo, address: usize) !*Module {
+         error.Found => {},
+     }
+ 
++    // Take the lock before updating internal state.
++    self.si_lock.lock();
++    defer self.si_lock.unlock();
++
+     if (self.address_map.get(ctx.base_address)) |obj_di| {
+         return obj_di;
+     }
+-- 
+2.49.0
+

--- a/build/zig/patches-0.15/verbose-link.patch
+++ b/build/zig/patches-0.15/verbose-link.patch
@@ -1,0 +1,26 @@
+From 43ac6d6a1896dac8ab2a0ecbcbcdd49a63392c78 Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <ryan@zinascii.com>
+Date: Wed, 24 Sep 2025 08:43:01 -0400
+Subject: [PATCH] verbose link
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ef371fcdd3..9ea564a5cf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -962,6 +962,9 @@ if(NOT "${ZIG_TARGET_DYNAMIC_LINKER}" STREQUAL "")
+   list(APPEND ZIG_BUILD_ARGS "-Ddynamic-linker=${ZIG_TARGET_DYNAMIC_LINKER}")
+ endif()
+ 
++if(ZIG_BUILD_VERBOSE_LINK)
++  list(APPEND ZIG_BUILD_ARGS "--verbose-link")
++endif()
+ 
+ add_custom_target(stage3 ALL
+   DEPENDS "${PROJECT_BINARY_DIR}/stage3/bin/zig"
+-- 
+2.49.0
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -121,6 +121,7 @@ extra.omnios ooce/developer/yasm
 extra.omnios ooce/developer/zig-012
 extra.omnios ooce/developer/zig-013
 extra.omnios ooce/developer/zig-014
+extra.omnios ooce/developer/zig-015
 extra.omnios ooce/driver/fuse
 extra.omnios ooce/editor/emacs
 extra.omnios ooce/editor/helix

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -90,6 +90,7 @@
 | ooce/developer/zig-012	| 0.12.1	| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/zig-013	| 0.13.0	| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/zig-014	| 0.14.1	| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
+| ooce/developer/zig-015	| 0.15.1	| https://ziglang.org/download/index.json https://ziglang.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/driver/fuse		| 1.6		| https://github.com/jurikm/illumos-fusefs/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/emacs		| 30.1		| https://ftp.gnu.org/gnu/emacs/ https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/helix		| 25.07.1	| https://github.com/helix-editor/helix/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Add support for zig 0.15.1.

```
/stage4/bin/zig build test -Denable-llvm -Dskip-release -Dskip-non-native --summary failures
...
Build Summary: 6156/6527 steps succeeded; 226 skipped; 72 failed; 15349/15430 tests passed; 81 skipped
```

There are codegen issues with the self-hosted backend, but that's due to it's incomplete/evolving nature. I'm sure there are other issues too but I didn't have time to dig into everything.