### PR TITLE
emacs: no longer need to disable ASLR

### DIFF
--- a/build/emacs/build.sh
+++ b/build/emacs/build.sh
@@ -18,6 +18,7 @@
 
 PROG=emacs
 VER=31.1
+DASHREV=1
 PKG=ooce/editor/emacs
 SUMMARY="Emacs editor"
 DESC="An extensible, customizable, free/libre text editor - and more."
@@ -59,12 +60,6 @@ CONFIGURE_OPTS="
     ac_cv_func_inotify_init=no
 "
 
-# According to solaris-userland:
-# ASLR should remain disabled for emacs. ASLR undermines emacs's dumping
-# code, which requires every execution to have the same mappings. Since
-# emacs is not network facing, or run with elevated privileges, this is
-# not a security concern.
-LDFLAGS="-z,aslr=disable"
 LDFLAGS[amd64]+=" -R$OPREFIX/${LIBDIRS[amd64]}"
 
 init


### PR DESCRIPTION
Emacs 27 made pdumper the default.  Emacs 30 removed the old unexec dumper. The configure option `--with-dumping` in 31.1 only takes `pdumper` or `none`.

```
build:extra:emacs% elfedit -re 'dyn:dump SUNW_ASLR' =emacs
elfedit: [19: .dynamic]: no elements of type SUNW_ASLR found

build:extra:emacs% emacs --batch -Q --eval '(prin1 (pdumper-stats))'
((dumped-with-pdumper . t) (load-time . 0.080367158) (dump-file-name . "/opt/ooce/emacs/libexec/amd64/emacs/31.1/x86_64-pc-solaris2.11/emacs-b6a90da89a28aec0b2a1d5bddc0b1020a77c4c5359399be0171d74bead2614db.pdmp"))%
```

I confirmed that emacs at least starts up and lets me exit again.