### PR TITLE
update-fish-4.8.1

### DIFF
--- a/build/fish/build.sh
+++ b/build/fish/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=fish
-VER=4.7.1
+VER=4.8.1
 PKG=ooce/shell/fish
 SUMMARY=$PROG
 DESC="$PROG - Friendly Interactive SHell"
@@ -54,7 +54,7 @@ SKIP_LICENSES=Various
 
 pre_build() {
     pushd ${TMPDIR}/${EXTRACTED_SRC}
-    logcmd cargo update -p nix
+    logcmd cargo update -p nix@0.31
     popd
 }
 

--- a/build/fish/patches/01-use-patched-nix.patch
+++ b/build/fish/patches/01-use-patched-nix.patch
@@ -1,7 +1,7 @@
 diff -wpruN --no-dereference '--exclude=*.orig' a~/Cargo.toml a/Cargo.toml
 --- a~/Cargo.toml	1970-01-01 00:00:00
 +++ a/Cargo.toml	1970-01-01 00:00:00
-@@ -235,3 +235,7 @@ print_stderr = "deny"
+@@ -260,3 +260,7 @@ print_stderr = "deny"
  
  [lints]
  workspace = true

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -223,7 +223,7 @@
 | ooce/server/haproxy		| 3.4.1		| https://www.haproxy.org/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx		| 1.31.3	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx-130		| 1.30.4	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)
-| ooce/shell/fish		| 4.7.1		| https://github.com/fish-shell/fish-shell/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/shell/fish		| 4.8.1		| https://github.com/fish-shell/fish-shell/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/storage/minio		| 2025-10-15T17-29-55Z | https://github.com/minio/minio/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/storage/minio-mc		| 2025-08-13T08-35-41Z | https://github.com/minio/mc/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/system/file-system/ntfs-3g | 2026.7.7	| https://github.com/tuxera/ntfs-3g/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Bump fish to 4.8.1. Using it as my daily driver with a package from my own repo, and had no problems.

Still uses [my own fork of nix](https://github.com/snltd/nix), as they haven't merged [the termios fix](https://github.com/nix-rust/nix/pull/2799) yet.