### PR TITLE
ZRepl : create stdinserver directory at start

### DIFF
--- a/build/zrepl/files/zrepl
+++ b/build/zrepl/files/zrepl
@@ -18,8 +18,9 @@
 
 case "$1" in
 'start')
-	mkdir -p /var/run/zrepl
+	mkdir -p /var/run/zrepl/stdinserver
 	chmod 700 /var/run/zrepl
+	chmod 400 /var/run/zrepl/stdinserver
 	/opt/ooce/zrepl/bin/zrepl --config "$2" daemon &
 	;;
 


### PR DESCRIPTION
I have set up zrepl on my servers using this method: https://extrowerk.com/2026-03-03/ZFS-replacation-with-zrepl.html
After rebootin the backup server zrepl started to complain the `/var/run/zrepl/stdinserver` is missing.  This PR attempts to fix this.