### PR TITLE
add-victorialogs

### DIFF
--- a/build/victorialogs/build.sh
+++ b/build/victorialogs/build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=victorialogs
+VER=1.50.0
+PKG=ooce/database/victorialogs
+SUMMARY="VictoriaLogs"
+DESC="A high-performance, lightweight, zero-config, schema-free database "
+DESC+="for logs."
+
+DATA=var/${PREFIX#/}/$PROG
+
+set_arch 64
+set_gover
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DUSER=$PROG
+    -DGROUP=$PROG
+    -DDATA=$DATA
+    -DVERSION=$VER
+    -DVL=victoria-logs
+"
+
+build() {
+    pushd $TMPDIR/$BUILDDIR > /dev/null
+
+    logmsg "Building $PROG"
+    export CGO_ENABLED=0
+    export GOOS=illumos
+
+    logcmd $MAKE \
+        || logerr "Unable to build victoria-logs"
+
+    logcmd $MAKE vlutils-pure \
+        || logerr "Unable to build vlutils-pure"
+
+    popd >/dev/null
+}
+
+# make it so
+init
+clone_go_source VictoriaLogs VictoriaMetrics v$VER
+prep_build
+build
+install_go bin/victoria-logs victoria-logs
+install_go bin/vlogscli-pure vlogscli
+xform files/$PROG-template.xml > $TMPDIR/$PROG.xml
+install_smf application $PROG.xml
+xform files/victoria-logs-profile-template.xml \
+    > $TMPDIR/victoria-logs-profile.xml
+add_notes README.install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/victorialogs/files/README.install
+++ b/build/victorialogs/files/README.install
@@ -1,0 +1,17 @@
+--------------------------
+VictoriaLogs Configuration
+--------------------------
+
+VictoriaLogs is not configured by configuration files. Configuration is achieved
+via command-line arguments or equivalent environment variables.
+
+For SMF service integration, service profiles with appropriate environment
+variables can be used.
+
+Example profiles are provided in `<prefix>/share/victorialogs`.
+
+These can edited and applied with:
+
+```
+svccfg apply <prefix>/share/victorialogs/victoria-logs-profile.xml
+```

--- a/build/victorialogs/files/victoria-logs-profile-template.xml
+++ b/build/victorialogs/files/victoria-logs-profile-template.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="profile" name="victorialogs">
+  <service name="ooce/application/victorialogs" type="service" version="1">
+    <instance name="victoria-logs">
+      <method_context>
+        <method_environment>
+          <envvar name="VL_storageDataPath" value="/$(DATA)"/>
+          <envvar name="VL_retentionPeriod" value="90d"/>
+        </method_environment>
+      </method_context>
+    </instance>
+  </service>
+</service_bundle>

--- a/build/victorialogs/files/victorialogs-template.xml
+++ b/build/victorialogs/files/victorialogs-template.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+-->
+<service_bundle type="manifest"
+                name="victorialogs">
+
+    <service name="ooce/database/victorialogs"
+             type="service"
+             version="1">
+
+        <instance name="victoria-logs"
+                  enabled="false">
+
+            <dependency name="loopback"
+                        grouping="require_any"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/network/loopback" />
+            </dependency>
+
+            <dependency name="network"
+                        grouping="optional_all"
+                        restart_on="error"
+                        type="service">
+                <service_fmri value="svc:/milestone/network" />
+            </dependency>
+
+            <dependency name="filesystem_local"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local:default" />
+            </dependency>
+            <method_context>
+                <method_credential user="$(USER)"
+                                   group="$(GROUP)"
+                                   privileges="basic" />
+                <method_environment>
+                    <envvar name="VL_storageDataPath"
+                            value="/$(DATA)" />
+                </method_environment>
+            </method_context>
+
+            <exec_method type="method"
+                         name="start"
+                         exec="%{config/exec} -envflag.enable -envflag.prefix=VL_"
+                         timeout_seconds="60" />
+
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="300" />
+
+            <property_group name="config"
+                            type="application">
+                <propval name="exec"
+                         type="astring"
+                         value="/$(PREFIX)/bin/$(VL)" />
+            </property_group>
+
+            <property_group name="startd"
+                            type="framework">
+                <propval name="duration"
+                         type="astring"
+                         value="child" />
+                <propval name="ignore_error"
+                         type="astring"
+                         value="core,signal" />
+            </property_group>
+
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">VictoriaLogs server
+                    $(VERSION)</loctext>
+                </common_name>
+            </template>
+
+        </instance>
+
+        <stability value="External" />
+
+    </service>
+
+</service_bundle>

--- a/build/victorialogs/local.mog
+++ b/build/victorialogs/local.mog
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=Apache2
+
+dir path=$(DATA) owner=$(USER) group=$(GROUP) mode=0700
+
+group groupname=$(GROUP) gid=99
+user ftpuser=false username=$(USER) uid=99 group=$(GROUP) \
+    gcos-field="VictoriaLogs user" \
+    home-dir=/$(DATA) password=NP
+
+file ./tmp/victoria-logs-profile.xml \
+    path=$(PREFIX)/share/$(PROG)/victoria-logs-profile.xml \
+    owner=$(USER) group=$(GROUP) mode=0444
+
+<transform file path=$(PREFIX)/bin/victoria-logs -> \
+    set restart_fmri svc:/application/$(PROG):victoria-logs>
+

--- a/doc/idlist.md
+++ b/doc/idlist.md
@@ -65,6 +65,7 @@
 | illumos	| 96	| unknown
 | pkg5		| 97	| pkg5srv
 | extra		| 98	| squid
+| extra		| 99	| victorialogs
 
 ### Groups
 
@@ -132,3 +133,4 @@
 | illumos	| 96	| unknown
 | pkg5		| 97	| pkg5srv
 | extra		| 98	| squid
+| extra		| 99	| victorialogs

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -51,6 +51,7 @@
 | ooce/database/postgresql-XX/pg_repack | 1.5.0	| https://github.com/reorg/pg_repack/tags | [omniosorg](https://github.com/omniosorg)
 | ooce/database/rrdtool		| 1.9.0		| https://github.com/oetiker/rrdtool-1.x/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/database/victoriametrics	| 1.138.0	| https://github.com/VictoriaMetrics/VictoriaMetrics | [gkoh](https://github.com/gkoh)
+| ooce/database/victorialogs | 1.50.0	| https://github.com/VictoriaMetrics/VictoriaLogs | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/aarch64-esr-decoder | 0.2.4	| https://github.com/google/aarch64-esr-decoder/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/autoconf-archive | 2024.10.16	| https://ftp.gnu.org/gnu/autoconf-archive/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/autogen	| 5.18.16	| https://ftp.gnu.org/gnu/autogen/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Builds a VictoriaLogs package. 

I have followed the existing VictoriaMetrics package as closely as possible. I've been running the package in my own infrastructure for a while now, without problems.

There was a vacancy at ID 94 for a separate `victorialogs` user, so I took that.