### PR TITLE
Bump atuin to v18.10.0

### DIFF
--- a/build/atuin/build.sh
+++ b/build/atuin/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=atuin
-VER=18.8.0
+VER=18.10.0
 PKG=ooce/util/atuin
 SUMMARY="Magical shell history"
 DESC="Replaces your existing shell history with a SQLite database and "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -249,7 +249,7 @@
 | ooce/text/tree-sitter-langs	| 0.12.308	| https://github.com/emacs-tree-sitter/tree-sitter-langs/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/text/xsv			| 0.13.0	| https://github.com/BurntSushi/xsv/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/acmefetch		| 0.8.1		| https://github.com/oetiker/AcmeFetch/releases | [omniosorg](https://github.com/omniosorg)
-| ooce/util/atuin		| 18.8.0	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/util/atuin		| 18.10.0	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/bat			| 0.25.0	| https://github.com/sharkdp/bat/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/diffr		| 0.1.5		| https://github.com/mookid/diffr/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/util/direnv		| 2.36.0	| https://github.com/direnv/direnv/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
As in previous bumps to this package I downloaded the tar and associated sha and built it locally.

```
Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
--- Published ooce/util/atuin@18.10.0,5.11-151054.0
--- Comparing old package with new

-set name=info.source-url value=https://mirrors.omnios.org/atuin/v18.8.0.tar.gz
+set name=info.source-url value=https://mirrors.omnios.org/atuin/v18.10.0.tar.gz

***
*** Differences found between old and new packages
***
Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
-- Cleaning up
--- Removing temporary install directory /tmp/build_omnios/atuin-18.10.0/ooce_util_atuin_pkg
--- Cleaning up temporary manifest and transform files
Done.
```