### PR TITLE
vaultwarden: update to 1.37.0

### DIFF
--- a/build/vaultwarden/build.sh
+++ b/build/vaultwarden/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=vaultwarden
-VER=1.36.0
+VER=1.37.0
 PKG=ooce/application/vaultwarden
 SUMMARY="Bitwarden compatible server"
 DESC="Unofficial Bitwarden compatible server written in Rust, formerly known "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -30,7 +30,7 @@
 | ooce/application/tidy		| 5.8.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tig 		| 2.5.10	| https://github.com/jonas/tig/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vagrant	| 2.2.19	| https://github.com/hashicorp/vagrant/tags | [omniosorg](https://github.com/omniosorg)
-| ooce/application/vaultwarden	| 1.36.0	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
+| ooce/application/vaultwarden	| 1.37.0	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.2.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.5.0		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/opus		| 1.6.1		| https://opus-codec.org/downloads/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This is somewhat urgent, as Bitwarden have just pushed out client updates and it would appear they're totally broken with vaultwarden.  There is a new vaultwarden release available to compensate, which does not appear to come with an update to the web component: https://github.com/dani-garcia/vaultwarden/releases#release-1.37.0