### PR TITLE
update-fish-4.9.2

### DIFF
--- a/build/fish/build.sh
+++ b/build/fish/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=fish
-VER=4.8.1
+VER=4.9.2
 PKG=ooce/shell/fish
 SUMMARY=$PROG
 DESC="$PROG - Friendly Interactive SHell"

--- a/build/fish/patches/01-use-patched-nix.patch
+++ b/build/fish/patches/01-use-patched-nix.patch
@@ -5,7 +5,6 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/Cargo.toml a/Cargo.toml
  
  [lints]
  workspace = true
-\ No newline at end of file
 +
 +[patch.crates-io]
 +nix = { git = "https://github.com/omniosorg/nix", branch = "fix/termios-from-bits-retain", version = "0.31.1" }

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -217,7 +217,7 @@
 | ooce/server/haproxy		| 3.4.3		| https://www.haproxy.org/ | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx		| 1.31.4	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)
 | ooce/server/nginx-130		| 1.30.4	| https://nginx.org/en/download.html | [omniosorg](https://github.com/omniosorg)
-| ooce/shell/fish		| 4.8.1		| https://github.com/fish-shell/fish-shell/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/shell/fish		| 4.9.2		| https://github.com/fish-shell/fish-shell/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/storage/minio		| 2025-10-15T17-29-55Z | https://github.com/minio/minio/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/storage/minio-mc		| 2025-08-13T08-35-41Z | https://github.com/minio/mc/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/system/file-system/ntfs-3g | 2026.7.7	| https://github.com/tuxera/ntfs-3g/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Bump fish to 4.9.2. Running it as my daily driver and had no issues. Still has the nix patch, as the upstream fix is not merged yet.