### PR TITLE
Bump atuin to v18.15.1

### DIFF
--- a/build/atuin/build.sh
+++ b/build/atuin/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=atuin
-VER=18.13.3
+VER=18.14.1
 PKG=ooce/util/atuin
 SUMMARY="Magical shell history"
 DESC="Replaces your existing shell history with a SQLite database and "

--- a/build/atuin/build.sh
+++ b/build/atuin/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=atuin
-VER=18.14.1
+VER=18.15.1
 PKG=ooce/util/atuin
 SUMMARY="Magical shell history"
 DESC="Replaces your existing shell history with a SQLite database and "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -253,7 +253,7 @@
 | ooce/text/tree-sitter-langs	| 0.12.308	| https://github.com/emacs-tree-sitter/tree-sitter-langs/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/text/xsv			| 0.13.0	| https://github.com/BurntSushi/xsv/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/acmefetch		| 0.8.1		| https://github.com/oetiker/AcmeFetch/releases | [omniosorg](https://github.com/omniosorg)
-| ooce/util/atuin		| 18.13.3	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/util/atuin		| 18.14.1	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/bat			| 0.26.1	| https://github.com/sharkdp/bat/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/diffr		| 0.1.5		| https://github.com/mookid/diffr/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/util/direnv		| 2.37.1	| https://github.com/direnv/direnv/releases | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -253,7 +253,7 @@
 | ooce/text/tree-sitter-langs	| 0.12.308	| https://github.com/emacs-tree-sitter/tree-sitter-langs/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/text/xsv			| 0.13.0	| https://github.com/BurntSushi/xsv/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/acmefetch		| 0.8.1		| https://github.com/oetiker/AcmeFetch/releases | [omniosorg](https://github.com/omniosorg)
-| ooce/util/atuin		| 18.14.1	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/util/atuin		| 18.15.1	| https://github.com/atuinsh/atuin/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/bat			| 0.26.1	| https://github.com/sharkdp/bat/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/util/diffr		| 0.1.5		| https://github.com/mookid/diffr/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/util/direnv		| 2.37.1	| https://github.com/direnv/direnv/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This bumps atuin to [release v18.14.1](https://github.com/atuinsh/atuin/releases/tag/v18.14.1)