### PR TITLE
xxhash: WIP

### DIFF
--- a/build/xxhash/build.sh
+++ b/build/xxhash/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=xxhash
+VER=0.8.3
+PKG=ooce/library/xxhash
+SUMMARY="xxhash"
+DESC="Extremely fast non-cryptographic hash algorithm"
+
+set_builddir "xxHash-$VER"
+
+# No configure
+CONFIGURE_CMD="/usr/bin/true"
+
+init
+download_source $PROG "v$VER"
+prep_build
+patch_source
+build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/xxhash/local.mog
+++ b/build/xxhash/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=simplified-BSD
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -201,6 +201,7 @@ extra.omnios ooce/library/tiff
 extra.omnios ooce/library/tree-sitter
 extra.omnios ooce/library/unbound
 extra.omnios ooce/library/unistring
+extra.omnios ooce/library/xxhash
 extra.omnios ooce/library/yaml
 extra.omnios ooce/multimedia/dav1d
 extra.omnios ooce/multimedia/dcraw

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -160,6 +160,7 @@
 | ooce/library/tiff		| 4.7.1		| https://download.osgeo.org/libtiff/ https://libtiff.gitlab.io/libtiff/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/tree-sitter	| 0.25.10	| https://github.com/tree-sitter/tree-sitter/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/library/unistring	| 1.4.1		| https://ftp.gnu.org/gnu/libunistring/ | [omniosorg](https://github.com/omniosorg)
+| ooce/library/xxhash		| 0.8.3		| https://github.com/Cyan4973/xxHash/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/library/yaml		| 0.2.5		| https://github.com/yaml/libyaml/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/dav1d		| 1.5.3		| https://downloads.videolan.org/pub/videolan/dav1d/ https://www.videolan.org/projects/dav1d.html | [omniosorg](https://github.com/omniosorg)
 | ooce/multimedia/dcraw		| 9.28.0	| https://www.dechifro.org/dcraw/archive/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
The makefile checks for uname here: https://github.com/Cyan4973/xxHash/blob/dev/Makefile#L572
and then it tries to use ginstall, which is not available on my side. 
I belive there must be an easier way than patching it, but I have failed to find it.

#HELPNEEDED