### PR TITLE
Fix GetProtocAbsolutePath() on illumos

### DIFF
--- a/build/protobuf/patches/abspath.patch
+++ b/build/protobuf/patches/abspath.patch
@@ -1,0 +1,28 @@
+diff -wpruN --no-deference '--exclude=*.orig' a~/src/google/protobuf/compiler/command_line_interface.cc a/src/google/protobuf/compiler/command_line_interface.cc
+--- a~/src/google/protobuf/compiler/command_line_interface.cc	1970-01-01 00:00:00
++++ a/src/google/protobuf/compiler/command_line_interface.cc	1970-01-01 00:00:00
+@@ -235,6 +235,24 @@ bool GetProtocAbsolutePath(std::string* path) {
+   if (sysctl(mib, 4, &buffer, &len, nullptr, 0) != 0) {
+     len = 0;
+   }
++#elif defined(__illumos__)
++  const char *name = getexecname();
++  char buffer[PATH_MAX];
++  size_t len;
++
++  buffer[0] = '\0';
++  if (name[0] != '/') {
++    if (!getcwd(buffer, sizeof(buffer))) {
++      return false;
++    }
++    if (strlcat(buffer, "/", sizeof(buffer)) >= sizeof(buffer)) {
++      return false;
++    }
++  }
++  len = strlcat(buffer, name, sizeof(buffer));
++  if (len >= sizeof(buffer)) {
++     len = 0;
++  }
+ #else
+   char buffer[PATH_MAX];
+   int len = readlink("/proc/self/exe", buffer, PATH_MAX);

--- a/build/protobuf/patches/series
+++ b/build/protobuf/patches/series
@@ -1,0 +1,1 @@
+abspath.patch


### PR DESCRIPTION
I'm going to attempt to upstream this patch, but in the meantime this should fix protoc so that it properly always includes the 'system' include directory as it does on other platforms (to borrow from ld's RPATH terminology), protoc is supposed to implicitly add the equivalent of `$ORIGIN/../include` to the include search path so you don't have to specify it.
