### PR TITLE
Vaultwarden: update to 1.37.1 and web to 2026.6.4

### DIFF
--- a/build/vaultwarden/build.sh
+++ b/build/vaultwarden/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=vaultwarden
-VER=1.37.0
+VER=1.37.1
 PKG=ooce/application/vaultwarden
 SUMMARY="Bitwarden compatible server"
 DESC="Unofficial Bitwarden compatible server written in Rust, formerly known "
@@ -25,8 +25,8 @@ DESC+="as bitwarden_rs"
 
 DANIGARCIA=$GITHUB/dani-garcia
 # https://github.com/dani-garcia/bw_web_builds/releases
-WEBVAULTVER=2026.4.1
-WEBVAULTSHA256=bc232d81223d8c02a816763ea70a5a8a3fafa39ce99ceca7dc9ee1ff55ab2642
+WEBVAULTVER=2026.6.4
+WEBVAULTSHA256=d47f16ed4e756c73c88143047281f8881f1a6fb680d9bf0dd24c8adae6799592
 
 set_arch 64
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -30,7 +30,7 @@
 | ooce/application/tidy		| 5.8.0		| https://github.com/htacg/tidy-html5/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/tig 		| 2.5.10	| https://github.com/jonas/tig/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/application/vagrant	| 2.2.19	| https://github.com/hashicorp/vagrant/tags | [omniosorg](https://github.com/omniosorg)
-| ooce/application/vaultwarden	| 1.37.0	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
+| ooce/application/vaultwarden	| 1.37.1	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.2.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.5.0		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/opus		| 1.6.1		| https://opus-codec.org/downloads/ | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Untested for now, because can't install a dependency (error 503)