### PR TITLE
Syslog-NG: add 4.10.2 : WIP

### DIFF
--- a/build/syslog-ng/build.sh
+++ b/build/syslog-ng/build.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=syslog-ng
+VER=4.10.2
+PKG=ooce/system/syslog-ng
+SUMMARY="A powerful, highly configurable monitoring and logging daemon"
+DESC="An enhanced log daemon, supporting a wide range of input and output methods: syslog, unstructured text, queueing, SQL & NoSQL."
+
+SKIP_SSP_CHECK=1
+SKIP_LICENCES=COPYING
+
+BUILD_DEPENDS_IPS="
+	ooce/developer/cmake
+	developer/versioning/git
+	library/pcre2
+	runtime/python-$PYTHONPKGVER
+"
+
+RUN_DEPENDS_IPS="
+	library/pcre2
+	runtime/python-$PYTHONPKGVER
+"
+
+XFORM_ARGS+=" -DPREFIX=${PREFIX#/}"
+
+set_arch 64
+set_clangver
+
+CONFIGURE_OPTS+="
+	-DCMAKE_BUILD_TYPE=Release
+	-DCMAKE_VERBOSE_MAKEFILE=1
+	-DENABLE_MANPAGES=ON
+	-DBUILD_TESTING=OFF
+	-DENABLE_AFSNMP=OFF
+	-DENABLE_JAVA=OFF
+	-DENABLE_PYTHON=OFF
+	-DENABLE_PYTHON_MODULES=OFF
+	-DCMAKE_INSTALL_PREFIX=$PREFIX
+	-DCMAKE_INSTALL_SYSCONFDIR=/etc
+"
+
+pre_configure() {
+	# this file is missing from the tarball. It contains only some string-coloring escape sequences
+	# see here: https://github.com/syslog-ng/syslog-ng/blob/ef85a01611537079c068437f0ec54dc13a65113e/cmake/common_helpers.cmake
+	# creating an empty file to make cmake happy
+	touch "$TMPDIR/src/cmake/common_helpers.cmake"
+	
+    typeset arch=$1
+
+    CONFIGURE_OPTS[$arch]="
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_VERBOSE_MAKEFILE=1
+        -DENABLE_MANPAGES=ON
+        -DBUILD_TESTING=OFF
+        -DENABLE_AFSNMP=OFF
+        -DENABLE_JAVA=OFF
+        -DENABLE_PYTHON=OFF
+        -DENABLE_PYTHON_MODULES=OFF
+        -DCMAKE_INSTALL_PREFIX=$PREFIX
+		-DCMAKE_INSTALL_SYSCONFDIR=/etc
+    "
+}
+
+init
+download_source $PROG syslog-ng-$VER ""
+patch_source
+prep_build cmake
+build -noctf
+#run_testsuite check
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/syslog-ng/local.mog
+++ b/build/syslog-ng/local.mog
@@ -1,0 +1,15 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+license COPYING license=GPLv2

--- a/build/syslog-ng/patches/cmake_compile_flags.patch
+++ b/build/syslog-ng/patches/cmake_compile_flags.patch
@@ -1,0 +1,14 @@
+diff -wpruN '--exclude=*.orig' original/CMakeLists.txt syslog-ng-4.10.2/CMakeLists.txt
+--- original/CMakeLists.txt	2026-01-01 16:46:39.687422110 +0000
++++ syslog-ng-4.10.2/CMakeLists.txt	2026-01-01 16:49:28.558680053 +0000
+@@ -391,6 +391,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "OSF1"
+   add_compile_definitions(_XOPEN_SOURCE=500 _XOPEN_SOURCE_EXTENDED _OSF_SOURCE _POSIX_C_SOURCE)
+ endif()
+ 
++if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
++  add_compile_definitions(__EXTENSIONS__ _XOPEN_SOURCE=600 _POSIX_C_SOURCE=200809L)
++endif()
++
+ # Let the user specify a timezone directory
+ set(TIMEZONE_DIR "" CACHE PATH "Use path as the directory to get the timezone files")
+ 

--- a/build/syslog-ng/patches/getent-sun_return_type_fix.patch
+++ b/build/syslog-ng/patches/getent-sun_return_type_fix.patch
@@ -1,0 +1,39 @@
+diff -wpruN '--exclude=*.orig' original/lib/compat/getent-sun.c syslog-ng-4.10.2/lib/compat/getent-sun.c
+--- original/lib/compat/getent-sun.c	2026-01-01 09:21:14.823763600 +0000
++++ syslog-ng-4.10.2/lib/compat/getent-sun.c	2026-01-01 09:22:46.416467050 +0000
+@@ -32,7 +32,7 @@ _compat_sun__getprotobynumber_r(int prot
+                                 size_t buflen, struct protoent **result)
+ {
+   *result = getprotobynumber_r(proto, result_buf, buf, buflen);
+-  return (*result ? NULL : errno);
++  return (*result ? 0 : errno);
+ }
+ 
+ int
+@@ -41,7 +41,7 @@ _compat_sun__getprotobyname_r(const char
+                               size_t buflen, struct protoent **result)
+ {
+   *result = getprotobyname_r(name, result_buf, buf, buflen);
+-  return (*result ? NULL : errno);
++  return (*result ? 0 : errno);
+ }
+ 
+ int
+@@ -50,7 +50,7 @@ _compat_sun__getservbyport_r(int port, c
+                              size_t buflen, struct servent **result)
+ {
+   *result =  getservbyport_r(port, proto, result_buf, buf, buflen);
+-  return (*result ? NULL : errno);
++  return (*result ? 0 : errno);
+ }
+ 
+ int
+@@ -59,7 +59,7 @@ _compat_sun__getservbyname_r(const char
+                              size_t buflen, struct servent **result)
+ {
+   *result =  getservbyname_r(name, proto, result_buf, buf, buflen);
+-  return (*result ? NULL : errno);
++  return (*result ? 0 : errno);
+ }
+ 
+ #endif

--- a/build/syslog-ng/patches/loggen_linker_flags.patch
+++ b/build/syslog-ng/patches/loggen_linker_flags.patch
@@ -1,0 +1,12 @@
+diff -wpruN '--exclude=*.orig' original/tests/loggen/CMakeLists.txt syslog-ng-4.10.2/tests/loggen/CMakeLists.txt
+--- original/tests/loggen/CMakeLists.txt	2025-12-30 16:00:10.519993748 +0000
++++ syslog-ng-4.10.2/tests/loggen/CMakeLists.txt	2025-12-30 16:02:45.646213243 +0000
+@@ -22,6 +22,8 @@ target_link_libraries(
+   GLib::GModule
+   GLib::GThread
+   OpenSSL::SSL
++  nsl
++  socket
+   )
+ 
+ set_target_properties(loggen_helper

--- a/build/syslog-ng/patches/series
+++ b/build/syslog-ng/patches/series
@@ -1,0 +1,5 @@
+loggen_linker_flags.patch
+getent-sun_return_type_fix.patch
+cmake_compile_flags.patch
+slog_strings_include.patch
+syslog-ng-ctl_linker_flags.patch

--- a/build/syslog-ng/patches/slog_strings_include.patch
+++ b/build/syslog-ng/patches/slog_strings_include.patch
@@ -1,0 +1,10 @@
+--- original/modules/secure-logging/slog.c	2026-01-01 16:46:39.719624871 +0000
++++ syslog-ng-4.10.2/modules/secure-logging/slog.c	2026-01-01 17:34:26.403824083 +0000
+@@ -25,6 +25,7 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ 
+ #include <glib.h>
+ 

--- a/build/syslog-ng/patches/syslog-ng-ctl_linker_flags.patch
+++ b/build/syslog-ng/patches/syslog-ng-ctl_linker_flags.patch
@@ -1,0 +1,14 @@
+--- original/syslog-ng-ctl/CMakeLists.txt	2026-01-01 16:46:39.623535082 +0000
++++ syslog-ng-4.10.2/syslog-ng-ctl/CMakeLists.txt	2026-01-01 17:51:38.894431336 +0000
+@@ -30,5 +30,11 @@ target_link_libraries(syslog-ng-ctl PRIV
+     secret-storage
+     GLib::GLib
+     ${RESOLV_LIBS})
++if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
++  target_link_libraries(syslog-ng-ctl PRIVATE
++    nsl
++    socket
++  )
++endif()
+ target_include_directories(syslog-ng-ctl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+ install(TARGETS syslog-ng-ctl RUNTIME DESTINATION sbin)


### PR DESCRIPTION
Syslog-NG builds with some minor patching.
TODO: The contrib folder have some Solaris 10 SMF XML files which we can probably reuse.