### PR TITLE
nsd: don't reuse libev's default loop across fork

### DIFF
--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -162,3 +162,7 @@ depend fmri=ooce/developer/llvm-22 type=conditional \
 depend fmri=ooce/developer/clang-22 type=conditional \
     predicate=release/name@0.5.11-151059
 
+# libevent became its own package in r151059
+depend fmri=library/libevent type=conditional \
+    predicate=release/name@0.5.11-151059
+

--- a/build/nsd/build.sh
+++ b/build/nsd/build.sh
@@ -39,11 +39,12 @@ XFORM_ARGS="
     -DPKGROOT=$PROG-$MAJVER
 "
 
-BUILD_DEPENDS_IPS="ooce/library/libev"
-
 set_arch 64
 # need msg_flags from struct msghdr and strcasecmp
 set_standard XPG6
+
+# For protobuf
+CPPFLAGS+=" -I $OPREFIX/include"
 
 export MAKE
 
@@ -53,7 +54,6 @@ BMI_EXPECTED=1
 CONFIGURE_OPTS="
     --sysconfdir=/etc$OPREFIX
     --with-run-dir=/var$sPREFIX
-    --with-libevent=$OPREFIX
     --with-pthreads
     --localstatedir=/var$sPREFIX
     --with-configdir=/etc$sPREFIX
@@ -64,6 +64,19 @@ CONFIGURE_OPTS="
     --with-zonelistfile=/var$sPREFIX/db/zone.list
     --with-pidfile=/var$sPREFIX/run/nsd.pid
 "
+
+# Prefer libevent if this release has it (r151059 and above), otherwise
+# fall back to libev. The build will always prefer libev if it's found
+# so we need to override a couple of things.
+if [ -f /usr/include/event2/event.h ]; then
+    CONFIGURE_OPTS+="
+        --with-libevent
+        ac_cv_header_event_h=no
+        ac_cv_have_decl_EV_VERSION_MAJOR=no
+    "
+else
+    CONFIGURE_OPTS+=" --with-libevent=$OPREFIX"
+fi
 
 pre_configure() {
     typeset arch=$1

--- a/build/nsd/build.sh
+++ b/build/nsd/build.sh
@@ -18,6 +18,7 @@
 
 PROG=nsd
 VER=4.14.2
+DASHREV=1
 PKG=ooce/network/nsd
 SUMMARY="Authoritative DNS server"
 DESC="The NLnet Labs Name Server Daemon (NSD) is an authoritative "

--- a/build/nsd/patches/libev-fork.patch
+++ b/build/nsd/patches/libev-fork.patch
@@ -1,0 +1,29 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/server.c a/server.c
+--- a~/server.c	1970-01-01 00:00:00
++++ a/server.c	1970-01-01 00:00:00
+@@ -3287,7 +3287,7 @@ nsd_event_method(void)
+ #  else
+ 	m = "?";
+ #  endif
+-#  ifdef MEMCLEAN
++#  if defined(MEMCLEAN) || defined(HAVE_EV_LOOP) || defined(HAVE_EV_DEFAULT_LOOP)
+ 	event_base_free(b);
+ #  endif
+ 	return m;
+@@ -3304,8 +3304,14 @@ nsd_child_event_base(void)
+ 	base = event_init(&secs, &now);
+ #else
+ #  if defined(HAVE_EV_LOOP) || defined(HAVE_EV_DEFAULT_LOOP)
+-	/* libev */
+-	base = (struct event_base *)ev_default_loop(EVFLAG_AUTO);
++	/* libev. Create a new loop rather than handing out the cached
++	 * default loop. The default loop survives fork() with its backend
++	 * (e.g. an illumos event port) still open and shared with the
++	 * parent, and libev's event_base_free() refuses to destroy it, so
++	 * every forked process would multiplex one kernel event object and
++	 * steal events from its relatives. A fresh loop per call gives each
++	 * process its own backend. */
++	base = (struct event_base *)ev_loop_new(EVFLAG_AUTO);
+ #  else
+ 	/* libevent */
+ #    ifdef HAVE_EVENT_BASE_NEW

--- a/build/nsd/patches/metrics-event2-buffer.patch
+++ b/build/nsd/patches/metrics-event2-buffer.patch
@@ -1,0 +1,11 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/metrics.c a/metrics.c
+--- a~/metrics.c	1970-01-01 00:00:00
++++ a/metrics.c	1970-01-01 00:00:00
+@@ -17,6 +17,7 @@
+ #include <sys/stat.h>
+ #include <errno.h>
+ #include <event2/event.h>
++#include <event2/buffer.h>
+ #include <event2/http.h>
+ #include <ctype.h>
+ 

--- a/build/nsd/patches/series
+++ b/build/nsd/patches/series
@@ -1,1 +1,2 @@
 libev-fork.patch
+metrics-event2-buffer.patch

--- a/build/nsd/patches/series
+++ b/build/nsd/patches/series
@@ -1,0 +1,1 @@
+libev-fork.patch


### PR DESCRIPTION
I've also opened an issue upstream at https://github.com/NLnetLabs/nsd/issues/491

This patches nsd so that older releases with `libev` will work, and switches us to `libevent` for r59+