### PR TITLE
add-zoxide

### DIFF
--- a/build/zoxide/build.sh
+++ b/build/zoxide/build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=zoxide
+VER=0.10.0
+PKG=ooce/terminal/zoxide
+SUMMARY="A smarter cd command"
+DESC='Remembers which directories you use most frequently, '
+DESC+='so you can \"jump\" to them in just a few keystrokes'
+
+BUILD_DEPENDS_IPS="
+    ooce/developer/rust
+"
+
+SKIP_SSP_CHECK=1
+
+BMI_EXPECTED=1
+
+CARGO_ARGS="--no-default-features"
+
+set_arch 64
+
+pre_build() {
+	typeset arch=$1
+	export CARGO_PROFILE_RELEASE_STRIP=none
+	export RUSTFLAGS="-C link-arg=-R$PREFIX/${LIBDIRS[$arch]}"
+}
+
+init
+clone_github_source $PROG "$GITHUB/ajeetdsouza/$PROG" v$VER
+append_builddir $PROG
+patch_source
+prep_build
+build_rust $CARGO_ARGS
+install_rust
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/zoxide/local.mog
+++ b/build/zoxide/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -242,6 +242,7 @@
 | ooce/terminal/minicom		| 2.11.1	| https://salsa.debian.org/api/v4/projects/minicom-team%2Fminicom/repository/tags/ https://salsa.debian.org/minicom-team/minicom/ | [omniosorg](https://github.com/omniosorg)
 | ooce/terminal/picocom		| 3.1		| https://github.com/npat-efault/picocom/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/terminal/starship	| 1.24.2	| https://github.com/starship/starship/releases https://starship.rs | [omniosorg](https://github.com/omniosorg)
+| ooce/terminal/zoxide | 0.10.0	| https://github.com/ajeetdsouza/zoxide | [omniosorg](https://github.com/omniosorg)
 | ooce/text/asciidoc		| 10.2.1	| https://pypi.org/rss/project/asciidoc/releases.xml | [omniosorg](https://github.com/omniosorg)
 | ooce/text/asciidoctor		| 2.0.23	| https://github.com/asciidoctor/asciidoctor/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/text/asciinema		| 2.4.0		| https://github.com/asciinema/asciinema/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
A recipe to build [zoxide](https://github.com/ajeetdsouza/zoxide). 

When I build, I get:

```
-- Checking ELF runtime attributes
==== opt/ooce/bin/zoxide ====
        NEEDED=librt.so.1       <dependency no longer necessary>
        NEEDED=libpthread.so.1  <dependency no longer necessary>
ELF runtime problems detected
```

But I get the same message building `bat` and `starship` from this repo, so I'm not sure whether it's an issue or not. If it is, I'm happy to chase it down.

I've been using my own package built from this `build.sh` for a long time now, with no problems.