### PR TITLE
gitea: update to 1.25.2

### DIFF
--- a/build/gitea/build.sh
+++ b/build/gitea/build.sh
@@ -18,7 +18,7 @@
 
 PROG=gitea
 PKG=ooce/application/gitea
-VER=1.23.8
+VER=1.25.2
 SUMMARY="Git with a cup of tea"
 DESC="Git with a cup of tea, painless self-hosted git service"
 
@@ -36,6 +36,9 @@ XFORM_ARGS="
     -DVERSION=$VER
 "
 
+BUILD_DEPENDS_IPS="
+	network/rsync
+"
 RUN_DEPENDS_IPS=developer/versioning/git
 
 # gitea build wants GNU grep from 1.11.x on

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -2,7 +2,7 @@
 | :------ | :------ | :--- | :--------- |
 | ooce/application/alpine	| 2.26		| https://alpineapp.email/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/fcgiwrap	| 1.1.0		| https://github.com/gnosek/fcgiwrap/tags | [omniosorg](https://github.com/omniosorg)
-| ooce/application/gitea	| 1.23.8	| https://github.com/go-gitea/gitea/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/application/gitea	| 1.25.2	| https://github.com/go-gitea/gitea/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/gnuplot	| 6.0.2		| https://sourceforge.net/projects/gnuplot/files/gnuplot/ http://www.gnuplot.info/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/graphviz	| 2.44.1	| https://www2.graphviz.org/Packages/stable/portable_source/ https://graphviz.org/download/source/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/imagemagick	| 7.1.1-38	| https://imagemagick.org/archive/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
## Updates Gitea from 1.23.8 to 1.25.2

I had issues on my buildsystem due to `pnpm.js` not being found, and ended up having to create a hardlink to fix it - Hope that is just something that's broken with my system - If not, I'm happy to try and fix the upstream problem if anyone knows what it is.  :)

```
ln -s /opt/ooce/node-22/lib/node_modules/corepack/shims/pnpm /opt/ooce/bin/
ln -s /opt/ooce/node-22/lib/node_modules/corepack/dist /opt/ooce/dist
```