### PR TITLE
Bump navidrome to v0.61.1

### DIFF
--- a/build/navidrome/build.sh
+++ b/build/navidrome/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=navidrome
-VER=0.60.3
+VER=0.61.1
 PKG=ooce/application/navidrome
 SUMMARY="$PROG"
 DESC="$PROG - an open source web-based music collection server and streamer"

--- a/build/navidrome/build.sh
+++ b/build/navidrome/build.sh
@@ -54,7 +54,10 @@ build() {
         -L$OPREFIX/${LIBDIRS[$BUILDARCH]}
         -Wl,-R$OPREFIX/${LIBDIRS[$BUILDARCH]}
     "
-    export CGO_CPPFLAGS CGO_LDFLAGS
+    # this is a bandaid for `gen2brain/webp` which tells it to fallback to WASM
+    # over using purego. this can be removed if/when purego supports illumos.
+    EXTRA_BUILD_TAGS=nodynamic
+    export CGO_CPPFLAGS CGO_LDFLAGS EXTRA_BUILD_TAGS
 
     logmsg "Building 64-bit"
     logcmd $MAKE setup || logerr "Setup failed"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -17,7 +17,7 @@
 | ooce/application/nagios-nrpe	| 4.1.0		| https://github.com/NagiosEnterprises/nrpe/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios-nsca	| 2.10.2	| https://github.com/NagiosEnterprises/nsca/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios-plugins | 2.4.8	| http://www.nagios-plugins.org/download/ | [omniosorg](https://github.com/omniosorg)
-| ooce/application/navidrome	| 0.60.3	| https://github.com/navidrome/navidrome/releases  | [omniosorg](https://github.com/omniosorg)
+| ooce/application/navidrome	| 0.61.1	| https://github.com/navidrome/navidrome/releases  | [omniosorg](https://github.com/omniosorg)
 | ooce/application/novnc	| 1.6.0		| https://github.com/novnc/noVNC/releases | Currently used solely by zadm
 | ooce/application/php-82	| 8.2.30	| https://www.php.net/downloads.php?source=Y | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-83	| 8.3.30	| https://www.php.net/downloads.php?source=Y | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This bumps navidrome to v0.61.1

Navidrome recently added webp support which pulled in [gen2brain/webp](https://github.com/gen2brain/webp), this currently breaks illumos as it requires [purego](https://github.com/ebitengine/purego) by default. There's an open issue in purego to support illumos which can be found [here](https://github.com/ebitengine/purego/issues/442).

As a workaround `gen2brain/webp` documents a build flag that disables `purego` and falls back to WASM, so we set it in this PR like so, at least until purego gains illumos support.
```
EXTRA_BUILD_TAGS=nodynamic
```