### PR TITLE
add-lame

### DIFF
--- a/build/ffmpeg/build.sh
+++ b/build/ffmpeg/build.sh
@@ -66,6 +66,7 @@ CONFIGURE_OPTS="
     --enable-libx265
     --enable-gnutls
     --enable-libopus
+    --enable-libmp3lame
 "
 CONFIGURE_OPTS[i386]="
     --disable-librav1e
@@ -92,6 +93,7 @@ pre_configure() {
     # to find x264.h for builtin check
     CPPFLAGS+=" -I${SYSROOT[$arch]}$OPREFIX/include"
 
+    LDFLAGS[$arch]+=" -L${SYSROOT[$arch]}$OPREFIX/${LIBDIRS[$arch]}"
     LDFLAGS[$arch]+=" -Wl,-R$OPREFIX/${LIBDIRS[$arch]}"
 
     ! cross_arch $arch && return

--- a/build/lame/build.sh
+++ b/build/lame/build.sh
@@ -20,37 +20,66 @@ PROG=lame
 VER=4.0
 PKG=ooce/audio/lame
 SUMMARY="The LAME MP3 encoder"
-SKIP_RTIME_CHECK=1
 DESC="A high quality MP3 enocder"
-CFLAGS+=" -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=implicit-int"
 
-OPREFIX=$PREFIX
-PREFIX+="/$PROG"
+MPG123VER=1.33.7
+
+forgo_isaexec
+set_clangver
+set_standard XPG6
 
 BUILD_DEPENDS_IPS="
     developer/nasm
 "
 
+SKIP_RTIME_CHECK=1
+
 XFORM_ARGS="
     -DPREFIX=${PREFIX#/}
-    -DOPREFIX=${OPREFIX#/}
-    -DPROG=$PROG
-    -DPKGROOT=$PROG
-    "
-CONFIGURE_OPTS+="
-    --prefix=$PREFIX
-    --enable-nasm
-    --disable-decoder
-    "
+"
 
-set_arch 64
+init
+prep_build
+
+#########################################################################
+
+save_buildenv
+
+# Download and build libmpg123
+CONFIGURE_OPTS="
+    --disable-components
+    --enable-libmpg123
+"
+CONFIGURE_OPTS[i386]+=" --with-cpu=x86"
+CONFIGURE_OPTS[amd64]+=" --with-cpu=x86-64"
+CONFIGURE_OPTS[aarch64]+=" --with-cpu=aarch64"
+
+build_dependency -merge mpg123 mpg123-$MPG123VER mpg123 mpg123 $MPG123VER
+
+restore_buildenv
+
+#########################################################################
+
+CONFIGURE_OPTS="
+    --enable-nasm
+"
+
+pre_configure() {
+    typeset arch=$1
+
+    _dd=$DESTDIR
+    cross_arch $arch && _dd+=.$arch
+
+    export mpg123_CFLAGS="-I$_dd$PREFIX/include"
+    export mpg123_LIBS="-L$_dd$PREFIX/${LIBDIRS[$arch]} -lmpg123"
+    LDFLAGS[$arch]+=" -Wl,-R$PREFIX/${LIBDIRS[$arch]}"
+}
 
 init
 download_source $PROG $PROG $VER
 patch_source
 build
-test
-strip_install
+LD_LIBRARY_PATH=$DESTDIR$PREFIX/${LIBDIRS[$BUILD_ARCH]} run_testsuite
 make_package
 clean_up
 

--- a/build/lame/build.sh
+++ b/build/lame/build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=lame
+VER=4.0
+PKG=ooce/audio/lame
+SUMMARY="The LAME MP3 encoder"
+SKIP_RTIME_CHECK=1
+DESC="A high quality MP3 enocder"
+CFLAGS+=" -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=implicit-int"
+
+OPREFIX=$PREFIX
+PREFIX+="/$PROG"
+
+BUILD_DEPENDS_IPS="
+    developer/nasm
+"
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DOPREFIX=${OPREFIX#/}
+    -DPROG=$PROG
+    -DPKGROOT=$PROG
+    "
+CONFIGURE_OPTS+="
+    --prefix=$PREFIX
+    --enable-nasm
+    --disable-decoder
+    "
+
+set_arch 64
+
+init
+download_source $PROG $PROG $VER
+patch_source
+build
+test
+strip_install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/lame/local.mog
+++ b/build/lame/local.mog
@@ -10,8 +10,9 @@
 
 # Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
 
-<include binlink.mog>
-<include manlink.mog>
-<transform path=$(PREFIX)/share/doc -> drop>
-
 license COPYING license=LGPLv2
+
+<transform path=$(PREFIX)/share/doc -> drop>
+# Drop static libraries
+<transform path=.*\.a$ -> drop>
+

--- a/build/lame/local.mog
+++ b/build/lame/local.mog
@@ -1,0 +1,17 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+
+<include binlink.mog>
+<include manlink.mog>
+<transform path=$(PREFIX)/share/doc -> drop>
+
+license COPYING license=LGPLv2

--- a/build/lame/patches/fix-compiler-warnings.patch
+++ b/build/lame/patches/fix-compiler-warnings.patch
@@ -1,0 +1,68 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/frontend/parse.c a/frontend/parse.c
+--- a~/frontend/parse.c	1970-01-01 00:00:00
++++ a/frontend/parse.c	1970-01-01 00:00:00
+@@ -410,13 +410,13 @@ set_id3v2tag(lame_global_flags* gfp, Tex
+         case TENC_UTF8:
+             switch (type)
+             {
+-                case 'a': return id3tag_set_textinfo_utf8(gfp, "TPE1", str);
+-                case 't': return id3tag_set_textinfo_utf8(gfp, "TIT2", str);
+-                case 'l': return id3tag_set_textinfo_utf8(gfp, "TALB", str);
+-                case 'g': return id3tag_set_textinfo_utf8(gfp, "TCON", str);
++                case 'a': return id3tag_set_textinfo_utf8(gfp, "TPE1", (char const*)str);
++                case 't': return id3tag_set_textinfo_utf8(gfp, "TIT2", (char const*)str);
++                case 'l': return id3tag_set_textinfo_utf8(gfp, "TALB", (char const*)str);
++                case 'g': return id3tag_set_textinfo_utf8(gfp, "TCON", (char const*)str);
+                 case 'c': return id3tag_set_comment_ucs2(gfp, 0, 0, str);
+-                case 'n': return id3tag_set_textinfo_utf8(gfp, "TRCK", str);
+-                case 'y': return id3tag_set_textinfo_utf8(gfp, "TYER", str);
++                case 'n': return id3tag_set_textinfo_utf8(gfp, "TRCK", (char const*)str);
++                case 'y': return id3tag_set_textinfo_utf8(gfp, "TYER", (char const*)str);
+                 case 'v': return id3tag_set_fieldvalue_ucs2(gfp, str);
+             }
+             ;;
+diff -wpruN --no-dereference '--exclude=*.orig' a~/include/lame.h a/include/lame.h
+--- a~/include/lame.h	1970-01-01 00:00:00
++++ a/include/lame.h	1970-01-01 00:00:00
+@@ -1297,6 +1297,9 @@ int CDECL id3tag_set_fieldvalue_ucs2(lam
+ int CDECL id3tag_set_fieldvalue_utf16(lame_t gfp, const unsigned short *fieldvalue);
+ 
+ /* experimental */
++int CDECL id3tag_set_fieldvalue_ucs2(lame_t gfp, const unsigned short *fieldvalue);
++
++/* experimental */
+ int CDECL id3tag_set_textinfo_utf16(lame_t gfp, char const *id, unsigned short const *text);
+ 
+ /* experimental */
+@@ -1308,6 +1311,8 @@ int CDECL id3tag_set_textinfo_utf8(lame_
+ /* experimental */
+ int CDECL id3tag_set_comment_utf8(lame_t gfp, char const *lang, char const *desc, char const *text);
+ 
++/* experimental */
++int CDECL id3tag_set_comment_ucs2(lame_t gfp, char const *lang, unsigned short const *desc, unsigned short const *text);
+ 
+ /***********************************************************************
+ *
+diff -wpruN --no-dereference '--exclude=*.orig' a~/libmp3lame/id3tag.c a/libmp3lame/id3tag.c
+--- a~/libmp3lame/id3tag.c	1970-01-01 00:00:00
++++ a/libmp3lame/id3tag.c	1970-01-01 00:00:00
+@@ -1284,9 +1284,6 @@ id3tag_set_comment_utf16(lame_t gfp, cha
+     return id3v2_add_ucs2(gfp, ID_COMMENT, lang, desc, text);
+ }
+ 
+-extern int
+-id3tag_set_comment_ucs2(lame_t gfp, char const *lang, unsigned short const *desc, unsigned short const *text);
+-
+ 
+ int
+ id3tag_set_comment_ucs2(lame_t gfp, char const *lang, unsigned short const *desc, unsigned short const *text)
+@@ -1832,9 +1829,6 @@ id3tag_set_fieldvalue_utf16(lame_t gfp,
+     return -1;
+ }
+ 
+-extern int
+-id3tag_set_fieldvalue_ucs2(lame_t gfp, const unsigned short *fieldvalue);
+-
+ int
+ id3tag_set_fieldvalue_ucs2(lame_t gfp, const unsigned short *fieldvalue)
+ {

--- a/build/lame/patches/series
+++ b/build/lame/patches/series
@@ -1,0 +1,1 @@
+fix-compiler-warnings.patch

--- a/build/lame/testsuite.log
+++ b/build/lame/testsuite.log
@@ -1,0 +1,25 @@
+LAME 4.0 64bits (https://lame.sourceforge.io)
+Using polyphase lowpass filter, transition band: 16538 Hz - 17071 Hz
+Encoding ./testcase.wav to testcase.new.mp3
+Encoding as 44.1 kHz j-stereo MPEG-1 Layer III (11x) 128 kbps qval=3
+    Frame          |  CPU time/estim | REAL time/estim | play/CPU |    ETA 
+     0/       ( 0%)|    0:00/     :  |    0:00/     :  |         x|     :  
+00:00--------------------------------------------------------------------------[K
+   kbps      %     %[K
+    0.0           [K[A[A[A     0/23     ( 0%)|    0:00/    0:00|    0:00/    0:00|   0.0000x|    0:00 
+00:00--------------------------------------------------------------------------[K
+   kbps      %     %[K
+    0.0           [K[A[A[A    23/23    (100%)|    0:00/    0:00|    0:00/    0:00|   54.620x|    0:00 
+-------------------------------------------------------------------------------[K
+   kbps        LR    MS  %     long switch short %[K
+  128.0       95.7   4.3        78.3  13.0   8.7[K
+Writing LAME Tag...done
+ReplayGain: -1.6dB
+
+real	0m0.02s
+user	0m0.01s
+sys	0m0.00s
+
+The following output has value only for a LAME-developer, do not make _any_
+assumptions about what this number means. You do not need to care about it.
+       0

--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -16,6 +16,7 @@ depend fmri=ooce/application/php-83 type=require
 depend fmri=ooce/application/php-84 type=require
 depend fmri=ooce/application/php-85 type=require
 depend fmri=ooce/audio/flac type=require
+depend fmri=ooce/audio/lame type=require
 depend fmri=ooce/audio/opus type=require
 depend fmri=ooce/database/bdb type=require
 depend fmri=ooce/database/lmdb type=require

--- a/doc/baseline
+++ b/doc/baseline
@@ -38,6 +38,7 @@ extra.omnios ooce/application/vaultwarden
 extra.omnios ooce/application/zabbix-agent
 extra.omnios ooce/application/zabbix-server
 extra.omnios ooce/audio/flac
+extra.omnios ooce/audio/lame
 extra.omnios ooce/audio/opus
 extra.omnios ooce/compress/lz4 r
 extra.omnios ooce/compress/pbzip2

--- a/doc/baseline.aarch64
+++ b/doc/baseline.aarch64
@@ -4,6 +4,7 @@ extra.omnios ooce/application/mutt
 extra.omnios ooce/application/tig
 extra.omnios ooce/application/vaultwarden
 extra.omnios ooce/audio/flac
+extra.omnios ooce/audio/lame
 extra.omnios ooce/audio/opus
 extra.omnios ooce/compress/pbzip2
 extra.omnios ooce/compress/pigz

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -33,6 +33,7 @@
 | ooce/application/vaultwarden	| 1.37.1	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.2.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.5.0		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
+| ooce/audio/lame		| 4.0		| https://sourceforge.net/projects/lame/	| [omniosorg](https://github.com/omniosorg)
 | ooce/audio/opus		| 1.6.1		| https://opus-codec.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pigz		| 2.8		| https://zlib.net/pigz/ | [omniosorg](https://github.com/omniosorg)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -33,7 +33,8 @@
 | ooce/application/vaultwarden	| 1.37.1	| https://github.com/dani-garcia/vaultwarden/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/application/zabbix	| 6.2.3		| https://www.zabbix.com/download_sources | [omniosorg](https://github.com/omniosorg)
 | ooce/audio/flac		| 1.5.0		| https://ftp.osuosl.org/pub/xiph/releases/flac/ https://xiph.org/flac/changelog.html | [omniosorg](https://github.com/omniosorg)
-| ooce/audio/lame		| 4.0		| https://sourceforge.net/projects/lame/	| [omniosorg](https://github.com/omniosorg)
+| ooce/audio/lame		| 4.0		| https://sourceforge.net/projects/lame/ | [omniosorg](https://github.com/omniosorg)
+| ooce/audio/mpg123		| 1.33.7	| https://sourceforge.net/projects/mpg123/files/mpg123/ https://mpg123.de/ | Currently used solely by lame
 | ooce/audio/opus		| 1.6.1		| https://opus-codec.org/downloads/ | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pbzip2		| 1.1.13	| https://launchpad.net/pbzip2/+download | [omniosorg](https://github.com/omniosorg)
 | ooce/compress/pigz		| 2.8		| https://zlib.net/pigz/ | [omniosorg](https://github.com/omniosorg)

--- a/doc/pkglist.aarch64
+++ b/doc/pkglist.aarch64
@@ -100,6 +100,7 @@ ooce/text/patchutils
 ooce/util/lrzsz
 ooce/library/fstrm
 ooce/audio/opus
+ooce/audio/lame
 ###############################################################################
 .SYSROOT
 ooce/audio/flac

--- a/tools/test
+++ b/tools/test
@@ -58,6 +58,9 @@ add_target()
 			*/zadm:*)
 				targets["ooce/application/novnc"]=`pver NOVNCVER`
 				;;
+			*/lame:*)
+				targets["ooce/audio/mpg123"]=`pver MPG123VER`
+				;;
 		esac
 		targets[$pkg]=$ver
 	elif [[ $build = *.p5m ]]; then


### PR DESCRIPTION
Add v4.0 of [LAME](https://sourceforge.net/projects/lame/). (Yes, 4.0, not 4.0.0)

I had to do a bit of `CFLAGS` chicanery to get it to build, but I suspect we're just using a more modern GCC than the LAME maintainers.

I disabled the decoder feature because I don't use it and it requires an external mpg123.

Been using it on my own machine for a while with no problems.