### PR TITLE
Bump vaultwarden to 1.35.2 and web vault to v2025.12.1+build.3

### DIFF
--- a/build/vaultwarden/build.sh
+++ b/build/vaultwarden/build.sh
@@ -12,12 +12,12 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=vaultwarden
-VER=1.34.3
+VER=1.35.2
 PKG=ooce/application/vaultwarden
 SUMMARY="Bitwarden compatible server"
 DESC="Unofficial Bitwarden compatible server written in Rust, formerly known "
@@ -25,8 +25,8 @@ DESC+="as bitwarden_rs"
 
 DANIGARCIA=$GITHUB/dani-garcia
 # https://github.com/dani-garcia/bw_web_builds/releases
-WEBVAULTVER=2025.7.0
-WEBVAULTSHA256=81ab0ab3ce3f3d25776e4d6ac11982e2a328d41a8cc992bc1fcd149c638f3eb7
+WEBVAULTVER=2025.12.1+build.3
+WEBVAULTSHA256=58316072afe4479f014717c24becc8f8af40ad606dad18e78d332fe07add18bd
 
 set_arch 64
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -29,7 +29,7 @@
 | ooce/application/tidy		| 5.8.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tig 		| 2.5.10	| https://github.com/jonas/tig/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vagrant	| 2.2.19	| https://github.com/hashicorp/vagrant/tags | [omniosorg](https://github.com/omniosorg)
-| ooce/application/vaultwarden	| 1.34.3	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
+| ooce/application/vaultwarden	| 1.35.2	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.2.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.5.0		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/opus		| 1.6		| https://opus-codec.org/downloads/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This bumps the vaultwarden and bundled web vault.

Note: build fails on my side:

```
-- Will retrieve files from /tmp
Running: /usr/bin/mkdir -p /tmp/build_szilard/tools
Running: /usr/bin/ln -sf /bin/false /tmp/build_szilard/tools/cc
Running: /usr/bin/ln -sf /bin/false /tmp/build_szilard/tools/CC
===== Build started at Wed Jan 21 07:37:12 UTC 2026 =====
Package name: ooce/application/vaultwarden
Selected flavor: None (use -f to specify a flavor)
Selected build arch: amd64
Extra dependency: None (use -d to specify a version)
Verifying dependencies
-- Checking for build dependency ooce/developer/rust
Running: /usr/bin/pkg info -q ooce/developer/rust
-- Checking for build dependency ooce/library/mariadb-114
Running: /usr/bin/pkg info -q ooce/library/mariadb-114
-- Checking for build dependency ooce/library/postgresql-17
Running: /usr/bin/pkg info -q ooce/library/postgresql-17
Running: /usr/bin/mkdir -p /tmp/build_szilard/vaultwarden-1.35.2
Running: /usr/bin/ln -sf /tmp/build_szilard/vaultwarden-1.35.2 /export/home/szilard/projekt/omnios-extra/build/vaultwarden/./tmp
Running: /usr/bin/ln -sf vaultwarden-1.35.2 /tmp/build_szilard/vaultwarden-1.35.2/src
vaultwarden -> /tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden
Running: /usr/bin/mkdir -p /tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2
Running: /usr/bin/git clone --no-single-branch --depth 1 https://github.com/dani-garcia/vaultwarden vaultwarden
Cloning into 'vaultwarden'...
Running: /usr/bin/git -C vaultwarden checkout 1.35.2
Note: switching to '1.35.2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 4352fff Fix web-vault version check and update web-vault (#6686)
Running: /usr/bin/git -C vaultwarden clean -fdx
Checking for patches in patches/ (in order to apply them)
--- No patches directory found
--- Not applying any patches
Preparing for autoconf build
--- Creating temporary installation directory
Running: /usr/bin/chmod -R u+w /tmp/build_szilard/vaultwarden-1.35.2/ooce_application_vaultwarden_pkg
chmod: WARNING: can't access /tmp/build_szilard/vaultwarden-1.35.2/ooce_application_vaultwarden_pkg
Running: /usr/bin/rm -rf /tmp/build_szilard/vaultwarden-1.35.2/ooce_application_vaultwarden_pkg
Running: /usr/bin/mkdir -p /tmp/build_szilard/vaultwarden-1.35.2/ooce_application_vaultwarden_pkg
Running: /usr/bin/rm -f /tmp/build_szilard/vaultwarden-1.35.2/frag.mog
Running: /usr/bin/ln -sf vaultwarden-1.35.2/vaultwarden /tmp/build_szilard/vaultwarden-1.35.2/build
Running: /usr/bin/ln -sf ooce_application_vaultwarden_pkg /tmp/build_szilard/vaultwarden-1.35.2/pkg
Building rust (amd64)
--- Callback pre_build(amd64)
Running: /opt/ooce/bin/cargo build --release --target=x86_64-unknown-illumos --features sqlite,mysql,postgresql
    Updating crates.io index
 Downloading crates ...
  Downloaded diesel_table_macro_syntax v0.3.0
  Downloaded dashmap v5.5.3
  Downloaded dsl_auto_type v0.2.0
  Downloaded elliptic-curve v0.13.8
  Downloaded diesel_migrations v2.3.1
  Downloaded cached_proc_macro v0.25.0
  Downloaded derive_more-impl v2.1.1
  Downloaded ar_archive_writer v0.2.0
  Downloaded psm v0.1.28
  Downloaded syslog v7.0.0
  Downloaded serde_path_to_error v0.1.20
  Downloaded ed25519-dalek v2.2.0
  Downloaded serde_spanned v0.6.9
  Downloaded webauthn-attestation-ca v0.5.4
  Downloaded is-terminal v0.4.17
  Downloaded simd-adler32 v0.3.8
  Downloaded async-process v2.5.0
  Downloaded simple_asn1 v0.6.3
  Downloaded async-global-executor v2.4.1
  Downloaded enum-as-inner v0.6.1
  Downloaded pest_meta v2.8.4
  Downloaded scheduled-thread-pool v0.2.7
  Downloaded ref-cast-impl v1.0.25
  Downloaded rtoolbox v0.0.3
  Downloaded devise_core v0.4.2
  Downloaded async-channel v2.5.0
  Downloaded derive_builder_core v0.20.2
  Downloaded webauthn-rs-proto v0.5.4
  Downloaded serde_spanned v1.0.4
  Downloaded r2d2 v0.8.10
  Downloaded threadpool v1.8.1
  Downloaded inlinable_string v0.1.15
  Downloaded binascii v0.1.4
  Downloaded async-lock v3.4.2
  Downloaded rocket_ws v0.1.1
  Downloaded pear_codegen v0.2.9
  Downloaded devise v0.4.2
  Downloaded totp-lite v2.0.1
  Downloaded ubyte v0.10.4
  Downloaded downcast-rs v2.0.2
  Downloaded diesel-derive-newtype v2.1.2
  Downloaded compression-core v0.4.31
  Downloaded svg-hush v0.9.5
  Downloaded jetscii v0.5.3
  Downloaded codemap v0.1.3
  Downloaded hostname v0.4.2
  Downloaded uncased v0.9.10
  Downloaded toml_datetime v0.7.5+spec-1.1.0
  Downloaded stable-pattern v0.1.0
  Downloaded itoa v1.0.17
  Downloaded tempfile v3.24.0
  Downloaded job_scheduler_ng v2.4.0
  Downloaded reopen v1.0.3
  Downloaded event-listener-strategy v0.5.4
  Downloaded pastey v0.2.1
  Downloaded yubico_ng v0.14.1
  Downloaded convert_case v0.10.0
  Downloaded async-signal v0.2.13
  Downloaded base64ct v1.8.1
  Downloaded zmij v1.0.2
  Downloaded migrations_internals v2.3.0
  Downloaded toml_parser v1.0.6+spec-1.1.0
  Downloaded pest_generator v2.8.4
  Downloaded rustls-pki-types v1.13.2
  Downloaded webauthn-rs v0.5.4
  Downloaded rmp v0.8.15
  Downloaded which v8.0.0
  Downloaded triomphe v0.1.15
  Downloaded pem v3.0.6
  Downloaded xml-rs v0.8.28
  Downloaded kv-log-macro v1.0.7
  Downloaded serde_with_macros v3.16.1
  Downloaded tracing-core v0.1.36
  Downloaded proc-macro2 v1.0.104
  Downloaded ryu v1.0.22
  Downloaded migrations_macros v2.3.0
  Downloaded derive_builder v0.20.2
  Downloaded icu_properties v2.1.2
  Downloaded cookie_store v0.22.0
  Downloaded uuid v1.19.0
  Downloaded num-modular v0.6.1
  Downloaded futures-lite v2.6.1
  Downloaded rocket_http v0.5.1
  Downloaded schemars v1.2.0
  Downloaded zerocopy-derive v0.8.31
  Downloaded raw-cpuid v11.6.0
  Downloaded pest v2.8.4
  Downloaded rpassword v7.4.0
  Downloaded webauthn-rs-core v0.5.4
  Downloaded rocket_codegen v0.5.1
  Downloaded tower-http v0.6.8
  Downloaded reqwest v0.12.28
  Downloaded winnow v0.7.14
  Downloaded lasso v0.7.3
  Downloaded cc v1.2.51
  Downloaded portable-atomic v1.13.0
  Downloaded zerocopy v0.8.31
  Downloaded indexmap v2.12.1
  Downloaded http v1.4.0
  Downloaded rocket v0.5.1
  Downloaded syn v2.0.111
  Downloaded diesel v2.3.5
  Downloaded async-std v1.13.2
  Downloaded governor v0.10.4
  Downloaded bigdecimal v0.4.10
  Downloaded rustix v1.1.3
  Downloaded lettre v0.11.19
  Downloaded openidconnect v4.0.1
  Downloaded grass_compiler v0.13.4
  Downloaded p384 v0.13.1
  Downloaded tracing v0.1.44
  Downloaded moka v0.12.12
  Downloaded oauth2 v5.0.0
  Downloaded jiff-static v0.2.17
  Downloaded hyper-util v0.1.19
  Downloaded hickory-resolver v0.25.2
  Downloaded fern v0.7.1
  Downloaded object v0.32.2
  Downloaded handlebars v6.3.2
  Downloaded diesel_derives v2.3.6
  Downloaded mio v1.1.1
  Downloaded html5gum v0.8.3
  Downloaded iri-string v0.7.10
  Downloaded der v0.7.10
  Downloaded async-compression v0.4.36
  Downloaded winnow v0.6.26
  Downloaded serde_with v3.16.1
  Downloaded jsonwebtoken v10.2.0
  Downloaded serde_json v1.0.148
  Downloaded figment v0.10.19
  Downloaded mini-moka v0.10.3
  Downloaded log v0.4.29
  Downloaded async-io v2.6.0
  Downloaded pest_derive v2.8.4
  Downloaded icu_properties_data v2.1.2
  Downloaded event-listener v5.4.1
  Downloaded derive_more v2.1.1
  Downloaded num-order v1.2.0
  Downloaded brotli v8.0.2
  Downloaded find-msvc-tools v0.1.6
  Downloaded ff v0.13.1
  Downloaded toml v0.9.10+spec-1.1.0
  Downloaded tracing-attributes v0.1.31
  Downloaded resolv-conf v0.7.6
  Downloaded pear v0.2.9
  Downloaded value-bag v1.12.0
  Downloaded toml v0.8.23
  Downloaded stacker v0.1.22
  Downloaded compression-codecs v0.4.35
  Downloaded blocking v1.6.2
  Downloaded backon v1.6.0
  Downloaded multer v3.1.0
  Downloaded jiff v0.2.17
  Downloaded rmpv v1.3.1
  Downloaded state v0.6.0
  Downloaded signal-hook-registry v1.4.8
  Downloaded libc v0.2.178
  Downloaded opendal v0.55.0
  Downloaded rustls-native-certs v0.8.3
  Downloaded env_home v0.1.0
  Downloaded openssl-probe v0.2.0
  Downloaded serde_cbor_2 v0.13.0
  Downloaded pq-sys v0.7.5
  Downloaded atomic v0.5.3
  Downloaded base64urlsafedata v0.5.4
  Downloaded async-executor v1.13.3
  Downloaded ref-cast v1.0.25
  Downloaded mysqlclient-sys v0.4.7
  Downloaded devise_codegen v0.4.2
  Downloaded derive_builder_macro v0.20.2
  Downloaded cached_proc_macro_types v0.1.1
  Downloaded cached v0.56.0
  Downloaded libsqlite3-sys v0.35.0
   Compiling proc-macro2 v1.0.104
   Compiling unicode-ident v1.0.22
   Compiling quote v1.0.42
   Compiling libc v0.2.178
   Compiling cfg-if v1.0.4
   Compiling version_check v0.9.5
   Compiling serde_core v1.0.228
   Compiling find-msvc-tools v0.1.6
   Compiling jobserver v0.1.34
   Compiling syn v2.0.111
   Compiling shlex v1.3.0
   Compiling smallvec v1.15.1
   Compiling cc v1.2.51
   Compiling memchr v2.7.6
   Compiling zeroize v1.8.2
   Compiling portable-atomic v1.13.0
   Compiling serde v1.0.228
   Compiling critical-section v1.2.0
   Compiling itoa v1.0.17
   Compiling parking_lot_core v0.9.12
   Compiling scopeguard v1.2.0
   Compiling pin-project-lite v0.2.16
   Compiling lock_api v0.4.14
   Compiling pkg-config v0.3.32
   Compiling once_cell v1.21.3
   Compiling getrandom v0.2.16
   Compiling subtle v2.6.1
   Compiling errno v0.3.14
   Compiling parking_lot v0.12.5
   Compiling log v0.4.29
   Compiling bytes v1.11.0
   Compiling autocfg v1.5.0
   Compiling typenum v1.19.0
   Compiling synstructure v0.13.2
   Compiling generic-array v0.14.9
   Compiling zerocopy v0.8.31
   Compiling signal-hook-registry v1.4.8
   Compiling const-oid v0.9.6
   Compiling futures-core v0.3.31
   Compiling stable_deref_trait v1.2.1
   Compiling socket2 v0.6.1
   Compiling mio v1.1.1
   Compiling allocator-api2 v0.2.21
   Compiling libm v0.2.15
   Compiling serde_derive v1.0.228
   Compiling zerofrom-derive v0.1.6
   Compiling displaydoc v0.2.5
   Compiling zerocopy-derive v0.8.31
   Compiling yoke-derive v0.8.1
   Compiling zerofrom v0.1.6
   Compiling zerovec-derive v0.11.2
   Compiling yoke v0.8.1
   Compiling tokio-macros v2.6.0
   Compiling zerovec v0.11.5
   Compiling tokio v1.48.0
   Compiling block-buffer v0.10.4
   Compiling crypto-common v0.1.6
   Compiling num-traits v0.2.19
   Compiling futures-sink v0.3.31
   Compiling digest v0.10.7
   Compiling percent-encoding v2.3.2
   Compiling futures-io v0.3.31
   Compiling tinystr v0.8.2
   Compiling slab v0.4.11
   Compiling litemap v0.8.1
   Compiling fnv v1.0.7
   Compiling writeable v0.6.2
   Compiling num-conv v0.1.0
   Compiling time-core v0.1.6
   Compiling icu_locale_core v2.1.1
   Compiling time-macros v0.2.24
   Compiling futures-channel v0.3.31
   Compiling potential_utf v0.1.4
   Compiling zerotrie v0.2.3
   Compiling icu_normalizer_data v2.1.1
   Compiling pin-utils v0.1.0
   Compiling icu_properties_data v2.1.2
   Compiling vcpkg v0.2.15
   Compiling icu_provider v2.1.1
   Compiling icu_collections v2.1.1
   Compiling futures-macro v0.3.31
   Compiling rand_core v0.6.4
   Compiling equivalent v1.0.2
   Compiling futures-task v0.3.31
   Compiling httparse v1.10.1
   Compiling bitflags v2.10.0
   Compiling futures-util v0.3.31
   Compiling icu_properties v2.1.2
   Compiling icu_normalizer v2.1.1
   Compiling ring v0.17.14
   Compiling powerfmt v0.2.0
   Compiling deranged v0.5.5
   Compiling idna_adapter v1.2.1
   Compiling tracing-attributes v0.1.31
   Compiling tracing-core v0.1.36
   Compiling utf8_iter v1.0.4
   Compiling num_threads v0.1.7
   Compiling idna v1.1.0
   Compiling time v0.3.44
   Compiling tracing v0.1.44
   Compiling form_urlencoded v1.2.2
   Compiling foldhash v0.2.0
   Compiling hashbrown v0.16.1
   Compiling ppv-lite86 v0.2.21
   Compiling strsim v0.11.1
   Compiling getrandom v0.3.4
   Compiling ident_case v1.0.1
   Compiling url v2.5.7
   Compiling openssl-sys v0.9.111
   Compiling http v1.4.0
   Compiling base64ct v1.8.1
   Compiling untrusted v0.9.0
   Compiling indexmap v2.12.1
   Compiling zmij v1.0.2
   Compiling pem-rfc7468 v0.7.0
   Compiling cookie v0.18.1
   Compiling cpufeatures v0.2.17
   Compiling serde_json v1.0.148
   Compiling der v0.7.10
   Compiling tokio-util v0.7.17
   Compiling num-integer v0.1.46
   Compiling proc-macro2-diagnostics v0.10.1
   Compiling tower-service v0.3.3
   Compiling try-lock v0.2.5
   Compiling want v0.3.1
   Compiling zstd-sys v2.0.16+zstd.1.5.7
   Compiling spki v0.7.3
   Compiling openssl v0.10.75
   Compiling foreign-types-shared v0.1.1
   Compiling yansi v1.0.1
   Compiling base64 v0.22.1
   Compiling thiserror v1.0.69
   Compiling foreign-types v0.3.2
   Compiling pkcs8 v0.10.2
   Compiling thiserror-impl v1.0.69
   Compiling openssl-macros v0.1.1
   Compiling rustls-pki-types v1.13.2
   Compiling ahash v0.8.12
   Compiling semver v1.0.27
   Compiling http-body v1.0.1
   Compiling hmac v0.12.1
   Compiling zstd-safe v7.2.4
   Compiling spin v0.9.8
   Compiling crc32fast v1.5.0
   Compiling alloc-no-stdlib v2.0.4
   Compiling alloc-stdlib v0.2.2
   Compiling rand_chacha v0.3.1
   Compiling rustls v0.23.35
   Compiling atomic-waker v1.1.2
   Compiling simd-adler32 v0.3.8
   Compiling ipnet v2.11.0
   Compiling base64 v0.21.7
   Compiling crossbeam-utils v0.8.21
   Compiling adler2 v2.0.1
   Compiling miniz_oxide v0.8.9
   Compiling h2 v0.4.12
   Compiling rand v0.8.5
   Compiling brotli-decompressor v5.0.0
   Compiling rustls-webpki v0.103.8
   Compiling num-bigint v0.4.6
   Compiling darling_core v0.21.3
   Compiling native-tls v0.2.14
   Compiling mime v0.3.17
   Compiling ref-cast v1.0.25
   Compiling winnow v0.7.14
   Compiling hyper v1.8.1
   Compiling darling_macro v0.21.3
   Compiling brotli v8.0.2
   Compiling flate2 v1.1.5
   Compiling hashbrown v0.14.5
   Compiling pear_codegen v0.2.9
   Compiling rand_core v0.9.3
   Compiling darling_core v0.20.11
   Compiling ff v0.13.1
   Compiling signature v2.2.0
   Compiling encoding_rs v0.8.35
   Compiling either v1.15.0
   Compiling minimal-lexical v0.2.1
   Compiling thiserror v2.0.17
   Compiling compression-core v0.4.31
   Compiling openssl-probe v0.1.6
   Compiling data-encoding v2.9.0
   Compiling base16ct v0.2.0
   Compiling iana-time-zone v0.1.64
   Compiling openssl-probe v0.2.0
   Compiling rustls-native-certs v0.8.3
   Compiling chrono v0.4.42
   Compiling sec1 v0.7.3
   Compiling nom v7.1.3
   Compiling darling_macro v0.20.11
   Compiling group v0.13.0
   Compiling rand_chacha v0.9.0
   Compiling tokio-rustls v0.26.4
   Compiling hyper-util v0.1.19
   Compiling darling v0.21.3
   Compiling lazy_static v1.5.0
   Compiling hkdf v0.12.4
   Compiling http-body-util v0.1.3
   Compiling sha2 v0.10.9
   Compiling uuid v1.19.0
   Compiling object v0.32.2
   Compiling futures-executor v0.3.31
   Compiling zstd v0.13.3
   Compiling crypto-bigint v0.5.5
   Compiling compression-codecs v0.4.35
   Compiling ref-cast-impl v1.0.25
   Compiling thiserror-impl v2.0.17
   Compiling sync_wrapper v1.0.2
   Compiling litrs v1.0.0
   Compiling psl-types v2.0.11
   Compiling heck v0.5.0
   Compiling tower-layer v0.3.3
   Compiling http v0.2.12
   Compiling tower v0.5.2
   Compiling document-features v0.2.12
   Compiling publicsuffix v2.3.0
   Compiling ar_archive_writer v0.2.0
   Compiling elliptic-curve v0.13.8
   Compiling async-compression v0.4.36
   Compiling futures v0.3.31
   Compiling rand v0.9.2
   Compiling rusticata-macros v4.1.0
   Compiling darling v0.20.11
   Compiling tokio-native-tls v0.3.1
   Compiling rustc_version v0.4.1
   Compiling webpki-roots v1.0.4
   Compiling asn1-rs-impl v0.2.0
   Compiling async-trait v0.1.89
   Compiling asn1-rs-derive v0.5.1
   Compiling is-terminal v0.4.17
   Compiling uncased v0.9.10
   Compiling iri-string v0.7.10
   Compiling siphasher v1.0.1
   Compiling fastrand v2.3.0
   Compiling ryu v1.0.22
   Compiling rustix v1.1.3
   Compiling rustls v0.21.12
   Compiling devise_core v0.4.2
   Compiling serde_urlencoded v0.7.1
   Compiling asn1-rs v0.6.2
   Compiling tower-http v0.6.8
   Compiling curve25519-dalek v4.1.3
   Compiling hyper-rustls v0.27.7
   Compiling hyper-tls v0.6.0
   Compiling psm v0.1.28
   Compiling cookie_store v0.22.0
   Compiling http-body v0.4.6
   Compiling rfc6979 v0.4.0
   Compiling rustls-webpki v0.101.7
   Compiling sct v0.7.1
   Compiling sha1 v0.10.6
   Compiling libsqlite3-sys v0.35.0
   Compiling serde_spanned v0.6.9
   Compiling toml_datetime v0.6.11
   Compiling socket2 v0.5.10
   Compiling httpdate v1.0.3
   Compiling unicode-xid v0.2.6
   Compiling toml_write v0.1.2
   Compiling pastey v0.1.1
   Compiling inlinable_string v0.1.15
   Compiling byteorder v1.5.0
   Compiling num-bigint-dig v0.8.6
   Compiling oid-registry v0.7.1
   Compiling ucd-trie v0.1.7
   Compiling phf_shared v0.11.3
   Compiling pest v2.8.4
   Compiling toml_parser v1.0.6+spec-1.1.0
   Compiling hyper v0.14.32
   Compiling pear v0.2.9
   Compiling base64urlsafedata v0.5.4
   Compiling toml_edit v0.22.27
   Compiling ecdsa v0.16.9
   Compiling reqwest v0.12.28
   Compiling devise_codegen v0.4.2
   Compiling primeorder v0.13.6
   Compiling serde_spanned v1.0.4
   Compiling toml_datetime v0.7.5+spec-1.1.0
   Compiling mysqlclient-sys v0.4.7
   Compiling num-iter v0.1.45
   Compiling stable-pattern v0.1.0
   Compiling curve25519-dalek-derive v0.1.1
   Compiling bigdecimal v0.4.10
   Compiling pq-sys v0.7.5
   Compiling stacker v0.1.22
   Compiling num_cpus v1.17.0
   Compiling multer v3.1.0
   Compiling figment v0.10.19
   Compiling webauthn-attestation-ca v0.5.4
   Compiling diesel_derives v2.3.6
   Compiling state v0.6.0
   Compiling signal-hook v0.3.18
   Compiling rocket_http v0.5.1
   Compiling toml v0.9.10+spec-1.1.0
   Compiling devise v0.4.2
   Compiling tokio-rustls v0.24.1
   Compiling toml v0.8.23
   Compiling pest_meta v2.8.4
   Compiling phf_generator v0.11.3
   Compiling der-parser v9.0.0
   Compiling derive_builder_core v0.20.2
   Compiling dsl_auto_type v0.2.0
   Compiling ed25519 v2.2.3
   Compiling crossbeam-channel v0.5.15
   Compiling rustls-pemfile v1.0.4
   Compiling pkcs1 v0.7.5
   Compiling half v2.7.1
   Compiling async-stream-impl v0.3.6
   Compiling diesel_table_macro_syntax v0.3.0
   Compiling reopen v1.0.3
   Compiling scheduled-thread-pool v0.2.7
   Compiling hostname v0.4.2
   Compiling rocket v0.5.1
   Compiling glob v0.3.3
   Compiling anyhow v1.0.100
   Compiling jetscii v0.5.3
   Compiling webauthn-rs-core v0.5.4
   Compiling utf-8 v0.7.6
   Compiling tagptr v0.2.0
   Compiling unicode-segmentation v1.12.0
   Compiling tinyvec_macros v0.1.1
   Compiling tinyvec v1.10.0
   Compiling tungstenite v0.21.0
   Compiling convert_case v0.10.0
   Compiling rocket_codegen v0.5.1
   Compiling r2d2 v0.8.10
   Compiling async-stream v0.3.6
   Compiling serde_cbor_2 v0.13.0
   Compiling rsa v0.9.9
   Compiling ed25519-dalek v2.2.0
   Compiling derive_builder_macro v0.20.2
   Compiling x509-parser v0.16.0
   Compiling migrations_internals v2.3.0
   Compiling phf_macros v0.11.3
   Compiling pest_generator v2.8.4
   Compiling tempfile v3.24.0
   Compiling p384 v0.13.1
   Compiling p256 v0.13.2
   Compiling webauthn-rs-proto v0.5.4
   Compiling phf_shared v0.12.1
   Compiling enum-as-inner v0.6.1
   Compiling serde_with_macros v3.16.1
   Compiling crossbeam-epoch v0.9.18
   Compiling raw-cpuid v11.6.0
   Compiling tokio-stream v0.1.17
   Compiling ordered-float v2.10.1
   Compiling ubyte v0.10.4
   Compiling serde_path_to_error v0.1.20
   Compiling aho-corasick v1.1.4
   Compiling downcast-rs v2.0.2
   Compiling atomic v0.5.3
   Compiling web-time v1.1.0
   Compiling num-modular v0.6.1
   Compiling hex v0.4.3
   Compiling winnow v0.6.26
   Compiling same-file v1.0.6
   Compiling chrono-tz v0.10.4
   Compiling foldhash v0.1.5
   Compiling binascii v0.1.4
   Compiling regex-syntax v0.8.8
   Compiling mini-moka v0.10.3
   Compiling cron v0.15.0
   Compiling regex-automata v0.4.13
   Compiling hashbrown v0.15.5
   Compiling walkdir v2.5.0
   Compiling diesel v2.3.5
   Compiling num-order v1.2.0
   Compiling quanta v0.12.6
   Compiling oauth2 v5.0.0
   Compiling serde-value v0.7.0
   Compiling serde_with v3.16.1
   Compiling hickory-proto v0.25.2
   Compiling moka v0.12.12
   Compiling phf v0.12.1
   Compiling phf v0.11.3
   Compiling chumsky v0.9.3
   Compiling pest_derive v2.8.4
   Compiling migrations_macros v2.3.0
   Compiling derive_builder v0.20.2
   Compiling tokio-tungstenite v0.21.0
   Compiling derive_more-impl v2.1.1
   Compiling syslog v7.0.0
   Compiling threadpool v1.8.1
   Compiling itertools v0.10.5
   Compiling backon v1.6.0
   Compiling cached_proc_macro v0.25.0
   Compiling simple_asn1 v0.6.3
   Compiling lasso v0.7.3
   Compiling dashmap v6.1.0
   Compiling dashmap v5.5.3
   Compiling email-encoding v0.4.1
   Compiling pem v3.0.6
   Compiling password-hash v0.5.0
   Compiling rmp v0.8.15
   Compiling blake2 v0.10.6
   Compiling md-5 v0.10.6
   Compiling serde_plain v1.0.2
   Compiling quick-xml v0.38.4
   Compiling email_address v0.2.9
   Compiling spinning_top v0.3.0
   Compiling jiff v0.2.17
   Compiling nom v8.0.0
   Compiling rtoolbox v0.0.3
   Compiling xml-rs v0.8.28
   Compiling env_home v0.1.0
   Compiling quick-error v2.0.1
   Compiling codemap v0.1.3
   Compiling data-url v0.3.2
   Compiling cached_proc_macro_types v0.1.1
   Compiling nonzero_ext v0.3.0
   Compiling resolv-conf v0.7.6
   Compiling vaultwarden v1.0.0 (/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden)
   Compiling dyn-clone v1.0.20
   Compiling futures-timer v3.0.3
   Compiling quoted_printable v0.5.1
   Compiling triomphe v0.1.15
   Compiling governor v0.10.4
   Compiling lettre v0.11.19
   Compiling openidconnect v4.0.1
   Compiling diesel_migrations v2.3.1
   Compiling hickory-resolver v0.25.2
   Compiling cached v0.56.0
   Compiling svg-hush v0.9.5
   Compiling opendal v0.55.0
   Compiling grass_compiler v0.13.4
   Compiling which v8.0.0
   Compiling rpassword v7.4.0
   Compiling argon2 v0.5.3
   Compiling rmpv v1.3.1
   Compiling jsonwebtoken v10.2.0
   Compiling derive_more v2.1.1
   Compiling yubico_ng v0.14.1
   Compiling fern v0.7.1
   Compiling html5gum v0.8.3
   Compiling rocket_ws v0.1.1
   Compiling handlebars v6.3.2
   Compiling webauthn-rs v0.5.4
   Compiling regex v1.12.2
   Compiling job_scheduler_ng v2.4.0
   Compiling totp-lite v2.0.1
   Compiling macros v0.1.0 (/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/macros)
   Compiling diesel-derive-newtype v2.1.2
   Compiling num-derive v0.4.2
   Compiling pico-args v0.5.0
   Compiling dotenvy v0.15.7
   Compiling pastey v0.2.1
error: could not exec the linker `gcc`
  |
  = note: Not enough space (os error 12)
  = note: LC_ALL="C" PATH="/opt/ooce/rust/lib/rustlib/x86_64-unknown-illumos/bin:/opt/gcc-14/bin:/tmp/build_szilard/tools:/usr/ccs/bin:/usr/bin:/usr/sbin:/opt/ooce/bin:/usr/gnu/bin:/usr/sfw/bin" VSLANG="1033" "gcc" "-m64" "-std=c99" "/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/target/x86_64-unknown-illumos/release/deps/vaultwarden-4a66e169da14c9b8.vaultwarden.3d58758dde0accdd-cgu.0.rcgu.o" "-Wl,-z,ignore" "-Wl,-Bstatic" "/tmp/rustcqix4pm/libzstd_sys-513cd9b712d7038f.rlib" "/tmp/rustcqix4pm/libpsm-f3f73c7d1b283712.rlib" "/tmp/rustcqix4pm/liblibsqlite3_sys-8b85da326035cf8f.rlib" "/tmp/rustcqix4pm/libring-45522742ab3285ae.rlib" "/opt/ooce/rust/lib/rustlib/x86_64-unknown-illumos/lib/libcompiler_builtins-e52f1269a77a80e0.rlib" "-Wl,-Bdynamic" "-lssl" "-lcrypto" "-lmariadb" "-lpq" "-lsendfile" "-llgrp" "-lsocket" "-lposix4" "-lpthread" "-lresolv" "-lnsl" "-lumem" "-lgcc_s" "-lm" "-lrt" "-lpthread" "-lsendfile" "-llgrp" "-L" "/tmp/rustcqix4pm/raw-dylibs" "-lc" "-lssp" "-L" "/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/target/x86_64-unknown-illumos/release/build/libsqlite3-sys-676d82fb3689cddb/out" "-L" "/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/target/x86_64-unknown-illumos/release/build/psm-4e2787bf8201a3f8/out" "-L" "/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/target/x86_64-unknown-illumos/release/build/ring-e3bb75f16638483c/out" "-L" "/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/target/x86_64-unknown-illumos/release/build/zstd-sys-9e91f6b6a9f1aafd/out" "-L" "/opt/ooce/mariadb-11.4/lib/amd64" "-L" "/opt/ooce/pgsql-18/lib/amd64" "-L" "/usr" "-o" "/tmp/build_szilard/vaultwarden-1.35.2/vaultwarden-1.35.2/vaultwarden/target/x86_64-unknown-illumos/release/deps/vaultwarden-4a66e169da14c9b8" "-nodefaultlibs" "-L/opt/ooce/mariadb-11.4/lib/amd64" "-L/opt/ooce/pgsql-17/lib/amd64" "-R/opt/ooce/mariadb-11.4/lib/amd64" "-R/opt/ooce/pgsql-17/lib/amd64"

error: could not compile `vaultwarden` (bin "vaultwarden") due to 1 previous error
build failed
===== Build aborted =====
Time: ooce/application/vaultwarden - 0h31m56s
szilard@build ~/p/o/b/vaultwarden (vaultwarden_2025.12.1_build.1)>
```