### PR TITLE
lmdb: fix package

### DIFF
--- a/build/lmdb/build.sh
+++ b/build/lmdb/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=lmdb
-VER=0.9.34
+VER=0.9.35
 PKG=ooce/database/lmdb
 SUMMARY="lmdb"
 DESC="Lightning Memory-Mapped Database"

--- a/build/lmdb/build.sh
+++ b/build/lmdb/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=lmdb
-VER=1.0.0
+VER=0.9.34
 PKG=ooce/database/lmdb
 SUMMARY="lmdb"
 DESC="Lightning Memory-Mapped Database"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -37,7 +37,7 @@
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pigz		| 2.8		| https://zlib.net/pigz/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/bdb		| 5.3.28	| http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html | [omniosorg](https://github.com/omniosorg)
-| ooce/database/lmdb		| 0.9.34	| https://github.com/LMDB/lmdb/tags https://symas.com/lmdb/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/lmdb		| 0.9.35	| https://github.com/LMDB/lmdb/tags https://symas.com/lmdb/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-106	| 10.6.27	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-1011	| 10.11.18	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-114	| 11.4.12	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -37,7 +37,7 @@
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pigz		| 2.8		| https://zlib.net/pigz/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/bdb		| 5.3.28	| http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html | [omniosorg](https://github.com/omniosorg)
-| ooce/database/lmdb		| 1.0.0		| https://github.com/LMDB/lmdb/tags https://symas.com/lmdb/ | [omniosorg](https://github.com/omniosorg)
+| ooce/database/lmdb		| 0.9.34	| https://github.com/LMDB/lmdb/tags https://symas.com/lmdb/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-106	| 10.6.27	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-1011	| 10.11.18	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/database/mariadb-114	| 11.4.12	| https://downloads.mariadb.org/mariadb/+releases/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
We are not yet moving to lmdb 1.x, yet as it will break users:
```
The on-disk file format has changed in LMDB 1.0 and versions 0.9
and 1.0 are mutually incompatible. You must use v0.9 #mdb_dump
to export your old DBs, and import with v1.0 #mdb_load if you
want to migrate your existing data to use LMDB 1.0. There is
no support in LMDB 1.0 for operating directly on v0.9 DB files.
Including such support would only bloat the library so it will
not be done.
```