### PR TITLE
Bump navidrome to v0.61.2

### DIFF
--- a/build/navidrome/build.sh
+++ b/build/navidrome/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=navidrome
-VER=0.61.1
+VER=0.61.2
 PKG=ooce/application/navidrome
 SUMMARY="$PROG"
 DESC="$PROG - an open source web-based music collection server and streamer"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -17,7 +17,7 @@
 | ooce/application/nagios-nrpe	| 4.1.0		| https://github.com/NagiosEnterprises/nrpe/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios-nsca	| 2.10.2	| https://github.com/NagiosEnterprises/nsca/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios-plugins | 2.4.8	| http://www.nagios-plugins.org/download/ | [omniosorg](https://github.com/omniosorg)
-| ooce/application/navidrome	| 0.61.1	| https://github.com/navidrome/navidrome/releases  | [omniosorg](https://github.com/omniosorg)
+| ooce/application/navidrome	| 0.61.2	| https://github.com/navidrome/navidrome/releases  | [omniosorg](https://github.com/omniosorg)
 | ooce/application/novnc	| 1.6.0		| https://github.com/novnc/noVNC/releases | Currently used solely by zadm
 | ooce/application/php-82	| 8.2.30	| https://www.php.net/downloads.php?source=Y | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-83	| 8.3.30	| https://www.php.net/downloads.php?source=Y | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
New navidrome release.

Release notes: https://github.com/navidrome/navidrome/releases/tag/v0.61.2

Build output:
```
===== User elected to continue after prompt. =====
--- Published ooce/application/navidrome@0.61.2,5.11-151056.0
--- Comparing old package with new

-set name=info.source-url value=https://github.com/navidrome/navidrome/tree/v0.60.3
+set name=info.source-url value=https://github.com/navidrome/navidrome/tree/v0.61.2

***
*** Differences found between old and new packages
***
Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
-- Cleaning up
--- Removing temporary install directory /tmp/build_omnios/navidrome-0.61.2/ooce_application_navidrome_pkg
--- Cleaning up temporary manifest and transform files
Done.
Time: ooce/application/navidrome - 0h6m17s
```