### PR TITLE
navidrome: update to v0.63.1

### DIFF
--- a/build/navidrome/build.sh
+++ b/build/navidrome/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=navidrome
-VER=0.62.0
+VER=0.63.1
 PKG=ooce/application/navidrome
 SUMMARY="$PROG"
 DESC="$PROG - an open source web-based music collection server and streamer"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -17,7 +17,7 @@
 | ooce/application/nagios-nrpe	| 4.1.0		| https://github.com/NagiosEnterprises/nrpe/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios-nsca	| 2.10.2	| https://github.com/NagiosEnterprises/nsca/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/nagios-plugins | 2.4.8	| http://www.nagios-plugins.org/download/ | [omniosorg](https://github.com/omniosorg)
-| ooce/application/navidrome	| 0.62.0	| https://github.com/navidrome/navidrome/releases  | [omniosorg](https://github.com/omniosorg)
+| ooce/application/navidrome	| 0.63.1	| https://github.com/navidrome/navidrome/releases  | [omniosorg](https://github.com/omniosorg)
 | ooce/application/novnc	| 1.7.0		| https://github.com/novnc/noVNC/releases | Currently used solely by zadm
 | ooce/application/php-82	| 8.2.31	| https://www.php.net/downloads.php?source=Y | [omniosorg](https://github.com/omniosorg)
 | ooce/application/php-83	| 8.3.31	| https://www.php.net/downloads.php?source=Y | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
There's a new version of [navidrome](https://github.com/navidrome/navidrome/releases/tag/v0.63.1)