### PR TITLE
buildctl: add ability to use custom pkglist and baseline

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -97,7 +97,10 @@ buildorder() {
     typeset var=$1
     typeset -n list=$var
     list=()
-    if [ -f "$ROOTDIR/doc/pkglist.$CLIBUILDARCH" ]; then
+    if [ -n "$OMNIOS_EXTRA_PKGLIST" ]; then
+        mapfile -t list \
+            < <(egrep -v '^#|^ *$' $OMNIOS_EXTRA_PKGLIST)
+    elif [ -f "$ROOTDIR/doc/pkglist.$CLIBUILDARCH" ]; then
         mapfile -t list \
             < <(egrep -v '^#|^ *$' $ROOTDIR/doc/pkglist.$CLIBUILDARCH)
     else
@@ -333,7 +336,9 @@ baseline() {
     init_repos
 
     typeset baselinef=$ROOTDIR/doc/baseline
-    if [ -n "$CLIBUILDARCH" -a -f "$baselinef.$CLIBUILDARCH" ]; then
+    if [ -n "$OMNIOS_EXTRA_BASELINE" ]; then
+        baselinef="$OMNIOS_EXTRA_BASELINE"
+    elif [ -n "$CLIBUILDARCH" -a -f "$baselinef.$CLIBUILDARCH" ]; then
         baselinef+=.$CLIBUILDARCH
         PKGSRVR=${REPOS[$CLIBUILDARCH]}
     fi


### PR DESCRIPTION
This commit based on 7fdb09ce6a01 ("buildctl: add ability to use custom pkglist and baseline") from omnios-build repo.

There are situations when you want to define a list of packages to build without changing doc/baseline, or for example, use a non-standard path.